### PR TITLE
Muscle force inversion issue in FL function

### DIFF
--- a/src/engine/engine_derivative.c
+++ b/src/engine/engine_derivative.c
@@ -804,7 +804,10 @@ static mjtNum mjd_muscleGain_vel(mjtNum len, mjtNum vel, const mjtNum lengthrang
 
   // length curve
   mjtNum FL = 0;
-  if (L >= lmin && L <= a) {
+  if (L < lmin){
+  FL = 0;
+  }
+  else if (L >= lmin && L <= a) {
     x = (L-lmin) / mju_max(mjMINVAL, a-lmin);
     FL = 0.5*x*x;
   } else if (L <= 1) {

--- a/src/engine/engine_util_misc.c
+++ b/src/engine/engine_util_misc.c
@@ -486,7 +486,9 @@ mjtNum mju_muscleGain(mjtNum len, mjtNum vel, const mjtNum lengthrange[2],
 
   // length curve
   mjtNum FL = 0;
-  if (L >= lmin && L <= a) {
+  if (L < lmin){
+    FL = 0;
+  } else if (L >= lmin && L <= a) {
     x = (L-lmin) / mjMAX(mjMINVAL, a-lmin);
     FL = 0.5*x*x;
   } else if (L <= 1) {


### PR DESCRIPTION
We were recently made aware of a bug in the mujoco muscle model by @andreh1111 , who also proposed a fix.

When the muscle lengthrange in the muscle actuator is set explicitly, it can happen that the muscle length moves outside the defined maximum and minimum ranges. This can lead to a case where the if-else clause in the [FL-function](https://github.com/google-deepmind/mujoco/blob/45208a5fe06bd8b80179dcaba2c68d61cff0c331/src/engine/engine_util_misc.c#L489) drops into the wrong condition and becomes negative. This produces strong positive forces in the muscle which are not physically consistent, as the muscles should only be able to contract. 

It also created some situation where muscles can create a jittering effect, even when the muscle excitations are held constant.

We have tracked and described this issue [here](https://github.com/MyoHub/myosuite/issues/91#issuecomment-1894580502) in the myosuite repo. 

Please let me know if you need a copy of the specific model and code to reproduce the plots

I'm repeating a few plots and videos here from the original issue:
Unfixed FL `muscleGain` function plot:
![active_fl_original](https://github.com/google-deepmind/mujoco/assets/24903880/f99217b4-5b94-4ed7-81c5-05b1dd164b18)

Blue marks the theoretical FL, dashed black the muscle length ranges and red the actually achieved lengths for a muscle-driven hand model.

Here is the fixed FL curve

![active_fl_fixed](https://github.com/google-deepmind/mujoco/assets/24903880/bce160a9-cf72-42d5-a98b-09746df04347)

And here is a video of the behavior. Left is the fixed one, right the original one. Muscle activity is held constant.


CC @vikashplus

https://github.com/google-deepmind/mujoco/assets/24903880/c2c134da-0f5c-4da3-b277-6c7948c718cb



