### PR TITLE
Unity Plugin - Fix wrong units indicated in ball joint tooltip

### DIFF
--- a/unity/Runtime/Components/Joints/MjBallJoint.cs
+++ b/unity/Runtime/Components/Joints/MjBallJoint.cs
@@ -20,7 +20,7 @@ namespace Mujoco {
 
   // The component represents a joint with 1 degree of translational freedom.
   public class MjBallJoint : MjBaseJoint {
-    [Tooltip("In radians.")]
+    [Tooltip("In degrees.")]
     public float RangeUpper;
 
     [Tooltip("Joint settings.")]


### PR DESCRIPTION
Tiny fix for a typo, ranges are defined in degrees (no way to change units by the plugin at the moment).