### PR TITLE
Remove dead link from comments, addressing issue #1622

### DIFF
--- a/src/render/glad/glad.c
+++ b/src/render/glad/glad.c
@@ -1441,7 +1441,6 @@ static int mjGlad_find_extensionsGL(void) {
 static void mjGlad_find_coreGL(void) {
 
   /* Thank you @elmindreda
-   * https://github.com/elmindreda/greg/blob/master/templates/greg.c.in#L176
    * https://github.com/glfw/glfw/blob/master/src/context.c#L36
    */
   int major, minor;


### PR DESCRIPTION
This pull request removes a deprecated hyperlink from the source code comments that led to an archived 'greg' repository, which is no longer maintained or available. The removal aligns with the information provided in issue #1622 and avoids potential confusion for developers referencing the code.