### PR TITLE
UI Improvements

### DIFF
--- a/include/mujoco/mjui.h
+++ b/include/mujoco/mjui.h
@@ -26,6 +26,7 @@
 #define mjMAXUIRECT     25      // maximum number of rectangles
 
 #define mjSEPCLOSED     1000    // closed state of adjustable separator
+#define mjPRESERVE      2000    // preserve section or separator state
 
 
 // key codes matching GLFW (user must remap for other frameworks)
@@ -268,7 +269,7 @@ struct mjuiSection_ {             // UI section
   int state;                      // section state (mjtSection)
   int modifier;                   // 0: none, 1: control, 2: shift; 4: alt
   int shortcut;                   // shortcut key; 0: undefined
-  int checkbox;                   // section checkbox: 0: none, 1: unchecked, 2: checked
+  int checkbox;                   // 0: none, 1: hidden, 2: unchecked, 2: checked
   int nitem;                      // number of items in use
   mjuiItem item[mjMAXUIITEM];     // preallocated array of items
 
@@ -303,6 +304,7 @@ struct mjUI_ {                    // entire UI
   int mouseitem;                  // item within section
   int mousehelp;                  // help button down: print shortcuts
   int mouseclicks;                // number of mouse clicks over UI
+  int mousesectcheck;             // 0: none, otherwise 1+section
 
   // keyboard focus and edit
   int editsect;                   // 0: none, otherwise 1+section

--- a/include/mujoco/mjui.h
+++ b/include/mujoco/mjui.h
@@ -171,6 +171,8 @@ struct mjuiThemeSpacing_ {        // UI visualization theme spacing
   int scroll;                     // scrollbar width
   int label;                      // label width
   int section;                    // section gap
+  int cornersect;                 // corner radius for section
+  int cornersep;                  // corner radius for separator
   int itemside;                   // item side gap
   int itemmid;                    // item middle gap
   int itemver;                    // item vertical gap
@@ -188,6 +190,10 @@ struct mjuiThemeColor_ {          // UI visualization theme color
   float master[3];                // master background
   float thumb[3];                 // scrollbar thumb
   float secttitle[3];             // section title
+  float secttitle2[3];            // section title: bottom gradient
+  float secttitlecheck[3];        // section title: flat color with checkbox
+  float separator[3];             // separator title
+  float separator2[3];            // separator title: bottom gradient
   float sectfont[3];              // section font
   float sectsymbol[3];            // section symbol
   float sectpane[3];              // section pane

--- a/include/mujoco/mjui.h
+++ b/include/mujoco/mjui.h
@@ -190,13 +190,14 @@ struct mjuiThemeColor_ {          // UI visualization theme color
   float master[3];                // master background
   float thumb[3];                 // scrollbar thumb
   float secttitle[3];             // section title
-  float secttitle2[3];            // section title: bottom gradient
-  float secttitlecheck[3];        // section title: flat color with checkbox
-  float separator[3];             // separator title
-  float separator2[3];            // separator title: bottom gradient
+  float secttitle2[3];            // section title: bottom color
+  float secttitlecheck[3];        // section title with checkbox
+  float secttitlecheck2[3];       // section title with checkbox: bottom color
   float sectfont[3];              // section font
   float sectsymbol[3];            // section symbol
   float sectpane[3];              // section pane
+  float separator[3];             // separator title
+  float separator2[3];            // separator title: bottom color
   float shortcut[3];              // shortcut background
   float fontactive[3];            // font active
   float fontinactive[3];          // font inactive

--- a/include/mujoco/mjui.h
+++ b/include/mujoco/mjui.h
@@ -106,6 +106,13 @@ typedef enum mjtItem_ {           // UI item type
 } mjtItem;
 
 
+typedef enum mjtSection_ {        // UI section state
+  mjSECT_CLOSED = 0,              // closed state (regular section)
+  mjSECT_OPEN,                    // open state (regular section)
+  mjSECT_FIXED                    // fixed section: always open, no title
+} mjtSection;
+
+
 // predicate function: set enable/disable based on item category
 typedef int (*mjfItemEnable)(int category, void* data);
 
@@ -236,6 +243,7 @@ struct mjuiItem_ {                // UI item
   void *pdata;                    // data pointer (type-specific)
   int sectionid;                  // id of section containing item
   int itemid;                     // id of item within section
+  int userid;                     // user-supplied id (for event handling)
 
   // type-specific properties
   union {
@@ -247,6 +255,7 @@ struct mjuiItem_ {                // UI item
 
   // internal
   mjrRect rect;                   // rectangle occupied by item
+  int skip;                       // item skipped due to closed separator
 };
 typedef struct mjuiItem_ mjuiItem;
 
@@ -256,15 +265,17 @@ typedef struct mjuiItem_ mjuiItem;
 struct mjuiSection_ {             // UI section
   // properties
   char name[mjMAXUINAME];         // name
-  int state;                      // 0: closed, 1: open
+  int state;                      // section state (mjtSection)
   int modifier;                   // 0: none, 1: control, 2: shift; 4: alt
   int shortcut;                   // shortcut key; 0: undefined
+  int checkbox;                   // section checkbox: 0: none, 1: unchecked, 2: checked
   int nitem;                      // number of items in use
   mjuiItem item[mjMAXUIITEM];     // preallocated array of items
 
   // internal
   mjrRect rtitle;                 // rectangle occupied by title
   mjrRect rcontent;               // rectangle occupied by content
+  int lastclick;                  // last mouse click over this section
 };
 typedef struct mjuiSection_ mjuiSection;
 
@@ -287,10 +298,11 @@ struct mjUI_ {                    // entire UI
   int maxheight;                  // height when all sections open
   int scroll;                     // scroll from top of UI
 
-  // mouse focus
+  // mouse focus and count
   int mousesect;                  // 0: none, -1: scroll, otherwise 1+section
   int mouseitem;                  // item within section
   int mousehelp;                  // help button down: print shortcuts
+  int mouseclicks;                // number of mouse clicks over UI
 
   // keyboard focus and edit
   int editsect;                   // 0: none, otherwise 1+section
@@ -315,6 +327,7 @@ struct mjuiDef_ {                 // table passed to mjui_add()
   int state;                      // state
   void* pdata;                    // pointer to data
   char other[mjMAXUITEXT];        // string with type-specific properties
+  int otherint;                   // int with type-specific properties
 };
 typedef struct mjuiDef_ mjuiDef;
 

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -677,7 +677,7 @@ void UpdateWatch(mj::Simulate* sim, const mjModel* m, const mjData* d) {
 void MakePhysicsSection(mj::Simulate* sim) {
   mjOption* opt = sim->is_passive_ ? &sim->scnstate_.model.opt : &sim->m_->opt;
   mjuiDef defPhysics[] = {
-    {mjITEM_SECTION,   "Physics",       mjPRESERVE, nullptr,           "AP"},
+    {mjITEM_SECTION,   "Physics",       mjPRESERVE, nullptr,          "AP"},
     {mjITEM_SELECT,    "Integrator",    2, &(opt->integrator),        "Euler\nRK4\nimplicit\nimplicitfast"},
     {mjITEM_SELECT,    "Cone",          2, &(opt->cone),              "Pyramidal\nElliptic"},
     {mjITEM_SELECT,    "Jacobian",      2, &(opt->jacobian),          "Dense\nSparse\nAuto"},

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -117,13 +117,13 @@ enum {
 
 // file section of UI
 const mjuiDef defFile[] = {
-  {mjITEM_SECTION,   "File",          1, nullptr,                    "AF"},
-  {mjITEM_BUTTON,    "Save xml",      2, nullptr,                    ""},
-  {mjITEM_BUTTON,    "Save mjb",      2, nullptr,                    ""},
-  {mjITEM_BUTTON,    "Print model",   2, nullptr,                    "CM"},
-  {mjITEM_BUTTON,    "Print data",    2, nullptr,                    "CD"},
-  {mjITEM_BUTTON,    "Quit",          1, nullptr,                    "CQ"},
-  {mjITEM_BUTTON,    "Screenshot",    2, nullptr,                    "CP"},
+  {mjITEM_SECTION,   "File",          1, nullptr, "AF"},
+  {mjITEM_BUTTON,    "Save xml",      2, nullptr, ""},
+  {mjITEM_BUTTON,    "Save mjb",      2, nullptr, ""},
+  {mjITEM_BUTTON,    "Print model",   2, nullptr, "CM"},
+  {mjITEM_BUTTON,    "Print data",    2, nullptr, "CD"},
+  {mjITEM_BUTTON,    "Quit",          1, nullptr, "CQ"},
+  {mjITEM_BUTTON,    "Screenshot",    2, nullptr, "CP"},
   {mjITEM_END}
 };
 
@@ -682,7 +682,7 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
     {mjITEM_SELECT,    "Cone",          2, &(opt->cone),              "Pyramidal\nElliptic"},
     {mjITEM_SELECT,    "Jacobian",      2, &(opt->jacobian),          "Dense\nSparse\nAuto"},
     {mjITEM_SELECT,    "Solver",        2, &(opt->solver),            "PGS\nCG\nNewton"},
-    {mjITEM_SEPARATOR, "Algorithmic Parameters", 1},
+    {mjITEM_SEPARATOR, "Algorithmic Parameters", mjSEPCLOSED + 1},
     {mjITEM_EDITNUM,   "Timestep",      2, &(opt->timestep),          "1 0 1"},
     {mjITEM_EDITINT,   "Iterations",    2, &(opt->iterations),        "1 0 1000"},
     {mjITEM_EDITNUM,   "Tolerance",     2, &(opt->tolerance),         "1 0 1"},
@@ -695,22 +695,22 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
     {mjITEM_EDITNUM,   "API Rate",      2, &(opt->apirate),           "1 0 1000"},
     {mjITEM_EDITINT,   "SDF Iter",      2, &(opt->sdf_iterations),    "1 1 20"},
     {mjITEM_EDITINT,   "SDF Init",      2, &(opt->sdf_initpoints),    "1 1 100"},
-    {mjITEM_SEPARATOR, "Physical Parameters", 1},
+    {mjITEM_SEPARATOR, "Physical Parameters", mjSEPCLOSED + 1},
     {mjITEM_EDITNUM,   "Gravity",       2, opt->gravity,              "3"},
     {mjITEM_EDITNUM,   "Wind",          2, opt->wind,                 "3"},
     {mjITEM_EDITNUM,   "Magnetic",      2, opt->magnetic,             "3"},
     {mjITEM_EDITNUM,   "Density",       2, &(opt->density),           "1"},
     {mjITEM_EDITNUM,   "Viscosity",     2, &(opt->viscosity),         "1"},
     {mjITEM_EDITNUM,   "Imp Ratio",     2, &(opt->impratio),          "1"},
-    {mjITEM_SEPARATOR, "Disable Flags", 1},
+    {mjITEM_SEPARATOR, "Disable Flags", mjSEPCLOSED + 1},
     {mjITEM_END}
   };
   mjuiDef defEnableFlags[] = {
-    {mjITEM_SEPARATOR, "Enable Flags", 1},
+    {mjITEM_SEPARATOR, "Enable Flags", mjSEPCLOSED + 1},
     {mjITEM_END}
   };
   mjuiDef defOverride[] = {
-    {mjITEM_SEPARATOR, "Contact Override", 1},
+    {mjITEM_SEPARATOR, "Contact Override", mjSEPCLOSED + 1},
     {mjITEM_EDITNUM,   "Margin",        2, &(opt->o_margin),          "1"},
     {mjITEM_EDITNUM,   "Sol Imp",       2, &(opt->o_solimp),          "5"},
     {mjITEM_EDITNUM,   "Sol Ref",       2, &(opt->o_solref),          "2"},
@@ -718,7 +718,7 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
     {mjITEM_END}
   };
   mjuiDef defDisableActuator[] = {
-    {mjITEM_SEPARATOR, "Actuator Group Enable", 1},
+    {mjITEM_SEPARATOR, "Actuator Group Enable", mjSEPCLOSED + 1},
     {mjITEM_CHECKBYTE,  "Act Group 0",  2, sim->enableactuator+0,     ""},
     {mjITEM_CHECKBYTE,  "Act Group 1",  2, sim->enableactuator+1,     ""},
     {mjITEM_CHECKBYTE,  "Act Group 2",  2, sim->enableactuator+2,     ""},
@@ -887,7 +887,7 @@ void MakeVisualizationSection(mj::Simulate* sim, const mjModel* m, int oldstate)
     {mjITEM_EDITFLOAT, "Ambient",         2, &(vis->headlight.ambient),    "3"},
     {mjITEM_EDITFLOAT, "Diffuse",         2, &(vis->headlight.diffuse),    "3"},
     {mjITEM_EDITFLOAT, "Specular",        2, &(vis->headlight.specular),   "3"},
-    {mjITEM_SEPARATOR, "Free Camera",  1},
+    {mjITEM_SEPARATOR, "Free Camera", 1},
     {mjITEM_RADIO,     "Orthographic",    2, &(vis->global.orthographic),  "No\nYes"},
     {mjITEM_EDITFLOAT, "Field of view",   2, &(vis->global.fovy),          "1"},
     {mjITEM_EDITNUM,   "Center",          2, &(stat->center),              "3"},
@@ -1322,9 +1322,22 @@ void UiLayout(mjuiState* state) {
   rect[3].height = rect[0].height;
 }
 
+// modify UI
 void UiModify(mjUI* ui, mjuiState* state, mjrContext* con) {
   mjui_resize(ui, con);
-  mjr_addAux(ui->auxid, ui->width, ui->maxheight, ui->spacing.samples, con);
+
+  // remake aux buffer only if missing or different
+  int id = ui->auxid;
+  if (con->auxFBO[id] == 0 || 
+      con->auxFBO_r[id] == 0 ||
+      con->auxColor[id] == 0 || 
+      con->auxColor_r[id] == 0 ||
+      con->auxWidth[id] != ui->width ||
+      con->auxHeight[id] != ui->maxheight ||
+      con->auxSamples[id] != ui->spacing.samples) {
+    mjr_addAux(id, ui->width, ui->maxheight, ui->spacing.samples, con);
+  }
+
   UiLayout(state);
   mjui_update(-1, -1, ui, state, con);
 }

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -117,7 +117,7 @@ enum {
 
 // file section of UI
 const mjuiDef defFile[] = {
-  {mjITEM_SECTION,   "File",          1, nullptr, "AF"},
+  {mjITEM_SECTION,   "File",          mjPRESERVE, nullptr, "AF"},
   {mjITEM_BUTTON,    "Save xml",      2, nullptr, ""},
   {mjITEM_BUTTON,    "Save mjb",      2, nullptr, ""},
   {mjITEM_BUTTON,    "Print model",   2, nullptr, "CM"},
@@ -674,15 +674,15 @@ void UpdateWatch(mj::Simulate* sim, const mjModel* m, const mjData* d) {
 //---------------------------------- UI construction -----------------------------------------------
 
 // make physics section of UI
-void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
+void MakePhysicsSection(mj::Simulate* sim) {
   mjOption* opt = sim->is_passive_ ? &sim->scnstate_.model.opt : &sim->m_->opt;
   mjuiDef defPhysics[] = {
-    {mjITEM_SECTION,   "Physics",       oldstate, nullptr,           "AP"},
+    {mjITEM_SECTION,   "Physics",       mjPRESERVE, nullptr,           "AP"},
     {mjITEM_SELECT,    "Integrator",    2, &(opt->integrator),        "Euler\nRK4\nimplicit\nimplicitfast"},
     {mjITEM_SELECT,    "Cone",          2, &(opt->cone),              "Pyramidal\nElliptic"},
     {mjITEM_SELECT,    "Jacobian",      2, &(opt->jacobian),          "Dense\nSparse\nAuto"},
     {mjITEM_SELECT,    "Solver",        2, &(opt->solver),            "PGS\nCG\nNewton"},
-    {mjITEM_SEPARATOR, "Algorithmic Parameters", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Algorithmic Parameters", mjPRESERVE},
     {mjITEM_EDITNUM,   "Timestep",      2, &(opt->timestep),          "1 0 1"},
     {mjITEM_EDITINT,   "Iterations",    2, &(opt->iterations),        "1 0 1000"},
     {mjITEM_EDITNUM,   "Tolerance",     2, &(opt->tolerance),         "1 0 1"},
@@ -695,22 +695,22 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
     {mjITEM_EDITNUM,   "API Rate",      2, &(opt->apirate),           "1 0 1000"},
     {mjITEM_EDITINT,   "SDF Iter",      2, &(opt->sdf_iterations),    "1 1 20"},
     {mjITEM_EDITINT,   "SDF Init",      2, &(opt->sdf_initpoints),    "1 1 100"},
-    {mjITEM_SEPARATOR, "Physical Parameters", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Physical Parameters", mjPRESERVE},
     {mjITEM_EDITNUM,   "Gravity",       2, opt->gravity,              "3"},
     {mjITEM_EDITNUM,   "Wind",          2, opt->wind,                 "3"},
     {mjITEM_EDITNUM,   "Magnetic",      2, opt->magnetic,             "3"},
     {mjITEM_EDITNUM,   "Density",       2, &(opt->density),           "1"},
     {mjITEM_EDITNUM,   "Viscosity",     2, &(opt->viscosity),         "1"},
     {mjITEM_EDITNUM,   "Imp Ratio",     2, &(opt->impratio),          "1"},
-    {mjITEM_SEPARATOR, "Disable Flags", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Disable Flags", mjPRESERVE},
     {mjITEM_END}
   };
   mjuiDef defEnableFlags[] = {
-    {mjITEM_SEPARATOR, "Enable Flags", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Enable Flags", mjPRESERVE},
     {mjITEM_END}
   };
   mjuiDef defOverride[] = {
-    {mjITEM_SEPARATOR, "Contact Override", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Contact Override", mjPRESERVE},
     {mjITEM_EDITNUM,   "Margin",        2, &(opt->o_margin),          "1"},
     {mjITEM_EDITNUM,   "Sol Imp",       2, &(opt->o_solimp),          "5"},
     {mjITEM_EDITNUM,   "Sol Ref",       2, &(opt->o_solref),          "2"},
@@ -718,7 +718,7 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
     {mjITEM_END}
   };
   mjuiDef defDisableActuator[] = {
-    {mjITEM_SEPARATOR, "Actuator Group Enable", mjSEPCLOSED + 1},
+    {mjITEM_SEPARATOR, "Actuator Group Enable", mjPRESERVE},
     {mjITEM_CHECKBYTE,  "Act Group 0",  2, sim->enableactuator+0,     ""},
     {mjITEM_CHECKBYTE,  "Act Group 1",  2, sim->enableactuator+1,     ""},
     {mjITEM_CHECKBYTE,  "Act Group 2",  2, sim->enableactuator+2,     ""},
@@ -757,12 +757,12 @@ void MakePhysicsSection(mj::Simulate* sim, int oldstate) {
 
 
 // make rendering section of UI
-void MakeRenderingSection(mj::Simulate* sim, const mjModel* m, int oldstate) {
+void MakeRenderingSection(mj::Simulate* sim, const mjModel* m) {
   mjuiDef defRendering[] = {
     {
       mjITEM_SECTION,
       "Rendering",
-      oldstate,
+      mjPRESERVE,
       nullptr,
       "AR"
     },
@@ -876,12 +876,12 @@ void MakeRenderingSection(mj::Simulate* sim, const mjModel* m, int oldstate) {
 }
 
 // make visualization section of UI
-void MakeVisualizationSection(mj::Simulate* sim, const mjModel* m, int oldstate) {
+void MakeVisualizationSection(mj::Simulate* sim, const mjModel* m) {
   mjStatistic* stat = sim->is_passive_ ? &sim->scnstate_.model.stat : &sim->m_->stat;
   mjVisual* vis = sim->is_passive_ ? &sim->scnstate_.model.vis : &sim->m_->vis;
 
   mjuiDef defVisualization[] = {
-    {mjITEM_SECTION,   "Visualization", oldstate, nullptr, "AV"},
+    {mjITEM_SECTION,   "Visualization", mjPRESERVE, nullptr, "AV"},
     {mjITEM_SEPARATOR, "Headlight",  1},
     {mjITEM_RADIO,     "Active",          5, &(vis->headlight.active),     "Off\nOn"},
     {mjITEM_EDITFLOAT, "Ambient",         2, &(vis->headlight.ambient),    "3"},
@@ -937,9 +937,9 @@ void MakeVisualizationSection(mj::Simulate* sim, const mjModel* m, int oldstate)
 }
 
 // make group section of UI
-void MakeGroupSection(mj::Simulate* sim, int oldstate) {
+void MakeGroupSection(mj::Simulate* sim) {
   mjuiDef defGroup[] = {
-    {mjITEM_SECTION,    "Group enable",     oldstate, nullptr,          "AG"},
+    {mjITEM_SECTION,    "Group enable",     mjPRESERVE, nullptr,          "AG"},
     {mjITEM_SEPARATOR,  "Geom groups",  1},
     {mjITEM_CHECKBYTE,  "Geom 0",           2, sim->opt.geomgroup,          " 0"},
     {mjITEM_CHECKBYTE,  "Geom 1",           2, sim->opt.geomgroup+1,        " 1"},
@@ -997,9 +997,9 @@ void MakeGroupSection(mj::Simulate* sim, int oldstate) {
 }
 
 // make joint section of UI
-void MakeJointSection(mj::Simulate* sim, int oldstate) {
+void MakeJointSection(mj::Simulate* sim) {
   mjuiDef defJoint[] = {
-    {mjITEM_SECTION, "Joint", oldstate, nullptr, "AJ"},
+    {mjITEM_SECTION, "Joint", mjPRESERVE, nullptr, "AJ"},
     {mjITEM_END}
   };
   mjuiDef defSlider[] = {
@@ -1050,9 +1050,9 @@ void MakeJointSection(mj::Simulate* sim, int oldstate) {
 }
 
 // make control section of UI
-void MakeControlSection(mj::Simulate* sim, int oldstate) {
+void MakeControlSection(mj::Simulate* sim) {
   mjuiDef defControl[] = {
-    {mjITEM_SECTION, "Control", oldstate, nullptr, "AC"},
+    {mjITEM_SECTION, "Control", mjPRESERVE, nullptr, "AC"},
     {mjITEM_BUTTON,  "Clear all", 2},
     {mjITEM_END}
   };
@@ -1107,35 +1107,17 @@ void MakeControlSection(mj::Simulate* sim, int oldstate) {
 
 // make model-dependent UI sections
 void MakeUiSections(mj::Simulate* sim, const mjModel* m, const mjData* d) {
-  // get section open-close state, UI 0
-  int oldstate0[NSECT0];
-  for (int i=0; i<NSECT0; i++) {
-    oldstate0[i] = 0;
-    if (sim->ui0.nsect>i) {
-      oldstate0[i] = sim->ui0.sect[i].state;
-    }
-  }
-
-  // get section open-close state, UI 1
-  int oldstate1[NSECT1];
-  for (int i=0; i<NSECT1; i++) {
-    oldstate1[i] = 0;
-    if (sim->ui1.nsect>i) {
-      oldstate1[i] = sim->ui1.sect[i].state;
-    }
-  }
-
   // clear model-dependent sections of UI
   sim->ui0.nsect = SECT_PHYSICS;
   sim->ui1.nsect = 0;
 
   // make
-  MakePhysicsSection(sim, oldstate0[SECT_PHYSICS]);
-  MakeRenderingSection(sim, m, oldstate0[SECT_RENDERING]);
-  MakeVisualizationSection(sim, m, oldstate0[SECT_VISUALIZATION]);
-  MakeGroupSection(sim, oldstate0[SECT_GROUP]);
-  MakeJointSection(sim, oldstate1[SECT_JOINT]);
-  MakeControlSection(sim, oldstate1[SECT_CONTROL]);
+  MakePhysicsSection(sim);
+  MakeRenderingSection(sim, m);
+  MakeVisualizationSection(sim, m);
+  MakeGroupSection(sim);
+  MakeJointSection(sim);
+  MakeControlSection(sim);
 }
 
 //---------------------------------- utility functions ---------------------------------------------
@@ -1517,7 +1499,7 @@ void UiEvent(mjuiState* state) {
       // remake joint section if joint group changed
       if (it->name[0]=='J' && it->name[1]=='o') {
         sim->ui1.nsect = SECT_JOINT;
-        MakeJointSection(sim, sim->ui1.sect[SECT_JOINT].state);
+        MakeJointSection(sim);
         sim->ui1.nsect = NSECT1;
         UiModify(&sim->ui1, state, &sim->platform_ui->mjr_context());
       }
@@ -2470,7 +2452,7 @@ void Simulate::Render() {
   if (pending_.ui_remake_ctrl) {
     if (this->ui1_enable && this->ui1.sect[SECT_CONTROL].state) {
       this->ui1.nsect = SECT_CONTROL;
-      MakeControlSection(this, this->ui1.sect[SECT_CONTROL].state);
+      MakeControlSection(this);
       this->ui1.nsect = NSECT1;
       UiModify(&this->ui1, &this->uistate, &this->platform_ui->mjr_context());
     }
@@ -2658,12 +2640,15 @@ void Simulate::RenderLoop() {
   this->platform_ui->SetEventCallback(UiEvent);
   this->platform_ui->SetLayoutCallback(UiLayout);
 
-  // populate uis with standard sections
+  // populate uis with standard sections, open some sections initially
   this->ui0.userdata = this;
   this->ui1.userdata = this;
   mjui_add(&this->ui0, defFile);
   mjui_add(&this->ui0, this->def_option);
   mjui_add(&this->ui0, this->def_simulation);
+  this->ui0.sect[0].state = 1;
+  this->ui0.sect[1].state = 1;
+  this->ui0.sect[2].state = 1;
   mjui_add(&this->ui0, this->def_watch);
   UiModify(&this->ui0, &this->uistate, &this->platform_ui->mjr_context());
   UiModify(&this->ui1, &this->uistate, &this->platform_ui->mjr_context());

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -265,7 +265,7 @@ class Simulate {
   // Constant arrays needed for the option section of UI and the UI interface
   // TODO setting the size here is not ideal
   const mjuiDef def_option[13] = {
-    {mjITEM_SECTION,  "Option",        1, nullptr,           "AO"},
+    {mjITEM_SECTION,  "Option",        mjPRESERVE, nullptr,  "AO"},
     {mjITEM_CHECKINT, "Help",          2, &this->help,       " #290"},
     {mjITEM_CHECKINT, "Info",          2, &this->info,       " #291"},
     {mjITEM_CHECKINT, "Profiler",      2, &this->profiler,   " #292"},
@@ -287,7 +287,7 @@ class Simulate {
 
   // simulation section of UI
   const mjuiDef def_simulation[14] = {
-    {mjITEM_SECTION,   "Simulation",    1, nullptr,              "AS"},
+    {mjITEM_SECTION,   "Simulation",    mjPRESERVE, nullptr,     "AS"},
     {mjITEM_RADIO,     "",              5, &this->run,           "Pause\nRun"},
     {mjITEM_BUTTON,    "Reset",         2, nullptr,              " #259"},
     {mjITEM_BUTTON,    "Reload",        5, nullptr,              "CL"},
@@ -306,7 +306,7 @@ class Simulate {
 
   // watch section of UI
   const mjuiDef def_watch[5] = {
-    {mjITEM_SECTION,   "Watch",         0, nullptr,              "AW"},
+    {mjITEM_SECTION,   "Watch",         mjPRESERVE, nullptr,     "AW"},
     {mjITEM_EDITTXT,   "Field",         2, this->field,          "qpos"},
     {mjITEM_EDITINT,   "Index",         2, &this->index,         "1"},
     {mjITEM_STATIC,    "Value",         2, nullptr,              " "},

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -26,137 +26,159 @@
 
 // theme spacing 0 : tight
 static const mjuiThemeSpacing themeSpacing0 = {
-  270,   // int total;
-  15,    // int scroll;
-  120,   // int label;
-  8,     // int section;
-  4,     // int itemside;
-  4,     // int itemmid;
-  4,     // int itemver;
-  8,     // int texthor;
-  4,     // int textver;
-  30,    // int linescroll;
-  4      // int samples;
+  270,   // total
+  15,    // scroll
+  120,   // label
+  8,     // section
+  6,     // cornersect
+  6,     // cornersep
+  4,     // itemside
+  4,     // itemmid
+  4,     // itemver
+  8,     // texthor
+  4,     // textver
+  30,    // linescroll
+  4      // samples
 };
 
 
 // theme spacing 1 : wide
 static const mjuiThemeSpacing themeSpacing1 = {
-  310,   // int total;
-  15,    // int scroll;
-  120,   // int label;
-  10,    // int section;
-  7,     // int itemside;
-  7,     // int itemmid;
-  7,     // int itemver;
-  10,    // int texthor;
-  5,     // int textver;
-  30,    // int linescroll;
-  4      // int samples;
+  310,   // total
+  15,    // scroll
+  120,   // label
+  10,    // section
+  10,    // cornersect
+  10,    // cornersep
+  7,     // itemside
+  7,     // itemmid
+  7,     // itemver
+  10,    // texthor
+  5,     // textver
+  30,    // linescroll
+  4      // samples
 };
 
 
 // theme color 0 : default
 static const mjuiThemeColor themeColor0 = {
-  {0.25, 0.25, 0.25},   // float master[3];
-  {0.12, 0.12, 0.12},   // float thumb[3];
-  {0.6,  0.2,  0.2},    // float secttitle[3];
-  {1.0,  1.0,  1.0},    // float sectfont[3];
-  {0.7,  0.7,  0.7},    // float sectsymbol[3];
-  {0.1,  0.1,  0.1},    // float sectpane[3];
-  {0.0,  0.0,  1.0},    // float shortcut[3];
-  {1.0,  1.0,  1.0},    // float fontactive[3];
-  {0.5,  0.5,  0.5},    // float fontinactive[3];
-  {0.3,  0.3,  0.3},    // float decorinactive[3];
-  {0.4,  0.4,  0.4},    // float decorinactive2[3];
-  {0.6,  0.4,  0.4},    // float button[3];
-  {0.4,  0.4,  0.7},    // float check[3];
-  {0.4,  0.6,  0.4},    // float radio[3];
-  {0.4,  0.6,  0.6},    // float select[3];
-  {0.2,  0.3,  0.3},    // float select2[3];
-  {0.3,  0.2,  0.3},    // float slider[3];
-  {0.6,  0.4,  0.6},    // float slider2[3];
-  {0.6,  0.6,  0.4},    // float edit[3];
-  {0.7,  0.0,  0.0},    // float edit2[3];
-  {0.9,  0.9,  0.9}     // float cursor[3];
+  {0.25, 0.25, 0.25},   // master
+  {0.12, 0.12, 0.12},   // thumb
+  {0.6,  0.2,  0.2},    // secttitle
+//  {0.6,  0.2,  0.2},    // secttitle2
+  {0.1,  0.1,  0.1},    // secttitle2
+  {0.45, 0.17, 0.17},   // secttitlecheck
+  {0.25, 0.25, 0.25},   // separator
+//  {0.25, 0.25, 0.25},   // separator2
+  {0.1,  0.1,  0.1},    // separator2
+  {1.0,  1.0,  1.0},    // sectfont
+  {0.7,  0.7,  0.7},    // sectsymbol
+  {0.1,  0.1,  0.1},    // sectpane
+  {0.0,  0.0,  1.0},    // shortcut
+  {1.0,  1.0,  1.0},    // fontactive
+  {0.5,  0.5,  0.5},    // fontinactive
+  {0.3,  0.3,  0.3},    // decorinactive
+  {0.4,  0.4,  0.4},    // decorinactive2
+  {0.6,  0.4,  0.4},    // button
+  {0.4,  0.4,  0.7},    // check
+  {0.4,  0.6,  0.4},    // radio
+  {0.4,  0.6,  0.6},    // select
+  {0.2,  0.3,  0.3},    // select2
+  {0.3,  0.2,  0.3},    // slider
+  {0.6,  0.4,  0.6},    // slider2
+  {0.6,  0.6,  0.4},    // edit
+  {0.7,  0.0,  0.0},    // edit2
+  {0.9,  0.9,  0.9}     // cursor
 };
 
 
 // theme color 1 : orange
 static const mjuiThemeColor themeColor1 = {
-  {0.2,  0.2,  0.2},       // float master[3];
-  {0.12, 0.12, 0.12},      // float thumb[3];
-  {0.3,  0.3,  0.3},       // float secttitle[3];
-  {0.8,  0.8,  0.8},       // float sectfont[3];
-  {0.7,  0.7,  0.7},       // float sectsymbol[3];
-  {0.15, 0.15, 0.15},      // float sectpane[3];
-  {0.0,  0.0,  1.0},       // float shortcut[3];
-  {0.9,  0.9,  0.9},       // float fontactive[3];
-  {0.5,  0.5,  0.5},       // float fontinactive[3];
-  {0.2,  0.2,  0.2},       // float decorinactive[3];
-  {0.25, 0.25, 0.25},      // float decorinactive2[3];
-  {0.6,  0.4,  0.2},       // float button[3];
-  {0.6,  0.4,  0.2},       // float check[3];
-  {0.6,  0.4,  0.2},       // float radio[3];
-  {0.6,  0.4,  0.2},       // float select[3];
-  {0.3,  0.2,  0.1},       // float select2[3];
-  {0.2,  0.2,  0.2},       // float slider[3];
-  {0.6,  0.4,  0.2},       // float slider2[3];
-  {0.6,  0.4,  0.2},       // float edit[3];
-  {0.7,  0.0,  0.0},       // float edit2[3];
-  {0.9,  0.9,  0.9}        // float cursor[3];
+  {0.2,  0.2,  0.2},    // master
+  {0.12, 0.12, 0.12},   // thumb
+  {0.3,  0.3,  0.3},    // secttitle
+  {0.15, 0.15, 0.15},   // secttitle2
+  {0.25, 0.25, 0.25},   // secttitlecheck
+  {0.2,  0.2,  0.2},    // separator
+  {0.15, 0.15, 0.15},   // separator2
+  {0.8,  0.8,  0.8},    // sectfont
+  {0.7,  0.7,  0.7},    // sectsymbol
+  {0.15, 0.15, 0.15},   // sectpane
+  {0.0,  0.0,  1.0},    // shortcut
+  {0.9,  0.9,  0.9},    // fontactive
+  {0.5,  0.5,  0.5},    // fontinactive
+  {0.2,  0.2,  0.2},    // decorinactive
+  {0.25, 0.25, 0.25},   // decorinactive2
+  {0.6,  0.4,  0.2},    // button
+  {0.6,  0.4,  0.2},    // check
+  {0.6,  0.4,  0.2},    // radio
+  {0.6,  0.4,  0.2},    // select
+  {0.3,  0.2,  0.1},    // select2
+  {0.2,  0.2,  0.2},    // slider
+  {0.6,  0.4,  0.2},    // slider2
+  {0.6,  0.4,  0.2},    // edit
+  {0.7,  0.0,  0.0},    // edit2
+  {0.9,  0.9,  0.9}     // cursor
 };
 
 
 // theme color 2 : white
 static const mjuiThemeColor themeColor2 = {
-  {0.9,  0.9,  0.9},       // float master[3];
-  {0.7,  0.7,  0.7},       // float thumb[3];
-  {0.8,  0.8,  0.8},       // float secttitle[3];
-  {0.0,  0.0,  0.8},       // float sectfont[3];
-  {0.0,  0.0,  0.8},       // float sectsymbol[3];
-  {1.0,  1.0,  1.0},       // float sectpane[3];
-  {0.0,  1.0,  1.0},       // float shortcut[3];
-  {0.0,  0.0,  0.0},       // float fontactive[3];
-  {0.7,  0.7,  0.7},       // float fontinactive[3];
-  {0.95, 0.95, 0.95},      // float decorinactive[3];
-  {0.9,  0.9,  0.9},       // float decorinactive2[3];
-  {0.8,  0.8,  0.8},       // float button[3];
-  {0.8,  0.8,  0.8},       // float check[3];
-  {0.8,  0.8,  0.8},       // float radio[3];
-  {0.8,  0.8,  0.8},       // float select[3];
-  {0.9,  0.9,  0.9},       // float select2[3];
-  {0.95, 0.95, 0.95},      // float slider[3];
-  {0.8,  0.8,  0.8},       // float slider2[3];
-  {0.8,  0.8,  0.8},       // float edit[3];
-  {1.0,  0.3,  0.3},       // float edit2[3];
-  {0.2,  0.2,  0.2}        // float cursor[3];
+  {0.9,  0.9,  0.9},    // master
+  {0.7,  0.7,  0.7},    // thumb
+  {0.8,  0.8,  0.8},    // secttitle
+  {1.0,  1.0,  1.0},    // secttitle2
+  {0.95, 0.95, 0.95},   // secttitlecheck
+  {0.9,  0.9,  0.9},    // separator
+  {1.0,  1.0,  1.0},    // separator2
+  {0.0,  0.0,  0.8},    // sectfont
+  {0.0,  0.0,  0.8},    // sectsymbol
+  {1.0,  1.0,  1.0},    // sectpane
+  {0.0,  1.0,  1.0},    // shortcut
+  {0.0,  0.0,  0.0},    // fontactive
+  {0.7,  0.7,  0.7},    // fontinactive
+  {0.95, 0.95, 0.95},   // decorinactive
+  {0.9,  0.9,  0.9},    // decorinactive2
+  {0.8,  0.8,  0.8},    // button
+  {0.8,  0.8,  0.8},    // check
+  {0.8,  0.8,  0.8},    // radio
+  {0.8,  0.8,  0.8},    // select
+  {0.9,  0.9,  0.9},    // select2
+  {0.95, 0.95, 0.95},   // slider
+  {0.8,  0.8,  0.8},    // slider2
+  {0.8,  0.8,  0.8},    // edit
+  {1.0,  0.3,  0.3},    // edit2
+  {0.2,  0.2,  0.2}     // cursor
 };
 
 
 // theme color 3 : black
 static const mjuiThemeColor themeColor3 = {
-  {0.15, 0.15, 0.15},      // float master[3];
-  {0.3,  0.3,  0.3},       // float thumb[3];
-  {0.25, 0.25, 0.25},      // float secttitle[3];
-  {1.0,  0.3,  0.3},       // float sectfont[3];
-  {1.0,  0.3,  0.3},       // float sectsymbol[3];
-  {0.0,  0.0,  0.0},       // float sectpane[3];
-  {0.0,  0.0,  1.0},       // float shortcut[3];
-  {1.0,  1.0,  1.0},       // float fontactive[3];
-  {0.4,  0.4,  0.4},       // float fontinactive[3];
-  {0.1,  0.1,  0.1},       // float decorinactive[3];
-  {0.15, 0.15, 0.15},      // float decorinactive2[3];
-  {0.3,  0.3,  0.3},       // float button[3];
-  {0.3,  0.3,  0.3},       // float check[3];
-  {0.3,  0.3,  0.3},       // float radio[3];
-  {0.3,  0.3,  0.3},       // float select[3];
-  {0.15, 0.15, 0.15},      // float select2[3];
-  {0.15, 0.15, 0.15},      // float slider[3];
-  {0.3,  0.3,  0.3},       // float slider2[3];
-  {0.3,  0.3,  0.3},       // float edit[3];
-  {0.8,  0.2,  0.2},       // float edit2[3];
-  {0.8,  0.8,  0.8}        // float cursor[3];
+  {0.15, 0.15, 0.15},   // master
+  {0.3,  0.3,  0.3},    // thumb
+  {0.25, 0.25, 0.25},   // secttitle
+  {0.0,  0.0,  0.0},    // secttitle2
+  {0.2,  0.2,  0.2},    // secttitlecheck
+  {0.15, 0.15, 0.15},   // separator
+  {0.0,  0.0,  0.0},    // separator2
+  {1.0,  0.3,  0.3},    // sectfont
+  {1.0,  0.3,  0.3},    // sectsymbol
+  {0.0,  0.0,  0.0},    // sectpane
+  {0.0,  0.0,  1.0},    // shortcut
+  {1.0,  1.0,  1.0},    // fontactive
+  {0.4,  0.4,  0.4},    // fontinactive
+  {0.1,  0.1,  0.1},    // decorinactive
+  {0.15, 0.15, 0.15},   // decorinactive2
+  {0.3,  0.3,  0.3},    // button
+  {0.3,  0.3,  0.3},    // check
+  {0.3,  0.3,  0.3},    // radio
+  {0.3,  0.3,  0.3},    // select
+  {0.15, 0.15, 0.15},   // select2
+  {0.15, 0.15, 0.15},   // slider
+  {0.3,  0.3,  0.3},    // slider2
+  {0.3,  0.3,  0.3},    // edit
+  {0.8,  0.2,  0.2},    // edit2
+  {0.8,  0.8,  0.8}     // cursor
 };
 
 
@@ -172,7 +194,7 @@ static int SCL(int sz, const mjrContext* con) {
 
 
 // init OpenGL
-static void initOpenGL(const mjUI* ui, const mjrContext* con) {
+static void initOpenGL(const mjrRect* r, const mjrContext* con) {
   // set OpenGL options
   glDisable(GL_NORMALIZE);
   glDisable(GL_DEPTH_TEST);
@@ -186,12 +208,12 @@ static void initOpenGL(const mjUI* ui, const mjrContext* con) {
   // standard 2D projection, in framebuffer units
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
-  glOrtho(0, ui->width, 0, ui->height, -1, 1);
+  glOrtho(0, r->width, 0, r->height, -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 
   // set viewport
-  glViewport(0, 0, ui->width, ui->height);
+  glViewport(r->left, r->bottom, r->width, r->height);
 }
 
 
@@ -277,10 +299,75 @@ static void drawrectangle(mjrRect rect, const float* rgb, const float* rgbback,
 
 
 
+// round corners of rectangle
+static void roundcorner(mjrRect rect, int flg_skipbottom, int flg_separator,
+                        const mjUI* ui, const mjrContext* con) {
+  // get rounding, return if disabled
+  int radcorner = flg_separator ? ui->spacing.cornersep : ui->spacing.cornersect;
+  if (radcorner == 0) {
+    return;
+  }
+
+  // divisions and radius
+  const int ndivide = 10;
+  double radius = radcorner * 0.01 * con->fontScale;
+
+  // loop over corners
+  for (int ic = (flg_skipbottom ? 2 : 0); ic < 4; ++ic) {
+    double corner[2];
+    double angle;
+
+    // set corner and angle
+    switch (ic) {
+    case 0:   // bottom-left
+      corner[0] = rect.left;
+      corner[1] = rect.bottom;
+      angle = 0;
+      break;
+
+    case 1:   // bottom-right
+      corner[0] = rect.left + rect.width;
+      corner[1] = rect.bottom;
+      angle = 0.5 * mjPI;
+      break;
+
+    case 2:   // top-right
+      corner[0] = rect.left + rect.width;
+      corner[1] = rect.bottom + rect.height;
+      angle = mjPI;
+      break;
+
+    default:  // top-left
+      corner[0] = rect.left;
+      corner[1] = rect.bottom + rect.height;
+      angle = 1.5 * mjPI;
+    }
+
+    // compute circle center: opposite to corner
+    double center[2];
+    center[0] = corner[0] + mju_sqrt(2.0) * radius * cos(angle + 0.25 * mjPI);
+    center[1] = corner[1] + mju_sqrt(2.0) * radius * sin(angle + 0.25 * mjPI);
+
+    // fill with erase color, start trinagle_fan from corner
+    glColor3fv(flg_separator ? ui->color.sectpane : ui->color.master);
+    glBegin(GL_TRIANGLE_FAN);
+    glVertex2d(corner[0], corner[1]);
+
+    // compute vertices of quarter-circle
+    for (int i = 0; i <= ndivide; i++) {
+      double a = angle + mjPI + 0.5 * mjPI * (double)i / (double)ndivide;
+      glVertex2d(center[0] + radius * cos(a), center[1] + radius * sin(a));
+    }
+    glEnd();
+  }
+}
+
+
+
 // draw oval
 static void drawoval(mjrRect rect, const float* rgb, const float* rgbback,
                      const mjrContext* con) {
-  const int ndivide = 20;
+  const int ndivide = 15;
 
   // require horizontal
   if (rect.height > rect.width) {
@@ -374,16 +461,16 @@ static void drawsymbol(mjrRect rect, int flg_open, int flg_sep,
     double y = d - u - 0.5*margin;
     if (flg_sep) {
       glColor3f(
-        (ui->color.master[0] + ui->color.sectpane[0]) * 0.5,
-        (ui->color.master[1] + ui->color.sectpane[1]) * 0.5,
-        (ui->color.master[2] + ui->color.sectpane[2]) * 0.5
-        );
+        (ui->color.separator[0] + ui->color.separator2[0]) * 0.5,
+        (ui->color.separator[1] + ui->color.separator2[1]) * 0.5,
+        (ui->color.separator[2] + ui->color.separator2[2]) * 0.5
+      );
     } else {
       glColor3f(
-        (ui->color.secttitle[0] + ui->color.sectpane[0]) * 0.5,
-        (ui->color.secttitle[1] + ui->color.sectpane[1]) * 0.5,
-        (ui->color.secttitle[2] + ui->color.sectpane[2]) * 0.5
-        );
+        (ui->color.secttitle[0] + ui->color.secttitle2[0]) * 0.5,
+        (ui->color.secttitle[1] + ui->color.secttitle2[1]) * 0.5,
+        (ui->color.secttitle[2] + ui->color.secttitle2[2]) * 0.5
+      );
     }
     glBegin(GL_TRIANGLES);
     glVertex2d(cx-margin, cy-y);
@@ -1222,9 +1309,9 @@ void mjui_add(mjUI* ui, const mjuiDef* def) {
       int oldstate = it->state;
       memset(it, 0, sizeof(mjuiItem));
 
-      // set or restore state for collapsable separator, copy state for others
+      // set or restore state for collapsible separator, copy state for others
       if (def[n].type == mjITEM_SEPARATOR && def[n].state == mjPRESERVE) {
-        // mjSEPCLOSED makes separator collapsable
+        // mjSEPCLOSED makes separator collapsible
         it->state = (oldstate < mjSEPCLOSED ? mjSEPCLOSED : oldstate);
       }
       else {
@@ -1812,7 +1899,8 @@ void mjui_update(int section, int item, const mjUI* ui,
 
   // start rendering
   mjr_setAux(ui->auxid, con);
-  initOpenGL(ui, con);
+  mjrRect rgl = { 0, 0, ui->width, ui->height };
+  initOpenGL(&rgl, con);
 
   // all sections: clear background
   if (section < 0) {
@@ -1851,7 +1939,7 @@ void mjui_update(int section, int item, const mjUI* ui,
         if (s->checkbox == 0) {
           // interpolated rectangle
           glBegin(GL_QUADS);
-          glColor3fv(ui->color.sectpane);
+          glColor3fv(ui->color.secttitle2);
           glVertex2i(r.left, r.bottom);
           glVertex2i(r.left + r.width, r.bottom);
           glColor3fv(ui->color.secttitle);
@@ -1868,14 +1956,8 @@ void mjui_update(int section, int item, const mjUI* ui,
       
         // section with checkbox
         else {
-          // solid rectangle
-          const float rgb[3] = {
-            0.7f * ui->color.secttitle[0] + 0.3f * ui->color.sectpane[0],
-            0.7f * ui->color.secttitle[1] + 0.3f * ui->color.sectpane[1],
-            0.7f * ui->color.secttitle[2] + 0.3f * ui->color.sectpane[2]
-          };
           glBegin(GL_QUADS);
-          glColor3fv(rgb);
+          glColor3fv(ui->color.secttitlecheck);
           glVertex2i(r.left, r.bottom);
           glVertex2i(r.left + r.width, r.bottom);
           glVertex2i(r.left + r.width, r.bottom + r.height);
@@ -1892,7 +1974,8 @@ void mjui_update(int section, int item, const mjUI* ui,
           if (s->checkbox > 1) {
             int cgap = r.height / 4;
             mjrRect cr = { r.left + cgap, r.bottom + cgap, r.height - 2 * cgap, r.height - 2 * cgap };
-            drawrectangle(cr, ui->color.sectsymbol, s->checkbox == 2 ? rgb : NULL, con);
+            drawrectangle(cr, ui->color.sectsymbol, 
+              s->checkbox == 2 ? ui->color.secttitlecheck : NULL, con);
           }
         }
 
@@ -1906,6 +1989,17 @@ void mjui_update(int section, int item, const mjUI* ui,
       if (s->state != mjSECT_CLOSED) {
         drawrectangle(s->rcontent, ui->color.sectpane, NULL, con);
       }
+
+      // round corners
+      mjrRect rround = s->rtitle;
+      if (s->state == mjSECT_FIXED) {
+        rround = s->rcontent;
+      }
+      else if (s->state == mjSECT_OPEN) {
+        rround.bottom = s->rcontent.bottom;
+        rround.height = s->rtitle.height + s->rcontent.height;
+      }
+      roundcorner(rround, 0, 0, ui, con);
     }
 
     // closed: skip items
@@ -1948,10 +2042,10 @@ void mjui_update(int section, int item, const mjUI* ui,
         // background
         r = it->rect;
         glBegin(GL_QUADS);
-        glColor3fv(ui->color.sectpane);
+        glColor3fv(ui->color.separator2);
         glVertex2i(r.left, r.bottom);
         glVertex2i(r.left+r.width, r.bottom);
-        glColor3fv(ui->color.master);
+        glColor3fv(ui->color.separator);
         glVertex2i(r.left+r.width, r.bottom+r.height);
         glVertex2i(r.left, r.bottom+r.height);
         glEnd();
@@ -1962,13 +2056,14 @@ void mjui_update(int section, int item, const mjUI* ui,
                  it->rect.bottom+g_textver,
                  it->rect.width-2*g_texthor, ui->color.sectfont, con);
 
-        // symbol
+        // symbol and round corners for collapsible
         if (it->state == mjSEPCLOSED+1) {
           drawsymbol(it->rect, 1, 1, ui, con);
+          roundcorner(it->rect, 1, 1, ui, con);
         } else if (it->state == mjSEPCLOSED) {
           drawsymbol(it->rect, 0, 1, ui, con);
+          roundcorner(it->rect, 0, 1, ui, con);
         }
-
         break;
 
       case mjITEM_STATIC:
@@ -2139,7 +2234,7 @@ void mjui_update(int section, int item, const mjUI* ui,
                    it->rect.width-2*g_texthor, rgbfont, con);
         }
 
-        // draw tracking at the end
+        // draw tracking in mjui_render()
         break;
 
       case mjITEM_SLIDERINT:
@@ -2252,46 +2347,6 @@ void mjui_update(int section, int item, const mjUI* ui,
 
       default:
         mju_error("mjui_update: internal error: unexpected item type");
-      }
-    }
-  }
-
-  // select tracking
-  if (ui->mousesect > 0 && ui->mouseitem >= 0) {
-    // get item pointer
-    const mjuiItem* it = ui->sect[ui->mousesect-1].item + ui->mouseitem;
-
-    // proceed if select type
-    if (it->type == mjITEM_SELECT) {
-      // margin
-      r = it->rect;
-      r.left -= g_itemside;
-      r.width += 2*g_itemside;
-      r.height = it->multi.nelem * cellheight + g_itemside;
-      r.bottom -= r.height;
-      drawrectangle(r, ui->color.sectpane, NULL, con);
-
-      // box
-      r = it->rect;
-      r.height = it->multi.nelem * cellheight;
-      r.bottom -= r.height;
-      drawrectangle(r, ui->color.select2, NULL, con);
-
-      // hightlight row under mouse
-      int k = findselect(it, ui, state, con);
-      if (k >= 0) {
-        mjrRect r1 = r;
-        r1.bottom = r.bottom + (it->multi.nelem-1-k)*cellheight;
-        r1.height = cellheight;
-        drawrectangle(r1, ui->color.select, NULL, con);
-      }
-
-      // values
-      for (int k=0; k < it->multi.nelem; k++) {
-        drawtext(it->multi.name[k],
-                 r.left+g_texthor,
-                 r.bottom+g_textver+(it->multi.nelem-1-k)*cellheight,
-                 r.width-2*g_texthor, ui->color.fontactive, con);
       }
     }
   }
@@ -2835,5 +2890,62 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
     // draw
     mjr_rectangle(thumb, ui->color.thumb[0], ui->color.thumb[1],
                   ui->color.thumb[2], 1);
+  }
+
+  // draw select tracking on top if needed
+  if (ui->mousesect > 0 && ui->mouseitem >= 0) {
+    // get item pointer
+    const mjuiItem* it = ui->sect[ui->mousesect-1].item + ui->mouseitem;
+
+    // get sizes
+    int g_texthor = SCL(ui->spacing.texthor, con);
+    int g_textver = SCL(ui->spacing.textver, con);
+    int g_itemside = SCL(ui->spacing.itemside, con);
+    int cellheight = con->charHeight + 2 * g_textver;
+    int offset = mjMAX(0, rect.height - ui->height + ui->scroll) -
+                 mjMAX(0, ui->height - ui->scroll - rect.height);
+
+    // proceed if select type
+    if (it->type == mjITEM_SELECT) {
+      // margin
+      mjrRect r = it->rect;
+      r.left -= g_itemside;
+      r.width += 2*g_itemside;
+      r.height = it->multi.nelem * cellheight + g_itemside;
+      r.bottom -= r.height;
+      r.bottom += offset;
+      r.left += rect.left;
+      mjr_rectangle(r, ui->color.sectpane[0],
+        ui->color.sectpane[1], ui->color.sectpane[2], 1);
+
+      // box
+      r = it->rect;
+      r.height = it->multi.nelem * cellheight;
+      r.bottom -= r.height;
+      r.bottom += offset;
+      r.left += rect.left;
+      mjr_rectangle(r, ui->color.select2[0],
+        ui->color.select2[1], ui->color.select2[2], 1);
+
+      // hightlight row under mouse
+      int k = findselect(it, ui, state, con);
+      if (k >= 0) {
+        mjrRect r1 = r;
+        r1.bottom = r.bottom + (it->multi.nelem-1-k)*cellheight;
+        r1.height = cellheight;
+        mjr_rectangle(r1, ui->color.select[0], 
+          ui->color.select[1], ui->color.select[2], 1);
+      }
+
+
+      // values
+      initOpenGL(&rect, con);
+      for (int k=0; k < it->multi.nelem; k++) {
+        drawtext(it->multi.name[k],
+                 r.left+g_texthor - rect.left,
+                 r.bottom+g_textver+(it->multi.nelem-1-k)*cellheight,
+                 r.width-2*g_texthor, ui->color.fontactive, con);
+      }
+    }
   }
 }

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -2923,9 +2923,6 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
       int offset = mjMAX(0, rect.height - ui->height + ui->scroll) -
                    mjMAX(0, ui->height - ui->scroll - rect.height);
 
-      // draw in entire ui rectangle
-      initOpenGL(&rect, con);
-
       // margin
       mjrRect r = it->rect;
       r.left -= g_itemside;
@@ -2934,7 +2931,8 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
       r.bottom -= r.height;
       r.bottom += offset;
       r.left += rect.left;
-      drawrectangle(r, ui->color.sectpane, NULL, con);
+      mjr_rectangle(r, ui->color.sectpane[0],
+        ui->color.sectpane[1], ui->color.sectpane[2], 1);
 
       // box
       r = it->rect;
@@ -2942,7 +2940,8 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
       r.bottom -= r.height;
       r.bottom += offset;
       r.left += rect.left;
-      drawrectangle(r, ui->color.select2, NULL, con);
+      mjr_rectangle(r, ui->color.select2[0], 
+        ui->color.select2[1], ui->color.select2[2], 1);
 
       // hightlight row under mouse
       int k = findselect(it, ui, state, con);
@@ -2950,10 +2949,12 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
         mjrRect r1 = r;
         r1.bottom = r.bottom + (it->multi.nelem-1-k)*cellheight;
         r1.height = cellheight;
-        drawrectangle(r1, ui->color.select, NULL, con);
+        mjr_rectangle(r1, ui->color.select[0],
+          ui->color.select[1], ui->color.select[2], 1);
       }
 
       // text values
+      initOpenGL(&rect, con);
       for (int k=0; k < it->multi.nelem; k++) {
         drawtext(it->multi.name[k],
                  r.left+g_texthor - rect.left,

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -65,15 +65,14 @@ static const mjuiThemeColor themeColor0 = {
   {0.25, 0.25, 0.25},   // master
   {0.12, 0.12, 0.12},   // thumb
   {0.6,  0.2,  0.2},    // secttitle
-//  {0.6,  0.2,  0.2},    // secttitle2
   {0.1,  0.1,  0.1},    // secttitle2
   {0.45, 0.17, 0.17},   // secttitlecheck
-  {0.25, 0.25, 0.25},   // separator
-//  {0.25, 0.25, 0.25},   // separator2
-  {0.1,  0.1,  0.1},    // separator2
+  {0.45, 0.17, 0.17},   // secttitlecheck2
   {1.0,  1.0,  1.0},    // sectfont
   {0.7,  0.7,  0.7},    // sectsymbol
   {0.1,  0.1,  0.1},    // sectpane
+  {0.25, 0.25, 0.25},   // separator
+  {0.1,  0.1,  0.1},    // separator2
   {0.0,  0.0,  1.0},    // shortcut
   {1.0,  1.0,  1.0},    // fontactive
   {0.5,  0.5,  0.5},    // fontinactive
@@ -99,11 +98,12 @@ static const mjuiThemeColor themeColor1 = {
   {0.3,  0.3,  0.3},    // secttitle
   {0.15, 0.15, 0.15},   // secttitle2
   {0.25, 0.25, 0.25},   // secttitlecheck
-  {0.2,  0.2,  0.2},    // separator
-  {0.15, 0.15, 0.15},   // separator2
+  {0.25, 0.25, 0.25},   // secttitlecheck2
   {0.8,  0.8,  0.8},    // sectfont
   {0.7,  0.7,  0.7},    // sectsymbol
   {0.15, 0.15, 0.15},   // sectpane
+  {0.2,  0.2,  0.2},    // separator
+  {0.15, 0.15, 0.15},   // separator2
   {0.0,  0.0,  1.0},    // shortcut
   {0.9,  0.9,  0.9},    // fontactive
   {0.5,  0.5,  0.5},    // fontinactive
@@ -129,11 +129,12 @@ static const mjuiThemeColor themeColor2 = {
   {0.8,  0.8,  0.8},    // secttitle
   {1.0,  1.0,  1.0},    // secttitle2
   {0.95, 0.95, 0.95},   // secttitlecheck
-  {0.9,  0.9,  0.9},    // separator
-  {1.0,  1.0,  1.0},    // separator2
+  {0.95, 0.95, 0.95},   // secttitlecheck2
   {0.0,  0.0,  0.8},    // sectfont
   {0.0,  0.0,  0.8},    // sectsymbol
   {1.0,  1.0,  1.0},    // sectpane
+  {0.9,  0.9,  0.9},    // separator
+  {1.0,  1.0,  1.0},    // separator2
   {0.0,  1.0,  1.0},    // shortcut
   {0.0,  0.0,  0.0},    // fontactive
   {0.7,  0.7,  0.7},    // fontinactive
@@ -159,11 +160,12 @@ static const mjuiThemeColor themeColor3 = {
   {0.25, 0.25, 0.25},   // secttitle
   {0.0,  0.0,  0.0},    // secttitle2
   {0.2,  0.2,  0.2},    // secttitlecheck
-  {0.15, 0.15, 0.15},   // separator
-  {0.0,  0.0,  0.0},    // separator2
+  {0.2,  0.2,  0.2},    // secttitlecheck2
   {1.0,  0.3,  0.3},    // sectfont
   {1.0,  0.3,  0.3},    // sectsymbol
   {0.0,  0.0,  0.0},    // sectpane
+  {0.15, 0.15, 0.15},   // separator
+  {0.0,  0.0,  0.0},    // separator2
   {0.0,  0.0,  1.0},    // shortcut
   {1.0,  1.0,  1.0},    // fontactive
   {0.4,  0.4,  0.4},    // fontinactive
@@ -180,7 +182,6 @@ static const mjuiThemeColor themeColor3 = {
   {0.8,  0.2,  0.2},    // edit2
   {0.8,  0.8,  0.8}     // cursor
 };
-
 
 
 
@@ -302,46 +303,43 @@ static void drawrectangle(mjrRect rect, const float* rgb, const float* rgbback,
 // round corners of rectangle
 static void roundcorner(mjrRect rect, int flg_skipbottom, int flg_separator,
                         const mjUI* ui, const mjrContext* con) {
-  // get rounding, return if disabled
-  int radcorner = flg_separator ? ui->spacing.cornersep : ui->spacing.cornersect;
-  if (radcorner == 0) {
+  // get rounding from theme, exit if disabled
+  int cornerspec = flg_separator ? ui->spacing.cornersep : ui->spacing.cornersect;
+  if (cornerspec == 0) {
     return;
   }
 
-  // divisions and radius
-  const int ndivide = 10;
-  double radius = radcorner * 0.01 * con->fontScale;
+  // quarter-circle divisions and radius
+  int ndivide = 10;
+  double radius = cornerspec * 0.01 * con->fontScale;
 
-  // loop over corners
+  // draw fans in the four corners, optionally skip bottom corners
   for (int ic = (flg_skipbottom ? 2 : 0); ic < 4; ++ic) {
+    // set corner
     double corner[2];
-    double angle;
-
-    // set corner and angle
     switch (ic) {
     case 0:   // bottom-left
       corner[0] = rect.left;
       corner[1] = rect.bottom;
-      angle = 0;
       break;
 
     case 1:   // bottom-right
       corner[0] = rect.left + rect.width;
       corner[1] = rect.bottom;
-      angle = 0.5 * mjPI;
       break;
 
     case 2:   // top-right
       corner[0] = rect.left + rect.width;
       corner[1] = rect.bottom + rect.height;
-      angle = mjPI;
       break;
 
     default:  // top-left
       corner[0] = rect.left;
       corner[1] = rect.bottom + rect.height;
-      angle = 1.5 * mjPI;
     }
+
+    // orient fan to point inside
+    double angle = ic * 0.5 * mjPI;
 
     // compute circle center: opposite to corner
     double center[2];
@@ -1957,9 +1955,10 @@ void mjui_update(int section, int item, const mjUI* ui,
         // section with checkbox
         else {
           glBegin(GL_QUADS);
-          glColor3fv(ui->color.secttitlecheck);
+          glColor3fv(ui->color.secttitlecheck2);
           glVertex2i(r.left, r.bottom);
           glVertex2i(r.left + r.width, r.bottom);
+          glColor3fv(ui->color.secttitlecheck);
           glVertex2i(r.left + r.width, r.bottom + r.height);
           glVertex2i(r.left, r.bottom + r.height);
           glEnd();
@@ -2880,7 +2879,7 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
   mjr_blitAux(ui->auxid, raux, rect.left,
               rect.bottom + mjMAX(0, rect.height - ui->height + ui->scroll), con);
 
-  // draw scrollbar on top if needed
+  // draw scrollbar over blit if needed
   if (ui->height > rect.height) {
     // construct rectangles
     mjrRect bar;
@@ -2892,21 +2891,24 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
                   ui->color.thumb[2], 1);
   }
 
-  // draw select tracking on top if needed
+  // draw selection box tracking over blit if needed
   if (ui->mousesect > 0 && ui->mouseitem >= 0) {
     // get item pointer
     const mjuiItem* it = ui->sect[ui->mousesect-1].item + ui->mouseitem;
 
-    // get sizes
-    int g_texthor = SCL(ui->spacing.texthor, con);
-    int g_textver = SCL(ui->spacing.textver, con);
-    int g_itemside = SCL(ui->spacing.itemside, con);
-    int cellheight = con->charHeight + 2 * g_textver;
-    int offset = mjMAX(0, rect.height - ui->height + ui->scroll) -
-                 mjMAX(0, ui->height - ui->scroll - rect.height);
-
     // proceed if select type
     if (it->type == mjITEM_SELECT) {
+      // get relevant sizes
+      int g_texthor = SCL(ui->spacing.texthor, con);
+      int g_textver = SCL(ui->spacing.textver, con);
+      int g_itemside = SCL(ui->spacing.itemside, con);
+      int cellheight = con->charHeight + 2 * g_textver;
+      int offset = mjMAX(0, rect.height - ui->height + ui->scroll) -
+                   mjMAX(0, ui->height - ui->scroll - rect.height);
+
+      // draw in entire ui rectangle
+      initOpenGL(&rect, con);
+
       // margin
       mjrRect r = it->rect;
       r.left -= g_itemside;
@@ -2915,8 +2917,7 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
       r.bottom -= r.height;
       r.bottom += offset;
       r.left += rect.left;
-      mjr_rectangle(r, ui->color.sectpane[0],
-        ui->color.sectpane[1], ui->color.sectpane[2], 1);
+      drawrectangle(r, ui->color.sectpane, NULL, con);
 
       // box
       r = it->rect;
@@ -2924,8 +2925,7 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
       r.bottom -= r.height;
       r.bottom += offset;
       r.left += rect.left;
-      mjr_rectangle(r, ui->color.select2[0],
-        ui->color.select2[1], ui->color.select2[2], 1);
+      drawrectangle(r, ui->color.select2, NULL, con);
 
       // hightlight row under mouse
       int k = findselect(it, ui, state, con);
@@ -2933,13 +2933,10 @@ void mjui_render(mjUI* ui, const mjuiState* state, const mjrContext* con) {
         mjrRect r1 = r;
         r1.bottom = r.bottom + (it->multi.nelem-1-k)*cellheight;
         r1.height = cellheight;
-        mjr_rectangle(r1, ui->color.select[0], 
-          ui->color.select[1], ui->color.select[2], 1);
+        drawrectangle(r1, ui->color.select, NULL, con);
       }
 
-
-      // values
-      initOpenGL(&rect, con);
+      // text values
       for (int k=0; k < it->multi.nelem; k++) {
         drawtext(it->multi.name[k],
                  r.left+g_texthor - rect.left,


### PR DESCRIPTION
When OpenGL buffer size is too small to hold entire UI with all sections open, older sections (as determined by latest mouse click) are automatically closed as needed.

To test this new functionality, uncomment the test near the top of mjui_resize().

UI items now have userid, which can be used for event handling.  It is set through the (new) last field of mjuiDef, called otherint.

Sections titles can now have a checkmark - in which case they are rendered differently. Set via mjuiDef.otherint: 0- none (as before), 1- rendering changed but box not shown, 2- box shown.  This can be used to label sections of special interest to the application.