### PR TITLE
Shell Script for Rebuilding Python Bindings

### DIFF
--- a/doc/python.rst
+++ b/doc/python.rst
@@ -575,6 +575,17 @@ The Python bindings should now be installed! To check that they've been
 successfully installed, ``cd`` outside of the ``mujoco`` directory and run
 ``python -c "import mujoco"``.
 
+.. note::
+   You can also build the python bindings from source by going into the
+   python directory and running:
+
+   .. code-block:: shell
+
+      MUJOCO_PATH=/PATH/TO/MUJOCO MUJOCO_PLUGIN_PATH=/PATH/TO/MUJOCO_PLUGIN ./build_python_bindings.sh
+
+   This is especially useful if you require to rebuild the python bindings
+   after making modifying them.
+
 .. tip::
    As a reference, a working build configuration can be found in MuJoCo's
    `continuous integration setup <https://github.com/google-deepmind/mujoco/blob/main/.github/workflows/build.yml>`_ on

--- a/python/build_python_bindings.sh
+++ b/python/build_python_bindings.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2022 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHONPATH="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DISTPATH="${PYTHONPATH}"/dist
+DISTPATTERN="mujoco-*.tar.gz"
+
+FILES=$(find "$DISTPATH" -type f -name "${DISTPATTERN}")
+
+if [ -n "$FILES" ]; then
+    echo "Found the following distributions:"
+    echo "$FILES"
+    echo "$FILES" | xargs rm
+    
+    echo "Matching files removed."
+else
+    echo "No current MuJoCo python distributions found."
+fi
+
+pythonpath="${PYTHONPATH}"
+bash "${pythonpath}/make_sdist.sh"
+
+FILES=$(find "$DISTPATH" -type f -name "${DISTPATTERN}")
+
+MUJOCO_PATH=$MUJOCO_PATH MUJOCO_PLUGIN_PATH=$MUJOCO_PLUGIN_PATH pip install ${FILES[0]}


### PR DESCRIPTION
Adding a simple shell script to automate the process of rebuilding python bindings.