### PR TITLE
[Python Viewer] load mjb files, fixes #1421

### DIFF
--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -169,7 +169,10 @@ def _file_loader(path: str) -> _LoaderWithPathType:
   """Loads an MJCF model from file path."""
 
   def load(path=path) -> Tuple[mujoco.MjModel, mujoco.MjData, str]:
-    m = mujoco.MjModel.from_xml_path(path)
+    if len(path) >= 4 and path[-4:] == '.mjb':
+      m = mujoco.MjModel.from_binary_path(path)
+    else:
+      m = mujoco.MjModel.from_xml_path(path)
     d = mujoco.MjData(m)
     return m, d, path
 


### PR DESCRIPTION
Fixes #1421.

Just as in #1116 the issue is that the logic of `simulate`'s [`main.cc`](https://github.com/google-deepmind/mujoco/blob/67982c4961b47a899ee93e988989c0bf2687b72f/simulate/main.cc#L218) does not match `viewer.py` but it is just a couple line fix.