### PR TITLE
Updating API to include the union types for mjuiItem

### DIFF
--- a/include/mujoco/mjui.h
+++ b/include/mujoco/mjui.h
@@ -208,24 +208,28 @@ struct mjuiItemSingle_ {          // check and button-related
   int modifier;                   // 0: none, 1: control, 2: shift; 4: alt
   int shortcut;                   // shortcut key; 0: undefined
 };
+typedef struct mjuiItemSingle_ mjuiItemSingle;
 
 
 struct mjuiItemMulti_ {                  // static, radio and select-related
   int nelem;                             // number of elements in group
   char name[mjMAXUIMULTI][mjMAXUINAME];  // element names
 };
+typedef struct mjuiItemMulti_ mjuiItemMulti;
 
 
 struct mjuiItemSlider_ {          // slider-related
   double range[2];                // slider range
   double divisions;               // number of range divisions
 };
+typedef struct mjuiItemSlider_ mjuiItemSlider;
 
 
 struct mjuiItemEdit_ {            // edit-related
   int nelem;                      // number of elements in list
   double range[mjMAXUIEDIT][2];   // element range (min>=max: ignore)
 };
+typedef struct mjuiItemEdit_ mjuiItemEdit;
 
 
 struct mjuiItem_ {                // UI item

--- a/introspect/codegen/generate_enums.py
+++ b/introspect/codegen/generate_enums.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Generates enums.py.
 
-The JSON input can be generated via:
-  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c mujoco.h
+The JSON input can be generated via running the following in the `mujoco/include` directory:
+  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c -I$(pwd) mujoco/mujoco.h
 """
 
 import json

--- a/introspect/codegen/generate_functions.py
+++ b/introspect/codegen/generate_functions.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Generates functions.py.
 
-The JSON input can be generated via:
-  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c mujoco.h
+The JSON input can be generated via running the following in the `mujoco/include` directory:
+  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c -I$(pwd) mujoco/mujoco.h
 """
 
 import json

--- a/introspect/codegen/generate_structs.py
+++ b/introspect/codegen/generate_structs.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Generates structs.py.
 
-The JSON input can be generated via:
-  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c mujoco.h
+The JSON input can be generated via running the following in the `mujoco/include` directory:
+  clang -Xclang -ast-dump=json -fsyntax-only -fparse-all-comments -x c -I$(pwd) mujoco/mujoco.h
 """
 
 import itertools

--- a/introspect/structs.py
+++ b/introspect/structs.py
@@ -7134,6 +7134,83 @@ STRUCTS: Mapping[str, StructDecl] = dict([
              ),
          ),
      )),
+    ('mjuiItemSingle',
+     StructDecl(
+         name='mjuiItemSingle',
+         declname='struct mjuiItemSingle_',
+         fields=(
+             StructFieldDecl(
+                 name='modifier',
+                 type=ValueType(name='int'),
+                 doc='0: none, 1: control, 2: shift; 4: alt',
+             ),
+             StructFieldDecl(
+                 name='shortcut',
+                 type=ValueType(name='int'),
+                 doc='shortcut key; 0: undefined',
+             ),
+         ),
+     )),
+    ('mjuiItemMulti',
+     StructDecl(
+         name='mjuiItemMulti',
+         declname='struct mjuiItemMulti_',
+         fields=(
+             StructFieldDecl(
+                 name='nelem',
+                 type=ValueType(name='int'),
+                 doc='number of elements in group',
+             ),
+             StructFieldDecl(
+                 name='name',
+                 type=ArrayType(
+                     inner_type=ValueType(name='char'),
+                     extents=(35, 40),
+                 ),
+                 doc='element names',
+             ),
+         ),
+     )),
+    ('mjuiItemSlider',
+     StructDecl(
+         name='mjuiItemSlider',
+         declname='struct mjuiItemSlider_',
+         fields=(
+             StructFieldDecl(
+                 name='range',
+                 type=ArrayType(
+                     inner_type=ValueType(name='double'),
+                     extents=(2,),
+                 ),
+                 doc='slider range',
+             ),
+             StructFieldDecl(
+                 name='divisions',
+                 type=ValueType(name='double'),
+                 doc='number of range divisions',
+             ),
+         ),
+     )),
+    ('mjuiItemEdit',
+     StructDecl(
+         name='mjuiItemEdit',
+         declname='struct mjuiItemEdit_',
+         fields=(
+             StructFieldDecl(
+                 name='nelem',
+                 type=ValueType(name='int'),
+                 doc='number of elements in list',
+             ),
+             StructFieldDecl(
+                 name='range',
+                 type=ArrayType(
+                     inner_type=ValueType(name='double'),
+                     extents=(7, 2),
+                 ),
+                 doc='element range (min>=max: ignore)',
+             ),
+         ),
+     )),
     ('mjuiItem',
      StructDecl(
          name='mjuiItem',
@@ -7178,22 +7255,22 @@ STRUCTS: Mapping[str, StructDecl] = dict([
                  fields=(
                      StructFieldDecl(
                          name='single',
-                         type=ValueType(name='struct mjuiItemSingle_'),
+                         type=ValueType(name='mjuiItemSingle'),
                          doc='check and button',
                      ),
                      StructFieldDecl(
                          name='multi',
-                         type=ValueType(name='struct mjuiItemMulti_'),
+                         type=ValueType(name='mjuiItemMulti'),
                          doc='static, radio and select',
                      ),
                      StructFieldDecl(
                          name='slider',
-                         type=ValueType(name='struct mjuiItemSlider_'),
+                         type=ValueType(name='mjuiItemSlider'),
                          doc='slider',
                      ),
                      StructFieldDecl(
                          name='edit',
-                         type=ValueType(name='struct mjuiItemEdit_'),
+                         type=ValueType(name='mjuiItemEdit'),
                          doc='edit',
                      ),
                  ),


### PR DESCRIPTION
Also changed the docs for running the clang command to generate the AST, as this errored without the include directory. I am not sure if this is the command that should be used, but it does not encounter any errors.

The chain change is modifying the header file `mjui.h` to add typedefs for the structs used by `mjuiItem` so that they can be discovered and generated by the `introspect` module.

@yuvaltassa @saran-t  I noticed that these typedefs were missing when I was writing code to base our Julia API on your `introspect` module. Also many thanks for your advice pointing us towards this module, it's incredibly helpful. 

