### PR TITLE
GitHub Actions: Use macos-13 image instead of deprecated macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
               -DCMAKE_CXX_COMPILER:STRING=clang++-10
               -DMUJOCO_HARDEN:BOOL=ON
             tmpdir: "/tmp"
-          - os: macos-12
+          - os: macos-13
             cmake_args: >-
               -G Ninja
               -DMUJOCO_HARDEN:BOOL=ON


### PR DESCRIPTION
The `macos-12` is now deprecated and subject to brownout periods and will be removed soon, see https://github.com/actions/runner-images/issues/10721 . To continue testing macOS with Intel processor, we can switch to use `macos-13`.