### PR TITLE
Unity Plugin - Enable mouse spring perturbations when clicking on a geom in scene view

### DIFF
--- a/unity/Editor/Components/MjMouseSpring.cs
+++ b/unity/Editor/Components/MjMouseSpring.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if UNITY_EDITOR
 using System;
 using UnityEditor;
 using UnityEngine;
@@ -192,4 +191,3 @@ namespace Mujoco {
     }
   }
 }
-#endif

--- a/unity/Editor/Components/MjMouseSpring.cs
+++ b/unity/Editor/Components/MjMouseSpring.cs
@@ -23,7 +23,7 @@ namespace Mujoco {
   // and left mouse drag will apply a force on the body.  Holding shift down will change the applied
   // force direction between World XZ plane and Y[camera-up].
 
-  [CustomEditor(typeof(MjBody))]
+  [CustomEditor(typeof(MjComponent), true)]
   public class MjMouseSpring : Editor {
     private bool _lastShiftKeyState = false;
 
@@ -102,7 +102,11 @@ namespace Mujoco {
         return;
       }
 
-      MjBody body = target as MjBody;
+      var targetObject = target as MjComponent;
+      MjBody body = targetObject.GetComponentInParent<MjBody>();
+      if(!body) 
+        return;
+
       Vector3 bodyPosition =
           body != null ? body.transform.position : Vector3.zero;
       var scene = MjScene.Instance;

--- a/unity/Editor/Components/MjShapeComponentEditor.cs
+++ b/unity/Editor/Components/MjShapeComponentEditor.cs
@@ -22,7 +22,7 @@ namespace Mujoco {
 
 [CustomEditor(typeof(MjShapeComponent), true)]
 [CanEditMultipleObjects]
-public class MjShapeComponentEditor : Editor {
+public class MjShapeComponentEditor : MjMouseSpring {
 
   public override void OnInspectorGUI() {
 


### PR DESCRIPTION
A small QoL edit, to allow clicking on a geom in scene view, and apply the mouse perturbations without needing to select the parent body in the hierarchy. It also removes the `#if UNITY_EDITOR`  directive, since the Editor only platform was defined in the file's assembly already (#303, 0180d83).