### PR TITLE
fix invalid xml example code block in modeling documentation

### DIFF
--- a/doc/modeling.rst
+++ b/doc/modeling.rst
@@ -144,7 +144,7 @@ the model. We start with an example.
                <geom type="ellipsoid"/>
                <geom type="sphere" rgba="0 0 1 0"/>
                <geom type="cylinder" class="main"/>
-           </geom>
+           </body>
        </worldbody>
    </mujoco>
 


### PR DESCRIPTION
Hi,

The example xml in modeling.rst was invalid xml because of a </geom> closing tag instead of a </body> closing tag.