### PR TITLE
Adding the ability to install libsimulate library and associated headers during installation.

### DIFF
--- a/simulate/CMakeLists.txt
+++ b/simulate/CMakeLists.txt
@@ -41,16 +41,12 @@ if(APPLE)
   enable_language(OBJCXX)
 endif()
 
-if(NOT DEFINED expose_headers)
-    
-endif()
 option(SIMULATE_BUILD_EXECUTABLE "Build the simulate executable binary." ON)
 option(SIMULATE_GLFW_DYNAMIC_SYMBOLS "Whether to resolve GLFW symbols dynamically." OFF)
 
 # Check if we are building as standalone project.
 set(SIMULATE_STANDALONE OFF)
 set(_INSTALL_SIMULATE ON)
-set(EXPOSE_HEADERS OFF)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(SIMULATE_STANDALONE ON)
   # If standalone, do not install the samples.

--- a/simulate/cmake/SimulateDependencies.cmake
+++ b/simulate/cmake/SimulateDependencies.cmake
@@ -103,9 +103,6 @@ if(NOT SIMULATE_STANDALONE)
   target_link_options(glfw PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 endif()
 
-
-message(STATUS "lolwaGLFW3 Source Directory: ${glfw3_SOURCE_DIR}")
-
 # Install GLFW headers if not using system GLFW
 if(NOT MUJOCO_SIMULATE_USE_SYSTEM_GLFW)
   FetchContent_GetProperties(glfw3)


### PR DESCRIPTION
Aim
I want to use the libsimulate header in my internal simulator. I want to leverage the default mujoco visualizer instead of writing my own. Wanted to add the ability to install the libsimulate and headers in my dev container directly from CMake.