### PR TITLE
cmake: support system-wide pybind11

### DIFF
--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -180,9 +180,10 @@ findorfetch(
 )
 
 # ==================== PYBIND11 ================================================
+option(MUJOCO_PYTHON_USE_SYSTEM_PYBIND11 "Use installed pybind11 version." OFF)
 findorfetch(
   USE_SYSTEM_PACKAGE
-  OFF
+  MUJOCO_PYTHON_USE_SYSTEM_PYBIND11
   PACKAGE_NAME
   pybind11
   LIBRARY_NAME


### PR DESCRIPTION
Conditionally uses system-wide pybind11 version when `MUJOCO_PYTHON_USE_SYSTEM_PYBIND11` is set.