### PR TITLE
Fix mj_saveXMLString's return value in case of success

### DIFF
--- a/doc/includes/references.h
+++ b/doc/includes/references.h
@@ -3143,6 +3143,7 @@ mjModel* mj_compile(mjSpec* s, const mjVFS* vfs);
 int mj_recompile(mjSpec* s, const mjVFS* vfs, mjModel* m, mjData* d);
 int mj_saveLastXML(const char* filename, const mjModel* m, char* error, int error_sz);
 void mj_freeLastXML(void);
+// Save spec to string, return 1 on success, 0 on failure, or required buffer size if too small
 int mj_saveXMLString(const mjSpec* s, char* xml, int xml_sz, char* error, int error_sz);
 int mj_saveXML(const mjSpec* s, const char* filename, char* error, int error_sz);
 void mj_step(const mjModel* m, mjData* d);

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -117,7 +117,7 @@ MJAPI int mj_saveLastXML(const char* filename, const mjModel* m, char* error, in
 // Free last XML model if loaded. Called internally at each load.
 MJAPI void mj_freeLastXML(void);
 
-// Save spec to XML string, return 1 on success, 0 otherwise.
+// Save spec to XML string, return 1 on success, 0 on failure, or required buffer size if too small
 MJAPI int mj_saveXMLString(const mjSpec* s, char* xml, int xml_sz, char* error, int error_sz);
 
 // Save spec to XML file, return 1 on success, 0 otherwise.

--- a/src/xml/xml_api.cc
+++ b/src/xml/xml_api.cc
@@ -257,6 +257,6 @@ int mj_saveXMLString(const mjSpec* s, char* xml, int xml_sz, char* error, int er
 
   result.copy(xml, xml_sz);
   xml[result.size()] = 0;
-  return 0;
+  return 1;
 }
 

--- a/src/xml/xml_api.cc
+++ b/src/xml/xml_api.cc
@@ -242,7 +242,7 @@ int mj_saveXML(const mjSpec* s, const char* filename, char* error, int error_sz)
 
 
 
-// save spec to string, return 1 on success, 0 otherwise
+// save spec to string, return 1 on success, 0 on failure, or required buffer size if too small
 int mj_saveXMLString(const mjSpec* s, char* xml, int xml_sz, char* error, int error_sz) {
   std::string result = WriteXML(NULL, s, error, error_sz);
   if (result.size() >= xml_sz) {

--- a/src/xml/xml_api.h
+++ b/src/xml/xml_api.h
@@ -48,8 +48,9 @@ MJAPI mjModel* mj_loadModel(const char* filename, const mjVFS* vfs);
 MJAPI mjSpec* mj_parseXML(const char* filename, const mjVFS* vfs, char* error, int error_sz);
 MJAPI mjSpec* mj_parseXMLString(const char* xml, const mjVFS* vfs, char* error, int error_sz);
 
-// Save spec to XML file and/or string, return 1 on success, 0 otherwise.
+// Save spec to XML file, return 1 on success, 0 otherwise.
 MJAPI int mj_saveXML(const mjSpec* s, const char* filename, char* error, int error_sz);
+// Save spec to string, return 1 on success, 0 on failure, or required buffer size if too small
 MJAPI int mj_saveXMLString(const mjSpec* s, char* xml, int xml_sz, char* error, int error_sz);
 
 #ifdef __cplusplus

--- a/test/xml/xml_api_test.cc
+++ b/test/xml/xml_api_test.cc
@@ -141,7 +141,7 @@ TEST_F(MujocoTest, SaveXml) {
 
   std::array<char, 274> out;
   EXPECT_THAT(mj_saveXMLString(spec, out.data(), out.size(), error.data(),
-                               error.size()), 0) << error.data();
+                               error.size()), 1) << error.data();
 
   mjSpec* saved_spec = mj_parseXMLString(xml, 0, error.data(), error.size());
   EXPECT_THAT(saved_spec, NotNull()) << "Invalid saved spec: " << error.data();


### PR DESCRIPTION
- Fix mj_saveXMLString's return value in case of success.
- Fix test case for mj_saveXMLString.