### PR TITLE
[Unity plugin] Preliminary support for Mj plugins

### DIFF
--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -50,6 +50,7 @@ public class MjImporterWithAssets : MjcfImporter {
     // mjcfString.
     var name = Path.GetFileNameWithoutExtension(filePath) + $"{UnityEngine.Random.Range(0,999)}";
     string newPath = Path.Combine(Application.temporaryCachePath, $"{name}.xml");
+    MjEngineTool.LoadPlugins();
     _mjModel = MjEngineTool.LoadModelFromFile(filePath);
     MjEngineTool.SaveModelToFile(newPath, _mjModel);
     Debug.Log($"Imported MJCF loaded, saved to {newPath}");

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -284,6 +284,11 @@ public class MjcfImporter {
         CreateGameObjectWithCamera(parentObject, child);
         break;
       }
+      case "plugin": {
+        Debug.Log($"Plugin elements are only partially supported.");
+        break;
+      }
+
       default: {
         Debug.Log($"The importer does not yet support tags <{child.Name}>.");
         break;

--- a/unity/Runtime/Plugins.meta
+++ b/unity/Runtime/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1135ed488170c0444b32c18cc61fb9ef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Runtime/Tools/MjEngineTool.cs
+++ b/unity/Runtime/Tools/MjEngineTool.cs
@@ -368,6 +368,16 @@ public static class MjEngineTool {
       }
     }
   }
+
+  public static void LoadPlugins() {
+    if(!Directory.Exists("Packages/org.mujoco/Runtime/Plugins/")) return;
+
+    foreach (string pluginPath in Directory.GetFiles("Packages/org.mujoco/Runtime/Plugins/")) {
+      MujocoLib.mj_loadPluginLibrary(pluginPath);
+    }
+    
+  }
+
 }
 
 public static class MjSceneImportSettings {


### PR DESCRIPTION
This PR is the start of the addition of MuJoCo plugin support (e.g. elasticity) to the Unity plugin. The current additions expect the user to supply the relevant Mj plugin libraries to a "Plugin" folder inside the Unity Package - This is a non ideal situation as it may pose an issue on builds or non-local installs of the Unity Package.

The current state of the PR loads plugins on XML import, letting the built-in parser properly process the file. The Unity scene will then be built based on the processed XML generated by `mj_saveLastXML` as usual. However, the Unity scene will have no idea it was generated from a plugin-using XML, so any effect the plugin would have had post-scene compile is currently lost.

Most of the plugin use cases that are not expected to be completely covered by the current state of the PR. Further commits will be added, I'm submitting it for visibility for interested users (#1394) , and for potential contributions.