### PR TITLE
'nstack' property of data is now removed, updating comment in mjData

### DIFF
--- a/include/mujoco/mjdata.h
+++ b/include/mujoco/mjdata.h
@@ -208,7 +208,7 @@ struct mjData_ {
 
   // buffers
   void*   buffer;            // main buffer; all pointers point in it                (nbuffer bytes)
-  void*   arena;             // arena+stack buffer                     (nstack*sizeof(mjtNum) bytes)
+  void*   arena;             // arena+stack buffer                     (narena*sizeof(mjtNum) bytes)
 
   //-------------------- main inputs and outputs of the computation
 

--- a/introspect/structs.py
+++ b/introspect/structs.py
@@ -4336,7 +4336,7 @@ STRUCTS: Mapping[str, StructDecl] = dict([
                  type=PointerType(
                      inner_type=ValueType(name='void'),
                  ),
-                 doc='arena+stack buffer                     (nstack*sizeof(mjtNum) bytes)',  # pylint: disable=line-too-long
+                 doc='arena+stack buffer                     (narena*sizeof(mjtNum) bytes)',  # pylint: disable=line-too-long
              ),
              StructFieldDecl(
                  name='qpos',


### PR DESCRIPTION
This is assuming that the size of `mjData.arena` is `mjData.narena*sizeof(mjtNum)` bytes