### PR TITLE
Copy all keys of def_map when copying a mjCModel. Fixes #1798

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -150,7 +150,10 @@ mjCModel& mjCModel::operator=(const mjCModel& other) {
     // create new default tree
     mjCDef* subtree = new mjCDef(*other.defaults_[0]);
     *this += *subtree;
-    def_map["main"] = Default();
+    for (const auto& [name, def] : other.def_map) {
+      std::size_t index = std::find(other.defaults_.begin(), other.defaults_.end(), def) - other.defaults_.begin();
+      def_map[name] = defaults_[index];
+    }
 
     // copy name maps
     for (int i=0; i<mjNOBJECT; i++) {

--- a/test/user/testdata/cube_with_mesh_def.xml
+++ b/test/user/testdata/cube_with_mesh_def.xml
@@ -1,0 +1,15 @@
+<mujoco>
+  <default>
+    <default class="mesh">
+      <mesh scale="2 2 2"/>
+    </default>
+  </default>
+
+  <asset>
+    <mesh file="cube.obj" class="mesh"/>
+  </asset>
+
+  <worldbody>
+    <geom type="mesh" mesh="cube"/>
+  </worldbody>
+</mujoco>


### PR DESCRIPTION
See #1798 