### PR TITLE
[Unity plugin] Reuse vertex indices when importing STL meshes

### DIFF
--- a/unity/Editor/Importer/StlMeshParser.cs
+++ b/unity/Editor/Importer/StlMeshParser.cs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mujoco {
 
@@ -26,6 +26,17 @@ public static class BinaryReaderExtensions {
     var y = reader.ReadSingle();
     var z = reader.ReadSingle();
     return new Vector3(x, y, z);
+  }
+
+  public static int GetOrCreateVertexIndex(Dictionary<Vector3, int> vertexIndexMap, List<Vector3> vertices, List<Vector3>normals, Vector3 vertex, Vector3 normal) {
+    if (vertexIndexMap.TryGetValue(vertex, out int existingIndex)) {
+      return existingIndex;
+    }
+    int newIndex = vertexIndexMap.Count;
+    vertexIndexMap.Add(vertex, newIndex);
+    vertices.Add(vertex);
+    normals.Add(normal);
+    return newIndex;
   }
 }
 
@@ -50,7 +61,7 @@ public class StlMeshParser {
   // The binary STL format is described here: https://en.wikipedia.org/wiki/STL_(file_format)
   public static Mesh ParseBinary(byte[] stlFileContents, Vector3 scale) {
     var fileTypeId = System.Text.Encoding.UTF8.GetString(
-      stlFileContents.Take(_asciiFileTypeId.Length).ToArray());
+        stlFileContents.Take(_asciiFileTypeId.Length).ToArray());
     if (fileTypeId == _asciiFileTypeId) {
       throw new IOException("Ascii STL file format is not supported.");
     }
@@ -59,27 +70,39 @@ public class StlMeshParser {
       using (var reader = new BinaryReader(stream)) {
         reader.ReadBytes(_headerLength);
         var numTriangles = reader.ReadUInt32();
-        var numVertices = numTriangles * _verticesPerTriangle;
-        if (numVertices > _unityLimitNumVerticesPerMesh) {
-          throw new IndexOutOfRangeException(
-              "The mesh exceeds the number of vertices per mesh allowed by Unity. " +
-              $"({numVertices} > {_unityLimitNumVerticesPerMesh})");
-        }
-        var triangleIndices = new List<int>(capacity: (int)numVertices);
-        var vertices = new List<Vector3>(capacity: (int)numVertices);
-        var normals = new List<Vector3>(capacity: (int)numVertices);
-        for (var i = 0; i < numVertices; i += _verticesPerTriangle) {
+        var maxNumVertices = numTriangles * _verticesPerTriangle;
+
+        Dictionary<Vector3, int> vertexIndexMap = new Dictionary<Vector3, int>();
+        var triangleIndices = new int[(int)numTriangles * _verticesPerTriangle];
+        var vertices = new List<Vector3>(capacity: (int)maxNumVertices);
+        var normals = new List<Vector3>(capacity: (int)maxNumVertices);
+        for (var i = 0; i < numTriangles; i++) {
           var triangleNormal = ToXZY(reader.ReadVector3());
-          normals.AddRange(new[] { triangleNormal, triangleNormal, triangleNormal });
-          vertices.AddRange(new[] {
-            ToXZY(reader.ReadVector3()),
-            ToXZY(reader.ReadVector3()),
-            ToXZY(reader.ReadVector3()) });
-          triangleIndices.AddRange(new[] {i, i + 2, i + 1});
-          reader.ReadInt16();  // Read the unused attribute indices field.
+          var verts = new[]
+          {
+              ToXZY(reader.ReadVector3()),
+              ToXZY(reader.ReadVector3()),
+              ToXZY(reader.ReadVector3())
+          };
+          var indices = new[] { verts[0], verts[2], verts[1] }.Select(v =>
+              BinaryReaderExtensions.GetOrCreateVertexIndex(vertexIndexMap,
+                  vertices,
+                  normals,
+                  v,
+                  triangleNormal)).ToArray();
+          for (int j = 0; j < 3; j++) {
+            triangleIndices[i * 3 + j] = indices[j];
+          }
+          reader.ReadInt16(); // Read the unused attribute indices field.
         }
 
         var mesh = new Mesh();
+        var numVertices = vertexIndexMap.Count;
+
+        if (numVertices > _unityLimitNumVerticesPerMesh) {
+          mesh.indexFormat = IndexFormat.UInt32;
+        }
+
         mesh.vertices = vertices.ToArray();
         mesh.normals = normals.ToArray();
         mesh.triangles = triangleIndices.ToArray();
@@ -88,6 +111,7 @@ public class StlMeshParser {
         mesh.RecalculateNormals();
         mesh.RecalculateTangents();
         mesh.RecalculateBounds();
+
         return mesh;
       }
     }
@@ -118,15 +142,16 @@ public class StlMeshParser {
           var i2 = triangles[i + 1];
           var i3 = triangles[i + 2];
           var faceNormal = (normals[i1] + normals[i2] + normals[i3]).normalized;
-          writer.Write(ToXZY(faceNormal));
+          writer.Write(faceNormal);
 
-          writer.Write(ToXZY(vertices[i1]));
-          writer.Write(ToXZY(vertices[i3]));
-          writer.Write(ToXZY(vertices[i2]));
+          writer.Write(vertices[i1]);
+          writer.Write(vertices[i2]);
+          writer.Write(vertices[i3]);
 
           writer.Write((short)0);
         }
-        return stream.GetBuffer();
+
+        return stream.ToArray();
       }
     }
   }

--- a/unity/Editor/Importer/StlMeshParser.cs
+++ b/unity/Editor/Importer/StlMeshParser.cs
@@ -142,11 +142,11 @@ public class StlMeshParser {
           var i2 = triangles[i + 1];
           var i3 = triangles[i + 2];
           var faceNormal = (normals[i1] + normals[i2] + normals[i3]).normalized;
-          writer.Write(faceNormal);
+          writer.Write(ToXZY(faceNormal));
 
-          writer.Write(vertices[i1]);
-          writer.Write(vertices[i2]);
-          writer.Write(vertices[i3]);
+          writer.Write(ToXZY(vertices[i1]));
+          writer.Write(ToXZY(vertices[i3]));
+          writer.Write(ToXZY(vertices[i2]));
 
           writer.Write((short)0);
         }


### PR DESCRIPTION
This PR makes modifications to the STL IO of the Unity plugin. Changes:
- Writes only the new bytes of the buffer to the file, which avoids having trailing nulls in the imported and scaled STL. Blender and other STL viewing software treated the files with trailing nulls as corrupted.
- Using a dictionary, indices of shared vertices are reused during the import. This allows loading larger meshes with the same index resolution, and the resulting files are smaller and render faster (~20%-40% smaller asset files in the MPL hand for example).
- Switch to 32bit indexing if 16 bits are not sufficient even with index reusing.

Tested with the MuJoCo mug, and the MPL hand.

It was unclear to me why was it necessary to perform axis swizzling in the STL writer part as well, and not just the parser. As I was working on this PR, meshes imported 90 degrees rotated sometimes. Removing the swizzling from there resolved that. In case I missed a case where that was key for the proper import, let me know @erez-tom.

EDIT: I re-reviewed my test cases and noticed I accidentally added an extra axis swizzling to the source mesh files when I decimated/subdivided the meshes to test with different vertex counts. Checking with the original mesh files revealed that swizzling on the writer too is necessary, so I added that back to the PR quickly.

@vidurvij-apptronik

Fixes #1244, replaces #1254