### PR TITLE
[Unity plugin] Throw exception if OBJ file is referenced in MJCF when loading in Unity

### DIFF
--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -154,7 +154,9 @@ public class MjImporterWithAssets : MjcfImporter {
     var sourceFilePath = Path.Combine(_sourceMeshesDir, fileName);
 
     if (Path.GetExtension(sourceFilePath) == ".obj") {
-      throw new NotImplementedException($"OBJ mesh file loading is not yet implemented. Please convert to binary STL. Attempted to load: {sourceFilePath}");
+      throw new NotImplementedException("OBJ mesh file loading is not yet implemented. " +
+                                        "Please convert to binary STL. " +
+                                        $"Attempted to load: {sourceFilePath}");
     }
 
     var targetFilePath = Path.Combine(_targetMeshesDir, assetReferenceName + ".stl");

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -152,6 +152,11 @@ public class MjImporterWithAssets : MjcfImporter {
       parentNode.GetStringAttribute("name", defaultValue: string.Empty);
     var assetReferenceName = MjEngineTool.Sanitize(unsanitizedAssetReferenceName);
     var sourceFilePath = Path.Combine(_sourceMeshesDir, fileName);
+
+    if (Path.GetExtension(sourceFilePath) == ".obj") {
+      throw new NotImplementedException($"OBJ mesh file loading is not yet implemented. Please convert to binary STL. Attempted to load: {sourceFilePath}");
+    }
+
     var targetFilePath = Path.Combine(_targetMeshesDir, assetReferenceName + ".stl");
     if (File.Exists(targetFilePath)) {
       File.Delete(targetFilePath);


### PR DESCRIPTION
An overdue warning for attempting to import MJCF scenes referencing OBJ assets. Partially addresses #2245.