### PR TITLE
refactor: extend and update Makefile

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -11,6 +11,7 @@ all:
 	g++ $(COMMON) uitools.o simulate.cc -lmujoco210 -lGL -lglew ../bin/libglfw.so.3 -o ../bin/simulate
 	rm *.o
 
+.PHONY: clean
 clean:
 	rm -rf ../bin
 	

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -10,3 +10,12 @@ all:
 	gcc -c -O2 -mavx -I../include ../include/uitools.c
 	g++ $(COMMON) uitools.o simulate.cc -lmujoco210 -lGL -lglew ../bin/libglfw.so.3 -o ../bin/simulate
 	rm *.o
+
+clean:
+	rm -rf ../bin
+	
+.PHONY: help
+help:
+	@echo "Available Targets:"
+	@echo "... all"
+	@echo "... clean"


### PR DESCRIPTION
add targets `clean` and `help`
1. clean: following tradition of `Makefile` , clean can be executed by anyone to create a clean build
2. help: can be useful when the target lists grow and it can allow quick overview of all targets that can be built without the need to open the Makefile