### PR TITLE
Fix ordering of `mjState_FULLPHYSICS` documentation

### DIFF
--- a/doc/includes/references.h
+++ b/doc/includes/references.h
@@ -35,7 +35,7 @@ typedef enum mjtState_ {          // state elements
 
   // convenience values for commonly used state specifications
   mjSTATE_PHYSICS       = mjSTATE_QPOS | mjSTATE_QVEL | mjSTATE_ACT,
-  mjSTATE_FULLPHYSICS   = mjSTATE_PHYSICS | mjSTATE_TIME | mjSTATE_PLUGIN,
+  mjSTATE_FULLPHYSICS   = mjSTATE_TIME | mjSTATE_PHYSICS | mjSTATE_PLUGIN,
   mjSTATE_USER          = mjSTATE_CTRL | mjSTATE_QFRC_APPLIED | mjSTATE_XFRC_APPLIED |
                           mjSTATE_EQ_ACTIVE | mjSTATE_MOCAP_POS | mjSTATE_MOCAP_QUAT |
                           mjSTATE_USERDATA,


### PR DESCRIPTION
The `mjState` [documentation](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate) describes the full physics state as 
```
mjSTATE_FULLPHYSICS = mjSTATE_PHYSICS | mjSTATE_TIME | mjSTATE_PLUGIN
```
which hints that time variable is after the physics state. However, the time is before the physics state. 
Therefore, the documentation should be 
```
mjSTATE_FULLPHYSICS = mjSTATE_TIME | mjSTATE_PHYSICS | mjSTATE_PLUGIN
```

@kevinzakka 