### PR TITLE
Draft of multithreaded minimize.py and more verbose logging

### DIFF
--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -32,14 +32,14 @@ class Verbosity(enum.Enum):
 
 class Status(enum.Enum):
   FACTORIZATION_FAILED = enum.auto()
-  NO_IMPORVEMENT = enum.auto()
+  NO_IMPROVEMENT = enum.auto()
   MAX_ITER = enum.auto()
   DX_TOL = enum.auto()
 
 
 _STATUS_MESSAGE = {
     Status.FACTORIZATION_FAILED: 'factorization failed.',
-    Status.NO_IMPORVEMENT: 'insufficient reduction.',
+    Status.NO_IMPROVEMENT: 'insufficient reduction.',
     Status.MAX_ITER: 'maximum iterations reached.',
     Status.DX_TOL: 'norm(dx) < tol.',
 }
@@ -322,7 +322,7 @@ def least_squares(
 
       if armijo < 0:
         if mu >= mu_max:
-          status = Status.NO_IMPORVEMENT
+          status = Status.NO_IMPROVEMENT
           break
         mu, n_reduc = increase_mu(mu)
 

--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -213,6 +213,8 @@ def least_squares(
 
   # Initialize logging.
   trace = []
+  last_n_res = 0
+  last_n_jac = 0
   n_res = 0
   n_jac = 0
   t_res = 0.0
@@ -348,9 +350,12 @@ def least_squares(
       message = (
           f'iter: {i:<3d}  y: {y:<9.4g}  log10mu: {logmu:>4.1f}  '
           f'ratio: {reduction_ratio:<7.2g}  '
-          f'dx: {dx_norm:<7.2g}  reduction: {reduction:<7.2g}'
+          f'dx: {dx_norm:<7.2g}  reduction: {reduction:<7.2g}  '
+          f'Res evals: {n_res-last_n_res:d}  Jac evals {n_jac-last_n_jac:d}'
       )
       print(message, file=output)
+      last_n_res = n_res
+      last_n_jac = n_jac
 
     # Append log to trace.
     log = IterLog(candidate=x, objective=y, reduction=reduction, regularizer=mu)


### PR DESCRIPTION
I've started using `minimize.py` for sysid, and it is working well!

This draft hacks `minimize.py` to support parallel jacobian estimation (in one case) and some WIP tweaks to the logging that make it easier to tune the mu parameters. On my problem this results in a 4.2x speedup and I think we can squeeze out a bit more without any real downsides.

If any subset of these changes sounds promising I would be happy to make a feature complete version for merging. I need this kind of parallelism for my work anyway. I'll probably also be looking into speculative multi-threaded line searches soon.

Below is an example of the speedup and logging changes:
```
Single thread
iter: 0    y: 3.418      log10mu: -1.0  ratio: 1.5      dx: 0.49     reduction: 1.5      Res evals: 2  Jac res evals 25  Jac evals 1  time: 25.8
iter: 1    y: 1.894      log10mu: -1.0  ratio: 0.068    dx: 0.81     reduction: 0.04     Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.7
iter: 2    y: 1.854      log10mu: -0.7  ratio: 0.4      dx: 0.61     reduction: 0.2      Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.8
iter: 3    y: 1.65       log10mu: -0.7  ratio: 0.6      dx: 0.23     reduction: 0.12     Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.6
iter: 4    y: 1.525      log10mu: -0.7  ratio: 1.3      dx: 0.1      reduction: 0.095    Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.5
iter: 5    y: 1.431      log10mu: -1.0  ratio: 5.1      dx: 0.0049   reduction: 0.0039   Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.5
iter: 6    y: 1.427      log10mu: -1.0  ratio: 1.2e+02  dx: 0.0016   reduction: 0.0084   Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.4
iter: 7    y: 1.418      log10mu: -1.0  ratio: 1.5      dx: 0.0028   reduction: 0.00088  Res evals: 1  Jac res evals 25  Jac evals 1  time: 25.4
iter: 8    y: 1.417      log10mu:  2.3  ratio: 75       dx: 0.00047  reduction: 0.0041   Res evals: 12  Jac res evals 25  Jac evals 1  time: 36.3
iter: 9    y: 1.413      log10mu:  5.0  ratio: 75       dx: 1.4e-06  reduction: -0.0041  Res evals: 11  Jac res evals 25  Jac evals 1  time: 35.6
Terminated after 9 iterations: insufficient reduction. y: 1.413, Residual evals: 32, Jacobian residual evals: 250, Jacobian evals: 10
total time 277.5s of which residual 11.4% Jacobian 88.6%


Multithread
iter: 0    y: 3.418      log10mu: -1.0  ratio: 1.5      dx: 0.49     reduction: 1.5      Res evals: 2  Jac res evals 25  Jac evals 1  time: 4.0
iter: 1    y: 1.894      log10mu: -1.0  ratio: 0.068    dx: 0.81     reduction: 0.04     Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.4
iter: 2    y: 1.854      log10mu: -0.7  ratio: 0.4      dx: 0.61     reduction: 0.2      Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.2
iter: 3    y: 1.65       log10mu: -0.7  ratio: 0.6      dx: 0.23     reduction: 0.12     Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.5
iter: 4    y: 1.525      log10mu: -0.7  ratio: 1.3      dx: 0.1      reduction: 0.095    Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.4
iter: 5    y: 1.431      log10mu: -1.0  ratio: 5.1      dx: 0.0049   reduction: 0.0039   Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.5
iter: 6    y: 1.427      log10mu: -1.0  ratio: 1.2e+02  dx: 0.0016   reduction: 0.0084   Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.5
iter: 7    y: 1.418      log10mu: -1.0  ratio: 1.5      dx: 0.0028   reduction: 0.00088  Res evals: 1  Jac res evals 25  Jac evals 1  time: 4.4
iter: 8    y: 1.417      log10mu:  2.3  ratio: 75       dx: 0.00047  reduction: 0.0041   Res evals: 12  Jac res evals 25  Jac evals 1  time: 15.3
iter: 9    y: 1.413      log10mu:  5.0  ratio: 75       dx: 1.4e-06  reduction: -0.0041  Res evals: 11  Jac res evals 25  Jac evals 1  time: 14.1
Terminated after 9 iterations: insufficient reduction. y: 1.413, Residual evals: 32, Jacobian residual evals: 250, Jacobian evals: 10
total time 65.7s of which residual 48.4% Jacobian 51.5%

```

Total speedup is 4.2x on a problem with ~25 variables, ~60k residuals, rollouts take a second or two each, 24 core cpu, process pool initialized with all data except for optimized variables.

If speculative line searches were implemented in a similar fashion, another ~30% speedup would be achieved on this problem. However, the mu parameters were tuned for this run. If they were not tuned, the speedup might be similar to parallel jacobian estimation.

