### PR TITLE
Rename `MuJoCo (mjpython).app` -> `MuJoCo_(mjpython).app`

### DIFF
--- a/python/mujoco/mjpython/mjpython.py
+++ b/python/mujoco/mjpython/mjpython.py
@@ -46,7 +46,7 @@ def get_executable_path():
 def main(argv):
   module_dir = os.path.dirname(importlib.util.find_spec('mujoco').origin)
   os.environ['MJPYTHON_BIN'] = os.path.join(
-      module_dir, 'MuJoCo (mjpython).app/Contents/MacOS/mjpython')
+      module_dir, 'MuJoCo_(mjpython).app/Contents/MacOS/mjpython')
 
   # Conda doesn't create a separate shared library for Python.
   # We instead use the Python binary itself, which can be dlopened just as well.

--- a/python/setup.py
+++ b/python/setup.py
@@ -218,7 +218,7 @@ class BuildCMakeExtension(build_ext.build_ext):
     src_dir = os.path.join(os.path.dirname(__file__), 'mujoco/mjpython')
     dst_contents_dir = os.path.join(
         os.path.dirname(self.get_ext_fullpath(self.extensions[0].name)),
-        'MuJoCo (mjpython).app/Contents')
+        'MuJoCo_(mjpython).app/Contents')
     os.makedirs(dst_contents_dir)
     shutil.copyfile(os.path.join(src_dir, 'Info.plist'),
                     os.path.join(dst_contents_dir, 'Info.plist'))


### PR DESCRIPTION
This should fix #2118. See the issue for details.