### PR TITLE
[Unity-plugin] Parse the "auto" value now used in "limited" fields by the XML writer

### DIFF
--- a/unity/Runtime/Components/Joints/MjJointSettings.cs
+++ b/unity/Runtime/Components/Joints/MjJointSettings.cs
@@ -165,14 +165,7 @@ namespace Mujoco {
       ImpFriction.FromMjcf(mjcf, "solimpfriction");
       FrictionLoss = mjcf.GetFloatAttribute("frictionloss", 0.0f);
 
-      bool defaultLimited = false;
-      if ((mjcf.OwnerDocument.GetElementsByTagName("compiler")[0]?["compiler"])
-              ?.GetBoolAttribute("autolimits", true) ??
-          true) {
-        defaultLimited = mjcf.HasAttribute("range");
-      }
-
-      Limited = mjcf.GetBoolAttribute("limited", defaultLimited);
+      Limited = mjcf.GetLimitedAttribute("limited", mjcf.HasAttribute("range"));
       Margin = mjcf.GetFloatAttribute("margin", defaultValue: 0.0f);
     }
   }

--- a/unity/Runtime/Components/MjActuator.cs
+++ b/unity/Runtime/Components/MjActuator.cs
@@ -82,13 +82,10 @@ public class MjActuator : MjComponent {
       LengthRange = mjcf.GetVector2Attribute("lengthrange", defaultValue: Vector2.zero);
       Gear = mjcf.GetFloatArrayAttribute("gear", defaultValue: new float[] { 1.0f }).ToList();
 
-      bool autolimits = (mjcf.OwnerDocument.GetElementsByTagName("compiler")[0]?["compiler"])
-                            ?.GetBoolAttribute("autolimits", true) ??
-                        false;
-      CtrlLimited = mjcf.GetBoolAttribute("ctrllimited",
-          defaultValue: autolimits ? CtrlRange != Vector2.zero : false);
-      ForceLimited = mjcf.GetBoolAttribute("forcelimited",
-          defaultValue: autolimits ? ForceRange != Vector2.zero : false);
+      CtrlLimited = mjcf.GetLimitedAttribute("ctrllimited",
+          rangeDefined: mjcf.HasAttribute("ctrlrange"));
+      ForceLimited = mjcf.GetLimitedAttribute("forcelimited",
+          rangeDefined: mjcf.HasAttribute("forcerange"));
     }
   }
 

--- a/unity/Runtime/Tools/XmlElementExtensions.cs
+++ b/unity/Runtime/Tools/XmlElementExtensions.cs
@@ -37,6 +37,28 @@ public static class XmlElementExtensions {
     }
   }
 
+  public static bool GetLimitedAttribute(
+      this XmlElement element, string name, bool rangeDefined) {
+    var strValue = element.GetStringAttribute(name, "auto");
+    if (strValue == "auto" && rangeDefined && element.GetAutolimitsEnabled()) return true;
+    if (strValue == "auto") return false;
+
+    bool parsedValue;
+    if (bool.TryParse(strValue, out parsedValue)) {
+      return parsedValue;
+    } else {
+      throw new ArgumentException($"'{strValue}' is not a bool.");
+    }
+  }
+
+  public static bool GetAutolimitsEnabled(
+      this XmlElement element) {
+    bool autolimits = (element.OwnerDocument?.GetElementsByTagName("compiler")[0]?["compiler"])
+                      ?.GetBoolAttribute("autolimits", true) ??
+                      true;
+    return autolimits;
+  }
+
   public static float GetFloatAttribute(
       this XmlElement element, string name, float defaultValue = 0.0f) {
     if (!element.HasAttribute(name)) {


### PR DESCRIPTION
A change between 3.1.2 and 3.1.3 meant that now auto values were written to the intermediary XML the Unity plugin uses for imports, (instead of only explicit `true` or `false` values). This PR handles the auto values now, and sets limited accordingly.

The autolimit field is still eventually lost on XML import, and converted to explicit limited fields. It could be time to add autolimits to MjGlobalOptions class, and switch the Limited field to either "Disable Limit" or an Enum in the Unity plugin.