### PR TITLE
[Unity Plugin] Track separate kv property for position actuators

### DIFF
--- a/unity/Editor/Components/MjActuatorEditor.cs
+++ b/unity/Editor/Components/MjActuatorEditor.cs
@@ -35,6 +35,7 @@ namespace Mujoco {
     private SerializedProperty _biasPrm;
     // Position actuator properties.
     private SerializedProperty _kp;
+    private SerializedProperty _kvp;
     // Velocity actuator properties.
     private SerializedProperty _kv;
     // Cylinder actuator properties.
@@ -70,6 +71,7 @@ namespace Mujoco {
       _biasPrm = customParams.FindPropertyRelative("BiasPrm");
       // Position actuator properties.
       _kp = customParams.FindPropertyRelative("Kp");
+      _kvp = customParams.FindPropertyRelative("Kvp");
       // Velocity actuator properties.
       _kv = customParams.FindPropertyRelative("Kv");
       // Cylinder actuator properties.
@@ -166,6 +168,7 @@ namespace Mujoco {
 
     private void EditPositionParams(MjActuator.CustomParameters parameters) {
       EditorGUILayout.PropertyField(_kp);
+      EditorGUILayout.PropertyField(_kvp, new GUIContent("Kv"));
     }
 
     private void EditVelocityParams(MjActuator.CustomParameters parameters) {

--- a/unity/Runtime/Components/MjActuator.cs
+++ b/unity/Runtime/Components/MjActuator.cs
@@ -164,11 +164,16 @@ public class MjActuator : MjComponent {
     [AbsoluteValue]
     public float Kp = 1.0f;
 
-    public void PositionToMjcf(XmlElement mjcf) {
+    [AbsoluteValue]
+    public float Kvp;
+
+      public void PositionToMjcf(XmlElement mjcf) {
       mjcf.SetAttribute("kp", MjEngineTool.MakeLocaleInvariant($"{Math.Abs(Kp)}"));
+      mjcf.SetAttribute("kv", MjEngineTool.MakeLocaleInvariant($"{Math.Abs(Kvp)}"));
     }
     public void PositionFromMjcf(XmlElement mjcf) {
       Kp = mjcf.GetFloatAttribute("kp", defaultValue: 1.0f);
+      Kvp = mjcf.GetFloatAttribute("kv", defaultValue: 0f);
     }
 
     //// Velocity actuator parameters.

--- a/unity/Runtime/Components/MjActuator.cs
+++ b/unity/Runtime/Components/MjActuator.cs
@@ -167,7 +167,7 @@ public class MjActuator : MjComponent {
     [AbsoluteValue]
     public float Kvp;
 
-      public void PositionToMjcf(XmlElement mjcf) {
+    public void PositionToMjcf(XmlElement mjcf) {
       mjcf.SetAttribute("kp", MjEngineTool.MakeLocaleInvariant($"{Math.Abs(Kp)}"));
       mjcf.SetAttribute("kv", MjEngineTool.MakeLocaleInvariant($"{Math.Abs(Kvp)}"));
     }

--- a/unity/Tests/Editor/Components/MjActuatorTests.cs
+++ b/unity/Tests/Editor/Components/MjActuatorTests.cs
@@ -279,19 +279,22 @@ public class MjPositionActuatorTests {
     Assert.That(_doc.OuterXml, Does.Contain($"<position"));
   }
 
-  [TestCase(3, "3")]
-  [TestCase(-2, "2")]
-  public void BiasParamsMjcf(float value, string expected) {
-    _actuator.CustomParams.Kp = value;
+  [TestCase(3, 2, "3", "2")]
+  [TestCase(-2, -1, "2", "1")]
+  public void BiasParamsMjcf(float valueP, float valueV, string expectedP, string expectedV) {
+    _actuator.CustomParams.Kp = valueP;
+    _actuator.CustomParams.Kvp = valueV;
     _doc.AppendChild(_actuator.GenerateMjcf("name", _doc));
-    Assert.That(_doc.OuterXml, Does.Contain($"kp=\"{expected}\""));
+    Assert.That(_doc.OuterXml, Does.Contain($"kp=\"{expectedP}\""));
+    Assert.That(_doc.OuterXml, Does.Contain($"kv=\"{expectedV}\""));
   }
 
   [Test]
   public void ParseAllSettings() {
-    _doc.LoadXml("<position joint=\"my_joint\" kp=\"2\"/>");
+    _doc.LoadXml("<position joint=\"my_joint\" kp=\"2\" kv=\"1\"/>");
     _actuator.ParseMjcf(_doc.GetElementsByTagName("position")[0] as XmlElement);
     Assert.That(_actuator.CustomParams.Kp, Is.EqualTo(2));
+    Assert.That(_actuator.CustomParams.Kvp, Is.EqualTo(1));
   }
 
   [Test]
@@ -299,6 +302,7 @@ public class MjPositionActuatorTests {
     _doc.LoadXml("<position joint=\"my_joint\"/>");
     _actuator.ParseMjcf(_doc.GetElementsByTagName("position")[0] as XmlElement);
     Assert.That(_actuator.CustomParams.Kp, Is.EqualTo(1));
+    Assert.That(_actuator.CustomParams.Kvp, Is.EqualTo(0));
   }
 }
 


### PR DESCRIPTION
Added support for `kv` in position actuators in Unity, missing since 3.1.0 . At first I just reused the `Kv` property of the velocity actuators however that had some undesired quirks, such as the default value being 1 instead of 0 for position actuators, or that changing the parameter value when editing the actuator as a velocity actuator influenced the position actuator. For this reason, I seemingly redundantly declared the `Kvp` parameter, let me know if you have any issues or suggestions for this issue. 

I'm also interested on any potential suggestions for the `intvelocity` actuators which are also missing at the moment, but have their own `kp` and `kv`. I'm considering not tracking all these parameters in MjActuator and its Editor at all in the first place, and have sibling classes for each different actuator type, drawing their own Editor and supplying their MJCF parsing/conversion separately.