### PR TITLE
Sample Return Codes

### DIFF
--- a/sample/basic.cc
+++ b/sample/basic.cc
@@ -104,7 +104,7 @@ int main(int argc, const char** argv) {
   // check command-line arguments
   if (argc!=2) {
     std::printf(" USAGE:  basic modelfile\n");
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   // load and compile model
@@ -186,5 +186,5 @@ int main(int argc, const char** argv) {
   glfwTerminate();
 #endif
 
-  return 1;
+  return EXIT_SUCCESS;
 }

--- a/sample/compile.cc
+++ b/sample/compile.cc
@@ -39,7 +39,7 @@ int finish(const char* msg = 0, mjModel* m = 0) {
     std::cout << msg << std::endl;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 

--- a/sample/derivative.cc
+++ b/sample/derivative.cc
@@ -284,7 +284,7 @@ int main(int argc, char** argv) {
   // print help if not enough arguments
   if (argc<2) {
     std::printf("\n Arguments: modelfile [nthread niter nwarmup nepoch nstep eps]\n\n");
-    return 1;
+    return EXIT_FAILURE;
   }
 
   // default nthread = number of logical cores (usually optimal)
@@ -313,13 +313,13 @@ int main(int argc, char** argv) {
   // check number of threads
   if (nthread<1 || nthread>MAXTHREAD) {
     std::printf("nthread must be between 1 and %d\n", MAXTHREAD);
-    return 1;
+    return EXIT_FAILURE;
   }
 
   // check number of epochs
   if (nepoch<1 || nepoch>MAXEPOCH) {
     std::printf("nepoch must be between 1 and %d\n", MAXEPOCH);
-    return 1;
+    return EXIT_FAILURE;
   }
 
   // load model
@@ -331,7 +331,7 @@ int main(int argc, char** argv) {
   }
   if (!m) {
     std::printf("Could not load modelfile '%s'\n", argv[1]);
-    return 1;
+    return EXIT_FAILURE;
   }
 
   // print arguments
@@ -435,5 +435,5 @@ int main(int argc, char** argv) {
     mj_deleteData(d[n]);
   }
   mj_deleteModel(m);
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/sample/record.cc
+++ b/sample/record.cc
@@ -219,7 +219,7 @@ int main(int argc, const char** argv) {
   // check command-line arguments
   if (argc!=5) {
     std::printf(" USAGE:  record modelfile duration fps rgbfile\n");
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   // parse numeric arguments
@@ -313,5 +313,5 @@ int main(int argc, const char** argv) {
   closeMuJoCo();
   closeOpenGL();
 
-  return 1;
+  return EXIT_SUCCESS;
 }

--- a/sample/testspeed.cc
+++ b/sample/testspeed.cc
@@ -58,7 +58,7 @@ int finish(const char* msg = NULL, mjModel* m = NULL) {
     std::printf("%s\n", msg);
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 std::vector<mjtNum> CtrlNoise(const mjModel* m, int nsteps, mjtNum ctrlnoise) {

--- a/sample/testxml.cc
+++ b/sample/testxml.cc
@@ -44,7 +44,7 @@ int finish(const char* msg = 0, mjModel* m = 0, mjData* d = 0) {
     std::printf("%s\n", msg);
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 


### PR DESCRIPTION
Modified samples to return EXIT_SUCCESS OR EXIT_FAILURE instead of 0 or 1. Also fixed incorrect return at the end of main method of basic.cc.