### PR TITLE
simulate: fix display of loading message

### DIFF
--- a/python/mujoco/simulate.cc
+++ b/python/mujoco/simulate.cc
@@ -203,7 +203,11 @@ PYBIND11_MODULE(_simulate, pymodule) {
       }))
       .def("destroy", &SimulateWrapper::Destroy,
            py::call_guard<py::gil_scoped_release>())
+      .def("load_message", CallIfNotNull(&mujoco::Simulate::LoadMessage),
+           py::call_guard<py::gil_scoped_release>())
       .def("load", &SimulateWrapper::Load)
+      .def("load_message_clear", CallIfNotNull(&mujoco::Simulate::LoadMessageClear),
+           py::call_guard<py::gil_scoped_release>())
       .def("sync", CallIfNotNull(&mujoco::Simulate::Sync),
            py::call_guard<py::gil_scoped_release>())
 

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -174,9 +174,11 @@ def _reload(
 ) -> Optional[Tuple[mujoco.MjModel, mujoco.MjData]]:
   """Internal function for reloading a model in the viewer."""
   try:
+    simulate.load_message('') # path is unknown at this point
     load_tuple = loader()
   except Exception as e:  # pylint: disable=broad-except
     simulate.load_error = str(e)
+    simulate.load_message_clear()
   else:
     m, d = load_tuple[:2]
 

--- a/simulate/main.cc
+++ b/simulate/main.cc
@@ -259,6 +259,7 @@ void PhysicsLoop(mj::Simulate& sim) {
   // run until asked to exit
   while (!sim.exitrequest.load()) {
     if (sim.droploadrequest.load()) {
+      sim.LoadMessage(sim.dropfilename);
       mjModel* mnew = LoadModel(sim.dropfilename, sim);
       sim.droploadrequest.store(false);
 
@@ -279,10 +280,14 @@ void PhysicsLoop(mj::Simulate& sim) {
         ctrlnoise = (mjtNum*) malloc(sizeof(mjtNum)*m->nu);
         mju_zero(ctrlnoise, m->nu);
       }
+      else {
+        sim.LoadMessageClear();
+      }
     }
 
     if (sim.uiloadrequest.load()) {
       sim.uiloadrequest.fetch_sub(1);
+      sim.LoadMessage(sim.filename);
       mjModel* mnew = LoadModel(sim.filename, sim);
       mjData* dnew = nullptr;
       if (mnew) dnew = mj_makeData(mnew);
@@ -300,6 +305,9 @@ void PhysicsLoop(mj::Simulate& sim) {
         free(ctrlnoise);
         ctrlnoise = static_cast<mjtNum*>(malloc(sizeof(mjtNum)*m->nu));
         mju_zero(ctrlnoise, m->nu);
+      }
+      else {
+        sim.LoadMessageClear();
       }
     }
 
@@ -404,6 +412,7 @@ void PhysicsLoop(mj::Simulate& sim) {
 void PhysicsThread(mj::Simulate* sim, const char* filename) {
   // request loadmodel if file given (otherwise drag-and-drop)
   if (filename != nullptr) {
+    sim->LoadMessage(filename);
     m = LoadModel(filename, *sim);
     if (m) d = mj_makeData(m);
     if (d) {
@@ -414,6 +423,8 @@ void PhysicsThread(mj::Simulate* sim, const char* filename) {
       free(ctrlnoise);
       ctrlnoise = static_cast<mjtNum*>(malloc(sizeof(mjtNum)*m->nu));
       mju_zero(ctrlnoise, m->nu);
+    } else {
+      sim->LoadMessageClear();
     }
   }
 

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -62,9 +62,17 @@ class Simulate {
   void UpdateMesh(int meshid);
   void UpdateTexture(int texid);
 
+  // Request that the Simulate UI display a "loading" message
+  // Called prior to Load or LoadMessageClear
+  void LoadMessage(const char* displayed_filename);
+
   // Request that the Simulate UI thread render a new model
-  // optionally delete the old model and data when done
   void Load(mjModel* m, mjData* d, const char* displayed_filename);
+
+  // Clear the loading message
+  // Can be called instead of Load to clear the message without
+  // requesting the UI load a model
+  void LoadMessageClear(void);
 
   // functions below are used by the renderthread
   // load mjb or xml model that has been requested by load()
@@ -173,6 +181,7 @@ class Simulate {
   std::atomic_int uiloadrequest = 0;
 
   // loadrequest
+  //   3: display a loading message
   //   2: render thread asked to update its model
   //   1: showing "loading" label, about to load
   //   0: model loaded or no load requested.


### PR DESCRIPTION
Model loading was moved to the physics thread sometime back (for good reason). This broke the "loading" message shown in UI because the UI did not a know a model was being loaded until after the fact.

The proposed solution adds optional methods to the Simulate class that set and clear a loading message as part of the UI's model loading state machine.

This works with C++ simulate application and the Python managed viewer. It should not affect the passive viewer.

EDIT: It also moves the loading message for command line based reloads to the left of the screen. Previously it was on the right for command line filenames and the left for UI based reloads (button or drag-n-drop) which is inconsistent.