### PR TITLE
Update actions/checkout and actions/setup-python to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare Linux
       if: ${{ runner.os == 'Linux' }}
       run: >
@@ -125,7 +125,7 @@ jobs:
     - name: Prepare macOS
       if: ${{ runner.os == 'macOS' }}
       run: brew install ninja
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Prepare Python


### PR DESCRIPTION
Our GitHub actions are outputting warnings about Node JS having to be upgraded, which I think are just to do with these built-in actions.