### PR TITLE
[Unity plugin] Remove sensor noise properties

### DIFF
--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -73,7 +73,6 @@ public struct MjcfOptionFlag {
   public EnableDisableFlag Override;
   public EnableDisableFlag Energy;
   public EnableDisableFlag FwdInv;
-  public EnableDisableFlag SensorNoise;
   public EnableDisableFlag MultiCCD;
   public static MjcfOptionFlag Default = new MjcfOptionFlag() {
     Constraint = EnableDisableFlag.enable,
@@ -91,7 +90,6 @@ public struct MjcfOptionFlag {
     Override = EnableDisableFlag.disable,
     Energy = EnableDisableFlag.disable,
     FwdInv = EnableDisableFlag.disable,
-    SensorNoise = EnableDisableFlag.disable,
     MultiCCD = EnableDisableFlag.disable
   };
 
@@ -114,7 +112,6 @@ public struct MjcfOptionFlag {
     Override = mjcf.GetEnumAttribute<EnableDisableFlag>("override", localDefault.Override);
     Energy = mjcf.GetEnumAttribute<EnableDisableFlag>("energy", localDefault.Energy);
     FwdInv = mjcf.GetEnumAttribute<EnableDisableFlag>("fwdinv", localDefault.FwdInv);
-    SensorNoise = mjcf.GetEnumAttribute<EnableDisableFlag>("sensornoise", localDefault.SensorNoise);
     MultiCCD = mjcf.GetEnumAttribute<EnableDisableFlag>("multiccd", localDefault.MultiCCD);
   }
 
@@ -134,7 +131,6 @@ public struct MjcfOptionFlag {
     mjcf.SetAttribute("override", Override.ToString());
     mjcf.SetAttribute("energy", Energy.ToString());
     mjcf.SetAttribute("fwdinv", FwdInv.ToString());
-    mjcf.SetAttribute("sensornoise", SensorNoise.ToString());
     mjcf.SetAttribute("multiccd", MultiCCD.ToString());
   }
 }

--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -335,8 +335,8 @@ public class MjGlobalSettings : MonoBehaviour {
         } else if (instances.Length == 1) {
           _instance = instances[0];
         }
-      }
-      return _instance;
+     }
+     return _instance;
     }
   }
 

--- a/unity/Runtime/Components/Sensors/MjBaseSensor.cs
+++ b/unity/Runtime/Components/Sensors/MjBaseSensor.cs
@@ -38,10 +38,6 @@ namespace Mujoco {
 // supported observation types.
 public abstract class MjBaseSensor : MjComponent {
 
-  [Tooltip("The standard deviation of zero-mean Gaussian noise added to the sensor output.")]
-  [AbsoluteValue]
-  public float Noise = 0.0f;
-
   [Tooltip("When this value is positive, it limits the absolute value of the sensor output.")]
   [AbsoluteValue]
   public float Cutoff = 0.0f;
@@ -53,7 +49,6 @@ public abstract class MjBaseSensor : MjComponent {
 
   // Parse the component settings from an external Mjcf.
   protected override void OnParseMjcf(XmlElement mjcf) {
-    Noise = mjcf.GetFloatAttribute("noise", defaultValue: 0.0f);
     Cutoff = mjcf.GetFloatAttribute("cutoff", defaultValue: 0.0f);
     FromMjcf(mjcf);
   }
@@ -61,7 +56,6 @@ public abstract class MjBaseSensor : MjComponent {
   // Generate implementation specific XML element.
   protected override XmlElement OnGenerateMjcf(XmlDocument doc) {
     var mjcf = ToMjcf(doc);
-    mjcf.SetAttribute("noise", Noise.ToString());
     mjcf.SetAttribute("cutoff", Cutoff.ToString());
     return mjcf;
   }

--- a/unity/Tests/Editor/Components/MjGlobalSettingsTests.cs
+++ b/unity/Tests/Editor/Components/MjGlobalSettingsTests.cs
@@ -101,7 +101,6 @@ public class MjGlobalSettingsGenerationTests {
     Assert.That(_doc.OuterXml, Does.Contain(@"override="));
     Assert.That(_doc.OuterXml, Does.Contain(@"energy="));
     Assert.That(_doc.OuterXml, Does.Contain(@"fwdinv="));
-    Assert.That(_doc.OuterXml, Does.Contain(@"sensornoise="));
   }
 }
 

--- a/unity/Tests/Editor/Components/Sensors/MjBaseSensorTests.cs
+++ b/unity/Tests/Editor/Components/Sensors/MjBaseSensorTests.cs
@@ -53,19 +53,16 @@ public class MjBaseSensorTests {
 
   [Test]
   public void GeneratingNoiseAndCutoffMjcf() {
-    _sensor.Noise = 2.0f;
     _sensor.Cutoff = 3.0f;
     _doc.AppendChild(_sensor.GenerateMjcf("name", _doc));
-    Assert.That(_doc.OuterXml, Does.Contain("noise=\"2\""));
     Assert.That(_doc.OuterXml, Does.Contain("cutoff=\"3\""));
   }
 
   [Test]
   public void ParsingShapePropertiesMjcf() {
-    var mjcfString = "<sensor noise=\"3\" cutoff=\"4\" actuator=\"actuator\"/>";
+    var mjcfString = "<sensor cutoff=\"4\" actuator=\"actuator\"/>";
     var mjcfElement = Parse(mjcfString, "sensor");
     _sensor.ParseMjcf(mjcfElement);
-    Assert.That(_sensor.Noise, Is.EqualTo(3.0f));
     Assert.That(_sensor.Cutoff, Is.EqualTo(4.0f));
   }
 }

--- a/unity/Tests/Editor/Importer/MjcfImporterTests.cs
+++ b/unity/Tests/Editor/Importer/MjcfImporterTests.cs
@@ -274,7 +274,7 @@ public class MjcfImporterTests {
   public void ReadingOptionFlags() {
     var mjcfString = @"<mujoco>
       <option>
-        <flag gravity='disable' contact='disable' sensornoise='enable'/>
+        <flag gravity='disable' contact='disable'/>
       </option>
       <worldbody/>
     </mujoco>";
@@ -283,7 +283,6 @@ public class MjcfImporterTests {
     var settings = _sceneRoot.GetComponentInChildren<MjGlobalSettings>();
     Assert.That(settings.GlobalOptions.Flag.Gravity, Is.EqualTo(EnableDisableFlag.disable));
     Assert.That(settings.GlobalOptions.Flag.Contact, Is.EqualTo(EnableDisableFlag.disable));
-    Assert.That(settings.GlobalOptions.Flag.SensorNoise, Is.EqualTo(EnableDisableFlag.enable));
   }
 
   [Test]


### PR DESCRIPTION
Remove references in MjGlobalOptions and sensor base class to the deprecated sensornoise attribute.