### PR TITLE
fixed minimal example shown at mjx.rst

### DIFF
--- a/doc/mjx.rst
+++ b/doc/mjx.rst
@@ -100,7 +100,7 @@ Neither ``mjx.Model`` nor ``mjx.Data`` are meant to be constructed manually.  An
 .. code-block:: python
 
    model = mujoco.MjModel.from_xml_string("...")
-   mjx_model = mjx.device_put(model)
+   mjx_model = mjx.put_model(model)
    mjx_data = mjx.make_data(model)
 
 Using ``mjx.make_data`` may be preferable when constructing batched ``mjx.Data`` structures inside of a ``vmap``.
@@ -151,7 +151,7 @@ Minimal example
    """
 
    model = mujoco.MjModel.from_xml_string(XML)
-   mjx_model = mjx.device_put(model)
+   mjx_model = mjx.put_model(model)
 
    @jax.vmap
    def batched_step(vel):


### PR DESCRIPTION
I tried to run a minimal example explained in mjx docs, but an error occurred as shown below:

![image](https://github.com/google-deepmind/mujoco/assets/50351712/6d8df4be-05dc-4a4d-ad49-76f95149cdf6)


therefore, I have changed the ```mjx.device_put(model)``` to ```mjx.put_model(model)```, and the example code works fine. 

I have PR the modified mjx.rst, if my modification needs to be corrected, please tell me how can I fix it in different way.