### PR TITLE
Add `MUJOCO_LOG.TXT` and `.cache` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ Info.framework.plist
 __pycache__/
 *.py[cod]
 *$py.class
+
+# MuJoCo's default log file
+MUJOCO_LOG.TXT
+
+# Clang cache
+.cache/


### PR DESCRIPTION
This might be helpful for others who build and test MuJoCo on macos.