### PR TITLE
Revert "Bump MuJoCo version to 3.2.6."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(MSVC_INCREMENTAL_DEFAULT ON)
 
 project(
   mujoco
-  VERSION 3.2.6
+  VERSION 3.2.5
   DESCRIPTION "MuJoCo Physics Simulator"
   HOMEPAGE_URL "https://mujoco.org"
 )

--- a/dist/mujoco.rc
+++ b/dist/mujoco.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-FILEVERSION 3,2,6,0
-PRODUCTVERSION 3,2,6,0
+FILEVERSION 3,2,5,0
+PRODUCTVERSION 3,2,5,0
 FILEOS 0x4
 FILETYPE 0x1
 {
@@ -9,9 +9,9 @@ FILETYPE 0x1
     BLOCK "040904b0"
     {
       VALUE "ProductName", "MuJoCo"
-      VALUE "ProductVersion", "3.2.6"
+      VALUE "ProductVersion", "3.2.5"
       VALUE "FileDescription", "MuJoCo"
-      VALUE "FileVersion", "3.2.6"
+      VALUE "FileVersion", "3.2.5"
       VALUE "InternalName", "mujoco.dll"
       VALUE "OriginalFilename", "mujoco.dll"
       VALUE "CompanyName", "Google DeepMind"

--- a/dist/simulate.rc
+++ b/dist/simulate.rc
@@ -1,8 +1,8 @@
 MUJOCO ICON "mujoco.ico"
 
 1 VERSIONINFO
-FILEVERSION 3,2,6,0
-PRODUCTVERSION 3,2,6,0
+FILEVERSION 3,2,5,0
+PRODUCTVERSION 3,2,5,0
 FILEOS 0x4
 FILETYPE 0x1
 {
@@ -11,9 +11,9 @@ FILETYPE 0x1
     BLOCK "040904b0"
     {
       VALUE "ProductName", "MuJoCo"
-      VALUE "ProductVersion", "3.2.6"
+      VALUE "ProductVersion", "3.2.5"
       VALUE "FileDescription", "MuJoCo"
-      VALUE "FileVersion", "3.2.6"
+      VALUE "FileVersion", "3.2.5"
       VALUE "InternalName", "simulate.exe"
       VALUE "OriginalFilename", "simulate.exe"
       VALUE "CompanyName", "Google DeepMind"

--- a/doc/APIreference/APIglobals.rst
+++ b/doc/APIreference/APIglobals.rst
@@ -517,7 +517,7 @@ shown in the table below. Their names are in the format ``mjKEY_XXX``. They corr
      - Maximum number of UI rectangles.
        Defined in `mjui.h <https://github.com/google-deepmind/mujoco/blob/main/include/mujoco/mjui.h>`_.
    * - ``mjVERSION_HEADER``
-     - 326
+     - 325
      - The version of the MuJoCo headers; changes with every release. This is an integer equal to 100x the software
        version, so 210 corresponds to version 2.1. Defined in  mujoco.h. The API function :ref:`mj_version` returns a
        number with the same meaning but for the compiled library.

--- a/doc/unity.rst
+++ b/doc/unity.rst
@@ -30,14 +30,14 @@ _____
 
 The MuJoCo app needs to be run at least once before the native library can be used, in order to register the library as
 a trusted binary. Then, copy the dynamic library file from
-``/Applications/MuJoCo.app/Contents/Frameworks/mujoco.framework/Versions/Current/libmujoco.3.2.6.dylib`` (it can be
+``/Applications/MuJoCo.app/Contents/Frameworks/mujoco.framework/Versions/Current/libmujoco.3.2.5.dylib`` (it can be
 found by browsing the contents of ``MuJoCo.app``) and rename it as ``mujoco.dylib``.
 
 Linux
 _____
 
 Expand the ``tar.gz`` archive to ``~/.mujoco``. Then copy the dynamic library from
-``~/.mujoco/mujoco-3.2.6/lib/libmujoco.so.3.2.6`` and rename it as ``libmujoco.so``.
+``~/.mujoco/mujoco-3.2.5/lib/libmujoco.so.3.2.5`` and rename it as ``libmujoco.so``.
 
 Windows
 _______

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -16,7 +16,7 @@
 #define MUJOCO_MUJOCO_H_
 
 // header version; should match the library version as returned by mj_version()
-#define mjVERSION_HEADER 326
+#define mjVERSION_HEADER 325
 
 // needed to define size_t, fabs and log10
 #include <stdlib.h>

--- a/mjx/pyproject.toml
+++ b/mjx/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name="mujoco-mjx"
-version = "3.2.6"
+version = "3.2.5"
 authors = [
     {name = "Google DeepMind", email = "mujoco@deepmind.com"},
 ]
@@ -30,7 +30,7 @@ dependencies = [
     "etils[epath]",
     "jax",
     "jaxlib",
-    "mujoco>=3.2.6.dev0",
+    "mujoco>=3.2.5.dev0",
     "scipy",
     "trimesh",
 ]
@@ -41,6 +41,6 @@ mjx-viewer = "mujoco.mjx.viewer:main"
 
 [project.urls]
 Homepage = "https://github.com/google-deepmind/mujoco/tree/main/mjx"
-Documentation = "https://mujoco.readthedocs.io/en/3.2.6"
+Documentation = "https://mujoco.readthedocs.io/en/3.2.5"
 Repository = "https://github.com/google-deepmind/mujoco/tree/main/mjx"
-Changelog = "https://mujoco.readthedocs.io/en/3.2.6/changelog.html"
+Changelog = "https://mujoco.readthedocs.io/en/3.2.5/changelog.html"

--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -84,7 +84,7 @@ if(NOT TARGET mujoco)
     if(MUJOCO_FRAMEWORK)
       message("MuJoCo framework is at ${MUJOCO_FRAMEWORK}/mujoco.framework")
       set(MUJOCO_LIBRARY
-          ${MUJOCO_FRAMEWORK}/mujoco.framework/Versions/A/libmujoco.3.2.6.dylib
+          ${MUJOCO_FRAMEWORK}/mujoco.framework/Versions/A/libmujoco.3.2.5.dylib
       )
       target_compile_options(mujoco INTERFACE -F${MUJOCO_FRAMEWORK})
     endif()
@@ -92,7 +92,7 @@ if(NOT TARGET mujoco)
 
   if(NOT MUJOCO_FRAMEWORK)
     find_library(
-      MUJOCO_LIBRARY mujoco mujoco.3.2.6 HINTS ${MUJOCO_LIBRARY_DIR} REQUIRED
+      MUJOCO_LIBRARY mujoco mujoco.3.2.5 HINTS ${MUJOCO_LIBRARY_DIR} REQUIRED
     )
     find_path(MUJOCO_INCLUDE mujoco/mujoco.h HINTS ${MUJOCO_INCLUDE_DIR} REQUIRED)
     message("MuJoCo is at ${MUJOCO_LIBRARY}")

--- a/python/mujoco/mjpython/Info.plist
+++ b/python/mujoco/mjpython/Info.plist
@@ -7,13 +7,13 @@
     <key>CFBundleIdentifier</key>
     <string>org.mujoco.mjpython</string>
     <key>CFBundleVersion</key>
-    <string>3.2.6</string>
+    <string>3.2.5</string>
     <key>CFBundleGetInfoString</key>
-    <string>3.2.6</string>
+    <string>3.2.5</string>
     <key>CFBundleLongVersionString</key>
-    <string>3.2.6</string>
+    <string>3.2.5</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.2.6</string>
+    <string>3.2.5</string>
     <key>CFBundleExecutable</key>
     <string>mjpython</string>
     <key>CFBundleIconFile</key>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mujoco"
-version = "3.2.6"
+version = "3.2.5"
 authors = [
     {name = "Google DeepMind", email = "mujoco@deepmind.com"},
 ]
@@ -35,9 +35,9 @@ dynamic = ["readme", "scripts"]
 
 [project.urls]
 Homepage = "https://github.com/google-deepmind/mujoco"
-Documentation = "https://mujoco.readthedocs.io/en/3.2.6"
+Documentation = "https://mujoco.readthedocs.io/en/3.2.5"
 Repository = "https://github.com/google-deepmind/mujoco"
-Changelog = "https://mujoco.readthedocs.io/en/3.2.6/changelog.html"
+Changelog = "https://mujoco.readthedocs.io/en/3.2.5/changelog.html"
 
 [tool.setuptools]
 include-package-data = false

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -24,7 +24,7 @@ set(MSVC_INCREMENTAL_DEFAULT ON)
 
 project(
   mujoco_samples
-  VERSION 3.2.6
+  VERSION 3.2.5
   DESCRIPTION "MuJoCo samples binaries"
   HOMEPAGE_URL "https://mujoco.org"
 )

--- a/simulate/CMakeLists.txt
+++ b/simulate/CMakeLists.txt
@@ -29,7 +29,7 @@ set(MUJOCO_DEP_VERSION_lodepng
 
 project(
   mujoco_simulate
-  VERSION 3.2.6
+  VERSION 3.2.5
   DESCRIPTION "MuJoCo simulate binaries"
   HOMEPAGE_URL "https://mujoco.org"
 )

--- a/src/engine/engine_support.c
+++ b/src/engine/engine_support.c
@@ -42,8 +42,8 @@
 
 //-------------------------- Constants -------------------------------------------------------------
 
- #define mjVERSION 326
-#define mjVERSIONSTRING "3.2.6"
+ #define mjVERSION 325
+#define mjVERSIONSTRING "3.2.5"
 
 // names of disable flags
 const char* mjDISABLESTRING[mjNDISABLE] = {

--- a/unity/Editor/Bindings/MujocoBinaryRetriever.cs
+++ b/unity/Editor/Bindings/MujocoBinaryRetriever.cs
@@ -37,7 +37,7 @@ public class MujocoBinaryRetriever {
           if (AssetDatabase.LoadMainAssetAtPath(mujocoPath + "/mujoco.dylib") == null) {
             File.Copy(
                 "/Applications/MuJoCo.app/Contents/Frameworks" +
-                "/mujoco.framework/Versions/Current/libmujoco.3.2.6.dylib",
+                "/mujoco.framework/Versions/Current/libmujoco.3.2.5.dylib",
                 mujocoPath + "/mujoco.dylib");
             AssetDatabase.Refresh();
           }
@@ -45,7 +45,7 @@ public class MujocoBinaryRetriever {
           if (AssetDatabase.LoadMainAssetAtPath(mujocoPath + "/libmujoco.so") == null) {
             File.Copy(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) +
-                "/.mujoco/mujoco-3.2.6/lib/libmujoco.so.3.2.6",
+                "/.mujoco/mujoco-3.2.5/lib/libmujoco.so.3.2.5",
                 mujocoPath + "/libmujoco.so");
             AssetDatabase.Refresh();
           }

--- a/unity/Runtime/Bindings/MjBindings.cs
+++ b/unity/Runtime/Bindings/MjBindings.cs
@@ -109,7 +109,7 @@ public const int mjMAXLINEPNT = 1000;
 public const int mjMAXPLANEGRID = 200;
 public const bool THIRD_PARTY_MUJOCO_MJXMACRO_H_ = true;
 public const bool THIRD_PARTY_MUJOCO_MUJOCO_H_ = true;
-public const int mjVERSION_HEADER = 326;
+public const int mjVERSION_HEADER = 325;
 
 
 // ------------------------------------Enums------------------------------------

--- a/unity/package.json
+++ b/unity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mujoco",
   "displayName": "MuJoCo",
-  "version": "3.2.6",
+  "version": "3.2.5",
   "description": "MuJoCo importer and runtime plug-in",
   "dependencies": {},
   "author": {


### PR DESCRIPTION
Current latest mujoco release is 3.2.5. This PR reverts the commit that bumps the version to 3.2.6 causing issues when trying to install the unity plugin. 

Reverted commit:  276f5b04cd32ae585c3c08fcabe9e2a1b716d7ff. 

