### PR TITLE
[Python Viewer] clear load error on successful reload, fixes #1116

### DIFF
--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -199,6 +199,9 @@ def _reload(
     path = load_tuple[2] if len(load_tuple) == 3 else ''
     simulate.load(m, d, path)
 
+    # Make sure any load_error message is cleared
+    simulate.load_error = ''
+
     if notify_loaded:
       notify_loaded()
 


### PR DESCRIPTION
This has been annoying me lately, turns out it is a one line fix. Fixes #1116.

[`main.cc`](https://github.com/google-deepmind/mujoco/blob/67982c4961b47a899ee93e988989c0bf2687b72f/simulate/main.cc#L236) always overwrites the `simulate.load_error` on a successful load, which implicitly sets an empty string if the load is successful. The python viewer's `viewer.py` just needs to do the same.