### PR TITLE
[Unity plugin] Consider "autolimits" in "limited" attributes

### DIFF
--- a/unity/Runtime/Components/Joints/MjJointSettings.cs
+++ b/unity/Runtime/Components/Joints/MjJointSettings.cs
@@ -164,7 +164,14 @@ namespace Mujoco {
       RefFriction.FromMjcf(mjcf, "solreffriction");
       ImpFriction.FromMjcf(mjcf, "solimpfriction");
       FrictionLoss = mjcf.GetFloatAttribute("frictionloss", 0.0f);
-      Limited = mjcf.GetBoolAttribute("limited", false);
+
+      bool defaultLimited = false;
+      if (mjcf.OwnerDocument.GetElementsByTagName("compiler")[0] is not XmlElement
+              compilerElement || !compilerElement.GetBoolAttribute("autolimits").Equals("false")) {
+        defaultLimited = mjcf.HasAttribute("range");
+      }
+
+      Limited = mjcf.GetBoolAttribute("limited", defaultLimited);
       Margin = mjcf.GetFloatAttribute("margin", defaultValue: 0.0f);
     }
   }

--- a/unity/Runtime/Components/Joints/MjJointSettings.cs
+++ b/unity/Runtime/Components/Joints/MjJointSettings.cs
@@ -167,7 +167,7 @@ namespace Mujoco {
 
       bool defaultLimited = false;
       if (mjcf.OwnerDocument.GetElementsByTagName("compiler")[0] is not XmlElement
-              compilerElement || !compilerElement.GetBoolAttribute("autolimits").Equals("false")) {
+              compilerElement || compilerElement.GetBoolAttribute("autolimits", true)) {
         defaultLimited = mjcf.HasAttribute("range");
       }
 

--- a/unity/Runtime/Components/MjActuator.cs
+++ b/unity/Runtime/Components/MjActuator.cs
@@ -77,12 +77,17 @@ public class MjActuator : MjComponent {
     }
 
     public void FromMjcf(XmlElement mjcf) {
-      CtrlLimited = mjcf.GetBoolAttribute("ctrllimited", defaultValue: false);
-      ForceLimited = mjcf.GetBoolAttribute("forcelimited", defaultValue: false);
       CtrlRange = mjcf.GetVector2Attribute("ctrlrange", defaultValue: Vector2.zero);
       ForceRange = mjcf.GetVector2Attribute("forcerange", defaultValue: Vector2.zero);
       LengthRange = mjcf.GetVector2Attribute("lengthrange", defaultValue: Vector2.zero);
       Gear = mjcf.GetFloatArrayAttribute("gear", defaultValue: new float[] { 1.0f }).ToList();
+
+      bool autolimits = mjcf.OwnerDocument.GetElementsByTagName("compiler")[0] is not XmlElement
+          compilerElement || compilerElement.GetBoolAttribute("autolimits", true);
+      CtrlLimited = mjcf.GetBoolAttribute("ctrllimited",
+          defaultValue: autolimits ? CtrlRange != Vector2.zero : false);
+      ForceLimited = mjcf.GetBoolAttribute("forcelimited",
+          defaultValue: autolimits ? ForceRange != Vector2.zero : false);
     }
   }
 


### PR DESCRIPTION
This PR checks for the `autolimit` state of the compiler element of the XML. Without this, the `limited` flag was most often ignored during imports, even when explicitly defined in the XML. This resolves #512, and was the root cause of #1052 and #654.