### PR TITLE
Print error instead of failing silently when loading plugins

### DIFF
--- a/src/engine/engine_plugin.cc
+++ b/src/engine/engine_plugin.cc
@@ -387,7 +387,15 @@ void mj_loadPluginLibrary(const char* path) {
 #if defined(_WIN32) || defined(__CYGWIN__)
   LoadLibraryA(path);
 #else
-  dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  void* handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  if (!handle) {
+    const char* error = dlerror();
+    if (error) {
+      mju_error("Error loading plugin library '%s': %s\n", path, error);
+    } else {
+      mju_error("Unknown error loading plugin library '%s'\n", path);
+    }
+  }
 #endif
 }
 


### PR DESCRIPTION
Previously the return value of dlopen was ignored, meaning a failed load of a shared library would stay unnoticed

Can be tested by compiling this piece of code into a shared library and then trying to load it

```cpp
#include <iostream>
#include <mujoco/mujoco.h>

void test();

mjPLUGIN_LIB_INIT
{
  test();
  std::cout << "Registering Test Plugin" << std::endl;
}

```