### PR TITLE
Allow rollout to accept a list of models of length nroll

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,6 +16,7 @@ Python bindings
 - Added ``bind`` method and removed id attribute from :ref:`mjSpec` objects. Using ids is error prone in scenarios of repeated attachment and
   detachment. Python users are encouraged to use names for unique identification of model elements.
 - Removed ``nroll`` argument from :ref:`rollout<PyRollout>` because its value can always be inferred.
+- :ref:`rollout<PyRollout>` can now accept lists of MjModel of length ``nroll``.
 
 Bug fixes
 ^^^^^^^^^

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,7 +16,8 @@ Python bindings
 - Added ``bind`` method and removed id attribute from :ref:`mjSpec` objects. Using ids is error prone in scenarios of repeated attachment and
   detachment. Python users are encouraged to use names for unique identification of model elements.
 - Removed ``nroll`` argument from :ref:`rollout<PyRollout>` because its value can always be inferred.
-- :ref:`rollout<PyRollout>` can now accept lists of MjModel of length ``nroll``.
+- :ref:`rollout<PyRollout>` can now accept lists of MjModel of length ``nroll``. ``nroll`` argument deprecated because
+  its value can always be inferred.
 
 Bug fixes
 ^^^^^^^^^

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,7 +16,7 @@ Python bindings
 - Added ``bind`` method and removed id attribute from :ref:`mjSpec` objects. Using ids is error prone in scenarios of repeated attachment and
   detachment. Python users are encouraged to use names for unique identification of model elements.
 - Removed ``nroll`` argument from :ref:`rollout<PyRollout>` because its value can always be inferred.
-- :ref:`rollout<PyRollout>` can now accept lists of MjModel of length ``nroll``. ``nroll`` argument deprecated because
+- :ref:`rollout<PyRollout>` can now accept sequences of MjModel of length ``nroll``. ``nroll`` argument deprecated because
   its value can always be inferred.
 
 Bug fixes

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -700,7 +700,7 @@ states and sensor values. The basic usage form is
 
    state, sensordata = rollout.rollout(model, data, initial_state, control)
 
-``model`` is either a single instance of MjModel or a list of compatible MjModel of length ``nroll``.
+``model`` is either a single instance of MjModel or a sequence of compatible MjModel of length ``nroll``.
 ``initial_state`` is an ``nroll x nstate`` array, with ``nroll`` initial states of size ``nstate``, where
 ``nstate = mj_stateSize(model, mjtState.mjSTATE_FULLPHYSICS)`` is the size of the
 :ref:`full physics state<geFullPhysics>`. ``control`` is a ``nroll x nstep x ncontrol`` array of controls. Controls are

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -700,6 +700,7 @@ states and sensor values. The basic usage form is
 
    state, sensordata = rollout.rollout(model, data, initial_state, control)
 
+``model`` is either a single instance of MjModel or a list of compatible MjModel of length ``nroll``.
 ``initial_state`` is an ``nroll x nstate`` array, with ``nroll`` initial states of size ``nstate``, where
 ``nstate = mj_stateSize(model, mjtState.mjSTATE_FULLPHYSICS)`` is the size of the
 :ref:`full physics state<geFullPhysics>`. ``control`` is a ``nroll x nstep x ncontrol`` array of controls. Controls are

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -73,26 +73,28 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int nroll, int n
   if (!(control_spec & mjSTATE_XFRC_APPLIED)) {
     mju_zero(d->xfrc_applied, 6*nbody);
   }
-  if (!(control_spec & mjSTATE_MOCAP_POS)) {
-    for (int i = 0; i < nbody; i++) {
-      int id = m[0]->body_mocapid[i];
-      if (id >= 0) mju_copy3(d->mocap_pos+3*id, m[0]->body_pos+3*i);
-    }
-  }
-  if (!(control_spec & mjSTATE_MOCAP_QUAT)) {
-    for (int i = 0; i < nbody; i++) {
-      int id = m[0]->body_mocapid[i];
-      if (id >= 0) mju_copy4(d->mocap_quat+4*id, m[0]->body_quat+4*i);
-    }
-  }
-  if (!(control_spec & mjSTATE_EQ_ACTIVE)) {
-    for (int i = 0; i < neq; i++) {
-      d->eq_active[i] = m[0]->eq_active0[i];
-    }
-  }
 
   // loop over rollouts
   for (int r = 0; r < nroll; r++) {
+    // clear user inputs if unspecified
+    if (!(control_spec & mjSTATE_MOCAP_POS)) {
+      for (int i = 0; i < nbody; i++) {
+        int id = m[r]->body_mocapid[i];
+        if (id >= 0) mju_copy3(d->mocap_pos+3*id, m[r]->body_pos+3*i);
+      }
+    }
+    if (!(control_spec & mjSTATE_MOCAP_QUAT)) {
+      for (int i = 0; i < nbody; i++) {
+        int id = m[r]->body_mocapid[i];
+        if (id >= 0) mju_copy4(d->mocap_quat+4*id, m[r]->body_quat+4*i);
+      }
+    }
+    if (!(control_spec & mjSTATE_EQ_ACTIVE)) {
+      for (int i = 0; i < neq; i++) {
+        d->eq_active[i] = m[r]->eq_active0[i];
+      }
+    }
+
     // set initial state
     mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
 

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -37,7 +37,7 @@ const auto rollout_doc = R"(
 Roll out open-loop trajectories from initial states, get resulting states and sensor values.
 
   input arguments (required):
-    model              instance of MjModel
+    model              list of MjModel instances of length nroll
     data               associated instance of MjData
     nstep              integer, number of steps to be taken for each trajectory
     control_spec       specification of controls, ncontrol = mj_stateSize(m, control_spec)
@@ -54,18 +54,18 @@ Roll out open-loop trajectories from initial states, get resulting states and se
 // C-style rollout function, assumes all arguments are valid
 // all input fields of d are initialised, contents at call time do not matter
 // after returning, d will contain the last step of the last rollout
-void _unsafe_rollout(const mjModel* m, mjData* d, int nroll, int nstep, unsigned int control_spec,
+void _unsafe_rollout(const mjModel** m, mjData* d, int nroll, int nstep, unsigned int control_spec,
                      const mjtNum* state0, const mjtNum* warmstart0, const mjtNum* control,
                      mjtNum* state, mjtNum* sensordata) {
   // sizes
-  int nstate = mj_stateSize(m, mjSTATE_FULLPHYSICS);
-  int ncontrol = mj_stateSize(m, control_spec);
-  int nv = m->nv, nbody = m->nbody, neq = m->neq;
-  int nsensordata = m->nsensordata;
+  int nstate = mj_stateSize(m[0], mjSTATE_FULLPHYSICS);
+  int ncontrol = mj_stateSize(m[0], control_spec);
+  int nv = m[0]->nv, nbody = m[0]->nbody, neq = m[0]->neq;
+  int nsensordata = m[0]->nsensordata;
 
   // clear user inputs if unspecified
   if (!(control_spec & mjSTATE_CTRL)) {
-    mju_zero(d->ctrl, m->nu);
+    mju_zero(d->ctrl, m[0]->nu);
   }
   if (!(control_spec & mjSTATE_QFRC_APPLIED)) {
     mju_zero(d->qfrc_applied, nv);
@@ -75,26 +75,26 @@ void _unsafe_rollout(const mjModel* m, mjData* d, int nroll, int nstep, unsigned
   }
   if (!(control_spec & mjSTATE_MOCAP_POS)) {
     for (int i = 0; i < nbody; i++) {
-      int id = m->body_mocapid[i];
-      if (id >= 0) mju_copy3(d->mocap_pos+3*id, m->body_pos+3*i);
+      int id = m[0]->body_mocapid[i];
+      if (id >= 0) mju_copy3(d->mocap_pos+3*id, m[0]->body_pos+3*i);
     }
   }
   if (!(control_spec & mjSTATE_MOCAP_QUAT)) {
     for (int i = 0; i < nbody; i++) {
-      int id = m->body_mocapid[i];
-      if (id >= 0) mju_copy4(d->mocap_quat+4*id, m->body_quat+4*i);
+      int id = m[0]->body_mocapid[i];
+      if (id >= 0) mju_copy4(d->mocap_quat+4*id, m[0]->body_quat+4*i);
     }
   }
   if (!(control_spec & mjSTATE_EQ_ACTIVE)) {
     for (int i = 0; i < neq; i++) {
-      d->eq_active[i] = m->eq_active0[i];
+      d->eq_active[i] = m[0]->eq_active0[i];
     }
   }
 
   // loop over rollouts
   for (int r = 0; r < nroll; r++) {
     // set initial state
-    mj_setState(m, d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
+    mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
 
     // set warmstart accelerations
     if (warmstart0) {
@@ -124,7 +124,7 @@ void _unsafe_rollout(const mjModel* m, mjData* d, int nroll, int nstep, unsigned
         for (; t < nstep; t++) {
           int step = r*nstep + t;
           if (state) {
-            mj_getState(m, d, state + step*nstate, mjSTATE_FULLPHYSICS);
+            mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
           }
           if (sensordata) {
             mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
@@ -137,15 +137,15 @@ void _unsafe_rollout(const mjModel* m, mjData* d, int nroll, int nstep, unsigned
 
       // controls
       if (control) {
-        mj_setState(m, d, control + step*ncontrol, control_spec);
+        mj_setState(m[r], d, control + step*ncontrol, control_spec);
       }
 
       // step
-      mj_step(m, d);
+      mj_step(m[r], d);
 
       // copy out new state
       if (state) {
-        mj_getState(m, d, state + step*nstate, mjSTATE_FULLPHYSICS);
+        mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
       }
 
       // copy out sensor values
@@ -188,7 +188,7 @@ PYBIND11_MODULE(_rollout, pymodule) {
   // get subsequent states and corresponding sensor values
   pymodule.def(
       "rollout",
-      [](const MjModelWrapper& m, MjDataWrapper& d,
+      [](py::list m, MjDataWrapper& d,
          int nstep, unsigned int control_spec,
          const PyCArray state0,
          std::optional<const PyCArray> warmstart0,
@@ -196,7 +196,12 @@ PYBIND11_MODULE(_rollout, pymodule) {
          std::optional<const PyCArray> state,
          std::optional<const PyCArray> sensordata
          ) {
-        const raw::MjModel* model = m.get();
+        // get raw pointers
+        int nroll = state0.shape(0);
+        const raw::MjModel* model_ptrs[nroll];
+        for (int r = 0; r < nroll; r++) {
+          model_ptrs[r] = m[r].cast<const MjModelWrapper*>()->get();
+        }
         raw::MjData* data = d.get();
 
         // check that some steps need to be taken, return if not
@@ -205,19 +210,17 @@ PYBIND11_MODULE(_rollout, pymodule) {
         }
 
         // get sizes
-        int nstate = mj_stateSize(model, mjSTATE_FULLPHYSICS);
-        int ncontrol = mj_stateSize(model, control_spec);
-        int nroll = state0.shape(0);
+        int nstate = mj_stateSize(model_ptrs[0], mjSTATE_FULLPHYSICS);
+        int ncontrol = mj_stateSize(model_ptrs[0], control_spec);
 
-        // get raw pointers
         mjtNum* state0_ptr = get_array_ptr(state0, "state0", nroll, 1, nstate);
         mjtNum* warmstart0_ptr = get_array_ptr(warmstart0, "warmstart0", nroll,
-                                               1, model->nv);
+                                               1, model_ptrs[0]->nv);
         mjtNum* control_ptr = get_array_ptr(control, "control", nroll,
                                             nstep, ncontrol);
         mjtNum* state_ptr = get_array_ptr(state, "state", nroll, nstep, nstate);
         mjtNum* sensordata_ptr = get_array_ptr(sensordata, "sensordata", nroll,
-                                               nstep, model->nsensordata);
+                                               nstep, model_ptrs[0]->nsensordata);
 
         // perform rollouts
         {
@@ -226,7 +229,7 @@ PYBIND11_MODULE(_rollout, pymodule) {
 
           // call unsafe rollout function
           InterceptMjErrors(_unsafe_rollout)(
-              model, data, nroll, nstep, control_spec, state0_ptr,
+              model_ptrs, data, nroll, nstep, control_spec, state0_ptr,
               warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr);
         }
       },

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -198,8 +198,7 @@ PYBIND11_MODULE(_rollout, pymodule) {
          ) {
         // get raw pointers
         int nroll = state0.shape(0);
-        std::vector<const raw::MjModel*> model_ptrs;
-        model_ptrs.reserve(nroll);
+        std::vector<const raw::MjModel*> model_ptrs(nroll);
         for (int r = 0; r < nroll; r++) {
           model_ptrs[r] = m[r].cast<const MjModelWrapper*>()->get();
         }

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -54,7 +54,7 @@ Roll out open-loop trajectories from initial states, get resulting states and se
 // C-style rollout function, assumes all arguments are valid
 // all input fields of d are initialised, contents at call time do not matter
 // after returning, d will contain the last step of the last rollout
-void _unsafe_rollout(const mjModel** m, mjData* d, int nroll, int nstep, unsigned int control_spec,
+void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int nroll, int nstep, unsigned int control_spec,
                      const mjtNum* state0, const mjtNum* warmstart0, const mjtNum* control,
                      mjtNum* state, mjtNum* sensordata) {
   // sizes
@@ -198,7 +198,8 @@ PYBIND11_MODULE(_rollout, pymodule) {
          ) {
         // get raw pointers
         int nroll = state0.shape(0);
-        const raw::MjModel* model_ptrs[nroll];
+        std::vector<const raw::MjModel*> model_ptrs;
+        model_ptrs.reserve(nroll);
         for (int r = 0; r < nroll; r++) {
           model_ptrs[r] = m[r].cast<const MjModelWrapper*>()->get();
         }

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Roll out open-loop trajectories from initial states, get subsequent states and sensor values."""
 
+from collections.abc import Sequence
 from typing import Optional, Union
 
 import mujoco
@@ -22,7 +23,7 @@ import numpy as np
 from numpy import typing as npt
 
 
-def rollout(model: Union[mujoco.MjModel, list[mujoco.MjModel]],
+def rollout(model: Union[mujoco.MjModel, Sequence[mujoco.MjModel]],
             data: mujoco.MjData,
             initial_state: npt.ArrayLike,
             control: Optional[npt.ArrayLike] = None,
@@ -41,7 +42,7 @@ def rollout(model: Union[mujoco.MjModel, list[mujoco.MjModel]],
   Allocates outputs if none are given.
 
   Args:
-    model: An mjModel or a list of MjModel with the same size signature.
+    model: An mjModel or a sequence of MjModel with the same size signature.
     data: An associated mjData instance.
     initial_state: Array of initial states from which to roll out trajectories.
       ([nroll or 1] x nstate)
@@ -75,6 +76,9 @@ def rollout(model: Union[mujoco.MjModel, list[mujoco.MjModel]],
     _rollout.rollout(model, data, nstep, control_spec, initial_state,
                      initial_warmstart, control, state, sensordata)
     return state, sensordata
+
+  if not isinstance(model, mujoco.MjModel):
+    model = list(model)
 
   # check control_spec
   if control_spec & ~mujoco.mjtState.mjSTATE_USER.value:
@@ -151,7 +155,7 @@ def rollout(model: Union[mujoco.MjModel, list[mujoco.MjModel]],
   _check_trailing_dimension(nsensordata, sensordata=sensordata)
 
   # tile input arrays/lists if required (singleton expansion)
-  model = model*nroll if len(model) == 1 else model
+  model = model * nroll if len(model) == 1 else model
   initial_state = _tile_if_required(initial_state, nroll)
   initial_warmstart = _tile_if_required(initial_warmstart, nroll)
   control = _tile_if_required(control, nroll, nstep)

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -458,7 +458,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     def thread_initializer():
       thread_local.data = mujoco.MjData(model)
 
-    model_list = [model]*nroll
+    model_list = [model] * nroll
     def call_rollout(initial_state, control, state, sensordata):
       rollout.rollout(model_list, thread_local.data, initial_state, control,
                       skip_checks=True,

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -335,6 +335,34 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     np.testing.assert_array_equal(sensordata, py_sensordata)
 
   @parameterized.parameters(ALL_MODELS.keys())
+  def test_multi_model(self, model_name):
+    nroll = 3  # number of initial states and models
+    nstep = 3  # number of timesteps
+
+    spec = mujoco.MjSpec.from_string(ALL_MODELS[model_name])
+
+    if len(spec.bodies) > 1:
+      model = []
+      for i in range(nroll):
+        body = spec.bodies[1]
+        assert body.name != 'world'
+        body.pos = body.pos + i
+        model.append(spec.compile())
+    else:
+      model = [spec.compile() for i in range(nroll)]
+
+    nstate = mujoco.mj_stateSize(model[0], mujoco.mjtState.mjSTATE_FULLPHYSICS)
+    data = mujoco.MjData(model[0])
+
+    initial_state = np.random.randn(nroll, nstate)
+    control = np.random.randn(nroll, nstep, model[0].nu)
+    state, sensordata = rollout.rollout(model, data, initial_state, control)
+
+    py_state, py_sensordata = py_rollout(model, data, initial_state, control)
+    np.testing.assert_array_equal(state, py_state)
+    np.testing.assert_array_equal(sensordata, py_sensordata)
+
+  @parameterized.parameters(ALL_MODELS.keys())
   def test_multi_rollout_fixed_ctrl_infer_from_output(self, model_name):
     model = mujoco.MjModel.from_xml_string(ALL_MODELS[model_name])
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
@@ -430,8 +458,9 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     def thread_initializer():
       thread_local.data = mujoco.MjData(model)
 
+    model_list = [model]*nroll
     def call_rollout(initial_state, control, state, sensordata):
-      rollout.rollout(model, thread_local.data, initial_state, control,
+      rollout.rollout(model_list, thread_local.data, initial_state, control,
                       skip_checks=True,
                       nstep=nstep, state=state, sensordata=sensordata)
 
@@ -677,13 +706,17 @@ def py_rollout(model, data, initial_state, control,
   control = ensure_3d(control)
   nroll = initial_state.shape[0]
   nstep = control.shape[1]
-  nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
+
+  if isinstance(model, mujoco.MjModel):
+    model = [model]*nroll
+
+  nstate = mujoco.mj_stateSize(model[0], mujoco.mjtState.mjSTATE_FULLPHYSICS)
 
   state = np.empty((nroll, nstep, nstate))
-  sensordata = np.empty((nroll, nstep, model.nsensordata))
+  sensordata = np.empty((nroll, nstep, model[0].nsensordata))
   for r in range(nroll):
     state_r, sensordata_r = one_rollout(
-        model, data, initial_state[r], control[r], control_spec
+        model[r], data, initial_state[r], control[r], control_spec
     )
     state[r] = state_r
     sensordata[r] = sensordata_r


### PR DESCRIPTION
`rollout` can now accept a list of models of length `nroll`, similar to its other arguments.

The models must be compatible, meaning `nstate`, `ncontrol`, `nv`, and `nsensordata` must be equal.