### PR TITLE
Do not test python bindings in python/dist directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,6 @@ jobs:
     - name: Test Python bindings
       if: ${{ runner.os != 'Windows' }}
       shell: bash
-      working-directory: python/dist
       env:
         MUJOCO_GL: disable
       run: >


### PR DESCRIPTION
This will permit to early catch tests that rely on files not installed in the wheel, i.e. catch if `pytest --pyargs mujoco` fails in a vanilla environment.

This PR intentionally fails in CI to show the problem discussed in https://github.com/google-deepmind/mujoco/pull/2160 .