### PR TITLE
Edited entry in README for 3rd part Julia bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ These packages give users of various languages access to MuJoCo functionality:
   by [Manoj Velmurugan](https://github.com/vmanoj1996).
 - **Swift**: [swift-mujoco](https://github.com/liuliu/swift-mujoco)
 - **Java**: [mujoco-java](https://github.com/CommonWealthRobotics/mujoco-java)
-- **Julia**: [Lyceum](https://github.com/Lyceum/MuJoCo.jl) (unmaintained)
+- **Julia**: [MuJoCo.jl](https://github.com/JamieMair/MuJoCo.jl)
 
 
 ### Converters


### PR DESCRIPTION
Hello!

@JamieMair and I have just announced the release of our package [MuJoCo.jl](https://github.com/JamieMair/MuJoCo.jl) which has revived the previous version of the Julia bindings for MuJoCo from the [Lyceum group](https://github.com/Lyceum/MuJoCo.jl). 
 
Could we please be listed as the (unofficial) Julia bindings for MuJoCo in `mujoco`'s `README.md`? Our package is supported and up to date with version `2.3.7` of MuJoCo. We're working on updating to version `3.0.0` in the near future.

Thanks!