### PR TITLE
Add installation of MuJoCo plugins as part of CMake installation logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,21 +160,6 @@ jobs:
     - name: Install MuJoCo
       working-directory: build
       run: cmake --install .
-    - name: Copy plugins (POSIX)
-      if: ${{ runner.os != 'Windows' }}
-      working-directory: build
-      run: mkdir -p ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp lib/libactuator.* ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp lib/libelasticity.* ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp lib/libsensor.* ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp lib/libsdf.* ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin
-    - name: Copy plugins (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      working-directory: build
-      run: mkdir -p ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp bin/Release/actuator.dll ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp bin/Release/elasticity.dll ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin &&
-           cp bin/Release/sensor.dll ${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin
     - name: Configure samples
       working-directory: sample
       run: >
@@ -212,7 +197,7 @@ jobs:
       run: >
         source ${{ matrix.tmpdir }}/venv/bin/activate &&
         MUJOCO_PATH="${{ matrix.tmpdir }}/mujoco_install"
-        MUJOCO_PLUGIN_PATH="${{ matrix.tmpdir }}/mujoco_install/mujoco_plugin"
+        MUJOCO_PLUGIN_PATH="${{ matrix.tmpdir }}/mujoco_install/bin/mujoco_plugin"
         MUJOCO_CMAKE_ARGS="-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF ${{ matrix.cmake_args }}"
         pip wheel -v --no-deps mujoco-*.tar.gz
     - name: Install Python bindings

--- a/cmake/MujocoOptions.cmake
+++ b/cmake/MujocoOptions.cmake
@@ -79,6 +79,30 @@ else()
 endif()
 
 option(MUJOCO_BUILD_MACOS_FRAMEWORKS "Build libraries as macOS Frameworks" OFF)
+option(MUJOCO_INSTALL_PLUGINS "Install MuJoCo plugins" ON)
+mark_as_advanced(MUJOCO_INSTALL_PLUGINS)
+
+# Define function to simplify installations of plugins
+function(mujoco_install_plugin plugin_target_name)
+  # Do not install plugin on macOS when using macOS Frameworks
+  if(MUJOCO_INSTALL_PLUGINS AND NOT MUJOCO_BUILD_MACOS_FRAMEWORKS)
+    if(WIN32)
+      install(TARGETS ${plugin_target_name}
+              # consistently with the official mujoco binary format, we do
+              # not want to install .lib import libraries on Windows, and
+              # only install .dll . To do so, we install non-.dll files to
+              # a fake install directory that is not actually in the install path
+              ARCHIVE DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fake_plugin_install"
+              LIBRARY DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fake_plugin_install"
+              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin")
+    else()
+      install(TARGETS ${plugin_target_name}
+              ARCHIVE DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin"
+              LIBRARY DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin"
+              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin")
+    endif()
+  endif()
+endfunction()
 
 # Get some extra link options.
 include(MujocoLinkOptions)

--- a/plugin/actuator/CMakeLists.txt
+++ b/plugin/actuator/CMakeLists.txt
@@ -39,3 +39,5 @@ target_link_options(
   ${MUJOCO_MACOS_LINK_OPTIONS}
   ${EXTRA_LINK_OPTIONS}
 )
+
+mujoco_install_plugin(actuator)

--- a/plugin/elasticity/CMakeLists.txt
+++ b/plugin/elasticity/CMakeLists.txt
@@ -47,3 +47,5 @@ target_link_options(
   ${MUJOCO_MACOS_LINK_OPTIONS}
   ${EXTRA_LINK_OPTIONS}
 )
+
+mujoco_install_plugin(elasticity)

--- a/plugin/sdf/CMakeLists.txt
+++ b/plugin/sdf/CMakeLists.txt
@@ -51,3 +51,5 @@ target_link_options(
   ${MUJOCO_MACOS_LINK_OPTIONS}
   ${EXTRA_LINK_OPTIONS}
 )
+
+mujoco_install_plugin(sdf)

--- a/plugin/sensor/CMakeLists.txt
+++ b/plugin/sensor/CMakeLists.txt
@@ -40,3 +40,5 @@ target_link_options(
   ${MUJOCO_MACOS_LINK_OPTIONS}
   ${EXTRA_LINK_OPTIONS}
 )
+
+mujoco_install_plugin(sensor)

--- a/simulate/cmake/SimulateOptions.cmake
+++ b/simulate/cmake/SimulateOptions.cmake
@@ -79,6 +79,30 @@ else()
 endif()
 
 option(MUJOCO_BUILD_MACOS_FRAMEWORKS "Build libraries as macOS Frameworks" OFF)
+option(MUJOCO_INSTALL_PLUGINS "Install MuJoCo plugins" ON)
+mark_as_advanced(MUJOCO_INSTALL_PLUGINS)
+
+# Define function to simplify installations of plugins
+function(mujoco_install_plugin plugin_target_name)
+  # Do not install plugin on macOS when using macOS Frameworks
+  if(MUJOCO_INSTALL_PLUGINS AND NOT MUJOCO_BUILD_MACOS_FRAMEWORKS)
+    if(WIN32)
+      install(TARGETS ${plugin_target_name}
+              # consistently with the official mujoco binary format, we do
+              # not want to install .lib import libraries on Windows, and
+              # only install .dll . To do so, we install non-.dll files to
+              # a fake install directory that is not actually in the install path
+              ARCHIVE DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fake_plugin_install"
+              LIBRARY DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fake_plugin_install"
+              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin")
+    else()
+      install(TARGETS ${plugin_target_name}
+              ARCHIVE DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin"
+              LIBRARY DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin"
+              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/mujoco_plugin")
+    endif()
+  endif()
+endfunction()
 
 # Get some extra link options.
 include(MujocoLinkOptions)


### PR DESCRIPTION
Some users in my lab found confusing the fact that `simulate` did not found the plugins out of the box if mujoco was built from source, and apparently also other users had the same confusion (see for example https://github.com/google-deepmind/mujoco/issues/723#issuecomment-1893594343). 

This PR hopefully simplifies this by also installing as part of the CMake install step the mujoco plugins in `${CMAKE_INSTALL_PREFIX}/bin/mujoco_plugin`, exactly where `simulate` expects to find them, and where they are placed in the official release binaries.

At the moment, I did not include this modifications for the case in which `MUJOCO_BUILD_MACOS_FRAMEWORKS` is `ON`, as it is not really clear to me how this should be handled. However, when building by source `MUJOCO_BUILD_MACOS_FRAMEWORKS` is set to `OFF`, so for all users that build from source, this PR ensure that the installed `simulate` will be able to find all the mujoco plugins out of the box.

fyi @francesco-romano 