### PR TITLE
remove unused mjx.model class attribute

### DIFF
--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -984,7 +984,6 @@ class Model(PyTreeNode):
   name_tupleadr: np.ndarray
   name_keyadr: np.ndarray
   names: bytes
-  _sizes: jax.Array
 
 
 class Contact(PyTreeNode):


### PR DESCRIPTION
As title :)

The recent release adds additional fields to mjx.model for further compatigbility with the mujoco structs, however `_sizes` doesn't seem to exist in mjModel.