### PR TITLE
Unity Plugin - Use default value of memory option if not present in imported XML

### DIFF
--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -147,7 +147,7 @@ public struct MjSizeStruct {
   };
 
   public void ParseMjcf(XmlElement mjcf) {
-    Memory = mjcf.GetAttribute("memory");
+    Memory = mjcf.GetStringAttribute("memory", "-1");
   }
 
   public XmlElement ToMjcf(XmlElement mjcf) {


### PR DESCRIPTION
Fixes issue where the XML parser extensions were not used in the MjGlobalSettings class's memory options. This previously made it necessary to manually input the default -1 value when importing scenes that have not defined it. 