### PR TITLE
Add CMake options to enable or disable installation of mujoco samples and simulate

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -118,7 +118,9 @@ if(APPLE AND MUJOCO_BUILD_MACOS_FRAMEWORKS)
   set(_INSTALL_SAMPLES OFF)
 endif()
 
-if(_INSTALL_SAMPLES)
+option(MUJOCO_SAMPLES_INSTALL "If ON, also install samples executables." ${_INSTALL_SAMPLES})
+
+if(MUJOCO_SAMPLES_INSTALL)
 
   include(TargetAddRpath)
 

--- a/simulate/CMakeLists.txt
+++ b/simulate/CMakeLists.txt
@@ -223,7 +223,9 @@ if(SIMULATE_BUILD_EXECUTABLE)
     set(_INSTALL_SIMULATE OFF)
   endif()
 
-  if(_INSTALL_SIMULATE)
+  option(MUJOCO_SIMULATE_INSTALL "If ON, also install simulate executable." ${_INSTALL_SIMULATE})
+
+  if(MUJOCO_SIMULATE_INSTALL)
 
     include(TargetAddRpath)
 


### PR DESCRIPTION
The current logic uses regular CMake variables, that create confusing behavior when a CMake cache variable with the same name is set from the command line. The PR does not change the behaviour of the build system, but permits to users to enable installation of simulate and samples executables from the CMake options.