### PR TITLE
Fixed incorrect mesh face circumradius calculation

### DIFF
--- a/src/user/user_mesh.cc
+++ b/src/user/user_mesh.cc
@@ -1915,7 +1915,7 @@ void mjCMesh::MakeCenter(void) {
     // compute circumradius
     double norm_a_2 = mjuu_dot3(a, a);
     double norm_b_2 = mjuu_dot3(b, b);
-    double area = mjuu_normvec(nrm, 3);
+    double area = sqrt(mjuu_dot3(nrm, nrm));
 
     // compute circumcenter
     double res[3], vec[3] = {


### PR DESCRIPTION
- In [this commit in v3.17](https://github.com/google-deepmind/mujoco/commit/8e2f830fd2d079d4391541bcbb4971d12e164e88), this was changed from `mju_norm3` to `mjuu_normvec`, but the latter will mutate its input to be normalized instead of just returning the norm.
  - Perhaps `mju_norm3` was mistaken as `mju_normalize3` which does mutate its input.
  - It looks like this was the only mistakenly changed callsite; other calls to `mju_norm3` were changed to `sqrt(mjuu_dot3(x, x))`
- This causes mesh ray casting to be incorrect; on some meshes I see a large increase in node visits within `mju_rayTree` (this fixes [issue #1875](https://github.com/google-deepmind/mujoco/issues/1875))
  - Before commit 8e2f830 on my mesh: `nstack` in `mju_rayTree` ~= 500. After the bug, nstack ~= 30000. With this fix, nstack drops back to ~500.
