### PR TITLE
Add options to enable or disable installation of mujoco samples and simulate

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -118,24 +118,28 @@ if(APPLE AND MUJOCO_BUILD_MACOS_FRAMEWORKS)
   set(_INSTALL_SAMPLES OFF)
 endif()
 
-if(_INSTALL_SAMPLES)
+option(MUJOCO_SAMPLES_INSTALL "If ON, also install samples executables." ${_INSTALL_SAMPLES})
 
-  include(TargetAddRpath)
+if(MUJOCO_SAMPLES_INSTALL)
 
-  # Add support to RPATH for the samples.
-  target_add_rpath(
-    TARGETS
-    basic
-    compile
-    record
-    testspeed
-    INSTALL_DIRECTORY
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
-    LIB_DIRS
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
-    DEPENDS
-    MUJOCO_ENABLE_RPATH
-  )
+  if(MUJOCO_ENABLE_RPATH)
+    include(TargetAddRpath)
+
+    # Add support to RPATH for the samples.
+    target_add_rpath(
+      TARGETS
+      basic
+      compile
+      record
+      testspeed
+      INSTALL_DIRECTORY
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
+      LIB_DIRS
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+      DEPENDS
+      MUJOCO_ENABLE_RPATH
+    )
+  endif()
 
   install(
     TARGETS basic

--- a/simulate/CMakeLists.txt
+++ b/simulate/CMakeLists.txt
@@ -223,21 +223,25 @@ if(SIMULATE_BUILD_EXECUTABLE)
     set(_INSTALL_SIMULATE OFF)
   endif()
 
-  if(_INSTALL_SIMULATE)
+  option(MUJOCO_SIMULATE_INSTALL "If ON, also install simulate executable." ${_INSTALL_SIMULATE})
 
-    include(TargetAddRpath)
+  if(MUJOCO_SIMULATE_INSTALL)
 
-    # Add support to RPATH for the samples.
-    target_add_rpath(
-      TARGETS
-      simulate
-      INSTALL_DIRECTORY
-      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
-      LIB_DIRS
-      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
-      DEPENDS
-      MUJOCO_ENABLE_RPATH
-    )
+    if(MUJOCO_ENABLE_RPATH)
+      include(TargetAddRpath)
+
+      # Add support to RPATH for the samples.
+      target_add_rpath(
+        TARGETS
+        simulate
+        INSTALL_DIRECTORY
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}"
+        LIB_DIRS
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+        DEPENDS
+        MUJOCO_ENABLE_RPATH
+      )
+    endif()
 
     install(
       TARGETS simulate


### PR DESCRIPTION
The current logic uses regular CMake variables, that create confusing behavior when a CMake cache variable with the same name is set from the command line. The PR does not change the behaviour of the build system, but permits to users to enable installation of simulate and samples executables from the CMake options, as long as they also set `MUJOCO_ENABLE_RPATH` to `OFF`.