### PR TITLE
Add a persistent thread pool to rollout

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,8 +11,9 @@ Bug fixes
 
 Python bindings
 ^^^^^^^^^^^^^^^
-- :ref:`rollout<PyRollout>` can now accept sequences of MjData of length ``nthread``. If passed, :ref:`rollout<PyRollout>`
-  will automatically create a persistent threadpool and parallelize rollouts.
+- :ref:`rollout<PyRollout>` now features native multi-threading. If a sequence of MjData instances
+  of length ``nthread`` is passed in, ``rollout`` will automatically create a persistent threadpool
+  and parallelize the computation. Contribution by :github:user:`aftersomemath`.
 
 Version 3.2.6 (Dec 2, 2024)
 ---------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Bug fixes
 ^^^^^^^^^
 - Fixed a bug in the box-sphere collider, depth was incorrect for deep penetrations (:github:issue:`2206`).
 
+Python bindings
+^^^^^^^^^^^^^^^
+- :ref:`rollout<PyRollout>` can now accept sequences of MjData of length ``nthread``. If passed, :ref:`rollout<PyRollout>`
+  will automatically create a persistent threadpool and parallelize rollouts.
+
 Version 3.2.6 (Dec 2, 2024)
 ---------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,8 +12,10 @@ Bug fixes
 Python bindings
 ^^^^^^^^^^^^^^^
 - :ref:`rollout<PyRollout>` now features native multi-threading. If a sequence of MjData instances
-  of length ``nthread`` is passed in, ``rollout`` will automatically create a persistent threadpool
-  and parallelize the computation. Contribution by :github:user:`aftersomemath`.
+  of length ``nthread`` is passed in, ``rollout`` will automatically create a thread pool and parallelize
+  the computation. The thread pool can resused across calls, but then the function cannot be called simultaneously
+  from multiple threads. To run multiple threaded rollouts simultaneously, use the new class ``Rollout`` which
+  encapsulates the thread pool. Contribution by :github:user:`aftersomemath`.
 
 Version 3.2.6 (Dec 2, 2024)
 ---------------------------

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -711,18 +711,20 @@ The ``mujoco`` package contains two sub-modules: ``mujoco.rollout`` and ``mujoco
 rollout
 -------
 
-``mujoco.rollout`` shows how to add additional C/C++ functionality, exposed as a Python module via pybind11. It is
-implemented in `rollout.cc <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout.cc>`__
+``mujoco.rollout`` and ``mujoco.Rollout`` shows how to add additional C/C++ functionality, exposed as a Python module
+via pybind11. It is implemented in `rollout.cc <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout.cc>`__
 and wrapped in `rollout.py <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout.py>`__. The module
 performs a common functionality where tight loops implemented outside of Python are beneficial: rolling out a trajectory
 (i.e., calling :ref:`mj_step` in a loop), given an intial state and sequence of controls, and returning subsequent
-states and sensor values. The basic usage form is
+states and sensor values. The rollouts are run in parallel with an internally managed thread pool if multiple MjData instances
+(one per thread) are passed as an argument. The basic usage form is
 
 .. code-block:: python
 
    state, sensordata = rollout.rollout(model, data, initial_state, control)
 
 ``model`` is either a single instance of MjModel or a sequence of compatible MjModel of length ``nroll``.
+``data`` is either a single instance of MjData or a sequence of compatible MjData of length ``nthread``.
 ``initial_state`` is an ``nroll x nstate`` array, with ``nroll`` initial states of size ``nstate``, where
 ``nstate = mj_stateSize(model, mjtState.mjSTATE_FULLPHYSICS)`` is the size of the
 :ref:`full physics state<geFullPhysics>`. ``control`` is a ``nroll x nstep x ncontrol`` array of controls. Controls are
@@ -732,13 +734,39 @@ specified by passing an optional ``control_spec`` bitflag.
 If a rollout diverges, the current state and sensor values are used to fill the remainder of the trajectory.
 Therefore, non-increasing time values can be used to detect diverged rollouts.
 
-The ``rollout`` function is designed to be completely stateless, so all inputs of the stepping pipeline are set and any
+The ``rollout`` function is designed to be computationally stateless, so all inputs of the stepping pipeline are set and any
 values already present in the given ``MjData`` instance will have no effect on the output.
 
-Since the Global Interpreter Lock can be released, this function can be efficiently threaded using Python threads. See
-the ``test_threading`` function in
+By default ``rollout.rollout`` creates a new thread pool every call if ``len(data) > 1``. To reuse the thread pool
+over multiple calls use the ``persistent_pool`` argument. ``rollout.rollout`` is not thread safe when using
+a persistent pool. The basic usage form is
+
+.. code-block:: python
+
+   state, sensordata = rollout.rollout(model, data, initial_state, persistent_pool=True)
+
+The pool is shutdown on interpreter shutdown or by a call to ``rollout.shutdown_persistent_pool``.
+
+To use multiple thread pools from multiple threads, use ``Rollout`` objects. The basic usage form is
+
+.. code-block:: python
+
+   # Pool shutdown upon exiting block
+   with rollout.Rollout(nthread) as rollout_:
+    rollout_.rollout(model, data, initial_state)
+
+or
+
+.. code-block:: python
+
+  # pool shutdown on object deletion, interpreter shutdown, or call to rollout_.shutdown_pool
+  rollout_ = rollout.Rollout(nthread)
+  rollout_.rollout(model, data, initial_state)
+
+Since the Global Interpreter Lock is released, this function can also be threaded using Python threads. However, this
+is less efficient than using native threads. See the ``test_threading`` function in
 `rollout_test.py <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout_test.py>`__ for an example
-of threaded operation (and more generally for usage examples).
+of threaded operation (and for more general usage examples).
 
 .. _PyMinimize:
 

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -759,9 +759,11 @@ or
 
 .. code-block:: python
 
-  # pool shutdown on object deletion, interpreter shutdown, or call to rollout_.shutdown_pool
+  # pool shutdown on object deletion or call to rollout_.shutdown_pool
+  # to ensure clean shutdown of threads, call shutdown_pool before interpreter exit
   rollout_ = rollout.Rollout(nthread)
   rollout_.rollout(model, data, initial_state)
+  rollout_.shutdown_pool()
 
 Since the Global Interpreter Lock is released, this function can also be threaded using Python threads. However, this
 is less efficient than using native threads. See the ``test_threading`` function in

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -711,7 +711,7 @@ The ``mujoco`` package contains two sub-modules: ``mujoco.rollout`` and ``mujoco
 rollout
 -------
 
-``mujoco.rollout`` and ``mujoco.Rollout`` shows how to add additional C/C++ functionality, exposed as a Python module
+``mujoco.rollout`` and ``mujoco.rollout.Rollout`` shows how to add additional C/C++ functionality, exposed as a Python module
 via pybind11. It is implemented in `rollout.cc <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout.cc>`__
 and wrapped in `rollout.py <https://github.com/google-deepmind/mujoco/blob/main/python/mujoco/rollout.py>`__. The module
 performs a common functionality where tight loops implemented outside of Python are beneficial: rolling out a trajectory
@@ -752,18 +752,18 @@ To use multiple thread pools from multiple threads, use ``Rollout`` objects. The
 .. code-block:: python
 
    # Pool shutdown upon exiting block
-   with rollout.Rollout(nthread) as rollout_:
+   with rollout.Rollout(nthread=nthread) as rollout_:
     rollout_.rollout(model, data, initial_state)
 
 or
 
 .. code-block:: python
 
-  # pool shutdown on object deletion or call to rollout_.shutdown_pool
-  # to ensure clean shutdown of threads, call shutdown_pool before interpreter exit
-  rollout_ = rollout.Rollout(nthread)
+  # pool shutdown on object deletion or call to rollout_.close
+  # to ensure clean shutdown of threads, call close before interpreter exit
+  rollout_ = rollout.Rollout(nthread=nthread)
   rollout_.rollout(model, data, initial_state)
-  rollout_.shutdown_pool()
+  rollout_.close()
 
 Since the Global Interpreter Lock is released, this function can also be threaded using Python threads. However, this
 is less efficient than using native threads. See the ``test_threading`` function in

--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -383,7 +383,7 @@ target_link_libraries(
           structs_header
 )
 
-mujoco_pybind11_module(_rollout rollout.cc)
+mujoco_pybind11_module(_rollout rollout.cc threadpool.cc)
 target_link_libraries(_rollout PRIVATE functions_header mujoco raw)
 
 mujoco_pybind11_module(

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -176,7 +176,7 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m, std::vector<mjData
                               int nroll, int nstep, unsigned int control_spec,
                               const mjtNum* state0, const mjtNum* warmstart0,
                               const mjtNum* control, mjtNum* state, mjtNum* sensordata,
-                              std::shared_ptr<ThreadPool> pool, int chunk_size) {
+                              std::shared_ptr<ThreadPool>& pool, int chunk_size) {
   int nfulljobs = nroll / chunk_size;
   int chunk_remainder = nroll % chunk_size;
   int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -20,119 +20,17 @@
 #include "errors.h"
 #include "raw.h"
 #include "structs.h"
+#include "threadpool.h"
 #include <pybind11/buffer_info.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-
-#include <condition_variable>
-#include <cstdint>
-#include <functional>
-#include <mutex>
-#include <queue>
-#include <thread>
-#include <vector>
-#include <absl/base/attributes.h>
 
 namespace mujoco::python {
 
 namespace {
 
 namespace py = ::pybind11;
-
-// Copied from https://github.com/google-deepmind/mujoco_mpc/blob/main/mjpc/threadpool.h
-// ThreadPool class
-class ThreadPool {
- public:
-  // constructor
-  explicit ThreadPool(int num_threads);
-  // destructor
-  ~ThreadPool();
-  int NumThreads() const { return threads_.size(); }
-  // returns an ID between 0 and NumThreads() - 1. must be called within
-  // worker thread (returns -1 if not).
-  static int WorkerId() { return worker_id_; }
-  // ----- methods ----- //
-  // set task for threadpool
-  void Schedule(std::function<void()> task);
-  // return number of tasks completed
-  std::uint64_t GetCount() { return ctr_; }
-  // reset count to zero
-  void ResetCount() { ctr_ = 0; }
-  // wait for count, then return
-  void WaitCount(int value) {
-    std::unique_lock<std::mutex> lock(m_);
-    cv_ext_.wait(lock, [&]() { return this->GetCount() >= value; });
-  }
- private:
-  // ----- methods ----- //
-  // execute task with available thread
-  void WorkerThread(int i);
-  ABSL_CONST_INIT static thread_local int worker_id_;
-  // ----- members ----- //
-  std::vector<std::thread> threads_;
-  std::mutex m_;
-  std::condition_variable cv_in_;
-  std::condition_variable cv_ext_;
-  std::queue<std::function<void()>> queue_;
-  std::uint64_t ctr_;
-};
-
-// Copied from https://github.com/google-deepmind/mujoco_mpc/blob/main/mjpc/threadpool.cc
-ABSL_CONST_INIT thread_local int ThreadPool::worker_id_ = -1;
-// ThreadPool constructor
-ThreadPool::ThreadPool(int num_threads) : ctr_(0) {
-  for (int i = 0; i < num_threads; i++) {
-    threads_.push_back(std::thread(&ThreadPool::WorkerThread, this, i));
-  }
-}
-// ThreadPool destructor
-ThreadPool::~ThreadPool() {
-  {
-    std::unique_lock<std::mutex> lock(m_);
-    for (int i = 0; i < threads_.size(); i++) {
-      queue_.push(nullptr);
-    }
-    cv_in_.notify_all();
-  }
-  for (auto& thread : threads_) {
-    thread.join();
-  }
-}
-// ThreadPool scheduler
-void ThreadPool::Schedule(std::function<void()> task) {
-  std::unique_lock<std::mutex> lock(m_);
-  queue_.push(std::move(task));
-  cv_in_.notify_one();
-}
-// ThreadPool worker
-void ThreadPool::WorkerThread(int i) {
-  worker_id_ = i;
-  while (true) {
-    auto task = [&]() {
-      std::unique_lock<std::mutex> lock(m_);
-      cv_in_.wait(lock, [&]() { return !queue_.empty(); });
-      std::function<void()> task = std::move(queue_.front());
-      queue_.pop();
-      cv_in_.notify_one();
-      return task;
-    }();
-    if (task == nullptr) {
-      {
-        std::unique_lock<std::mutex> lock(m_);
-        ++ctr_;
-        cv_ext_.notify_one();
-      }
-      break;
-    }
-    task();
-    {
-      std::unique_lock<std::mutex> lock(m_);
-      ++ctr_;
-      cv_ext_.notify_one();
-    }
-  }
-}
 
 // NOLINTBEGIN(whitespace/line_length)
 
@@ -265,19 +163,18 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll, 
 static ThreadPool* pool = nullptr;
 void _unsafe_rollout_threaded(std::vector<const mjModel*>& m, std::vector<mjData*>& d,
                               int nroll, int nstep, unsigned int control_spec,
-                              const mjtNum* state0, const mjtNum* warmstart0, const mjtNum* control,
-                              mjtNum* state, mjtNum* sensordata,
+                              const mjtNum* state0, const mjtNum* warmstart0,
+                              const mjtNum* control, mjtNum* state, mjtNum* sensordata,
                               int nthread, int chunk_size) {
   int nfulljobs = nroll / chunk_size;
   int chunk_remainder = nroll % chunk_size;
-  int njobs = nfulljobs;
-  if (chunk_remainder > 0) njobs++;
+  int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;
 
   if (pool == nullptr) {
     pool = new ThreadPool(nthread);
   }
   else if (pool->NumThreads() != nthread) {
-    delete pool; // TODO make sure pool is shutdown correctly
+    delete pool;
     pool = new ThreadPool(nthread);
   } else {
     pool->ResetCount();

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -25,7 +25,7 @@ from numpy import typing as npt
 
 def rollout(
     model: Union[mujoco.MjModel, Sequence[mujoco.MjModel]],
-    data: mujoco.MjData,
+    data: Union[mujoco.MjData, Sequence[mujoco.MjData]],
     initial_state: npt.ArrayLike,
     control: Optional[npt.ArrayLike] = None,
     *,  # require subsequent arguments to be named
@@ -44,8 +44,8 @@ def rollout(
   Allocates outputs if none are given.
 
   Args:
-    model: An mjModel or a sequence of MjModel with the same size signature.
-    data: An associated mjData instance.
+    model: An instance or length nroll sequence of MjModel with the same size signature.
+    data: Associated mjData instance or sequence of instances with length nthread.
     initial_state: Array of initial states from which to roll out trajectories.
       ([nroll or 1] x nstate)
     control: Open-loop controls array to apply during the rollouts.
@@ -142,6 +142,9 @@ def rollout(
     )
   elif not isinstance(model, list):
     model = [model]  # Use a length 1 list to simplify code below
+
+  if not isinstance(data, list):
+    data = [data]  # Use a length 1 list to simplify code below
 
   # infer nstep, check for incompatibilities
   nstep = _infer_dimension(

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -322,7 +322,7 @@ def rollout(
     rollout = Rollout(nthread=nthread)
 
   try:
-    ret = rollout.rollout(
+    return rollout.rollout(
       model,
       data,
       initial_state,
@@ -337,9 +337,6 @@ def rollout(
   finally:
     if not persistent_pool:
       rollout.close()
-
-  # return outputs
-  return ret
 
 def _check_must_be_numeric(**kwargs):
   for key, value in kwargs.items():

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Roll out open-loop trajectories from initial states, get subsequent states and sensor values."""
 
+import atexit
 from collections.abc import Sequence
 from typing import Optional, Union
 
@@ -22,6 +23,229 @@ from mujoco import _rollout
 import numpy as np
 from numpy import typing as npt
 
+class Rollout:
+  def __init__(self, nthread: int = None):
+    """Construct a rollout object containing a thread pool for parallel rollouts.
+
+    Args:
+      nthread: Number of threads in pool.
+        If zero, this pool is not started and rollouts run on the calling thread.
+    """  # fmt: skip
+    self.nthread = 0 if nthread is None else nthread
+    self.rollout_ = _rollout.Rollout(self.nthread)
+    atexit.register(self.shutdown_pool)
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    self.shutdown_pool()
+
+  def shutdown_pool(self):
+    del self.rollout_
+    self.rollout_ = None
+
+  def rollout(
+    self,
+    model: Union[mujoco.MjModel, Sequence[mujoco.MjModel]],
+    data: Union[mujoco.MjData, Sequence[mujoco.MjData]],
+    initial_state: npt.ArrayLike,
+    control: Optional[npt.ArrayLike] = None,
+    *,  # require subsequent arguments to be named
+    control_spec: int = mujoco.mjtState.mjSTATE_CTRL.value,
+    skip_checks: bool = False,
+    nstep: Optional[int] = None,
+    initial_warmstart: Optional[npt.ArrayLike] = None,
+    state: Optional[npt.ArrayLike] = None,
+    sensordata: Optional[npt.ArrayLike] = None,
+    chunk_size: int = None,
+  ):
+    """Rolls out open-loop trajectories from initial states, get subsequent states and sensor values.
+
+    Python wrapper for rollout.cc, see documentation therein.
+    Infers nroll and nstep.
+    Tiles inputs with singleton dimensions.
+    Allocates outputs if none are given.
+
+    Args:
+      model: An instance or length nroll sequence of MjModel with the same size signature.
+      data: Associated mjData instance or sequence of instances with length nthread.
+      initial_state: Array of initial states from which to roll out trajectories.
+        ([nroll or 1] x nstate)
+      control: Open-loop controls array to apply during the rollouts.
+        ([nroll or 1] x [nstep or 1] x ncontrol)
+      control_spec: mjtState specification of control vectors.
+      skip_checks: Whether to skip internal shape and type checks.
+      nstep: Number of steps in rollouts (inferred if unspecified).
+      initial_warmstart: Initial qfrc_warmstart array (optional).
+        ([nroll or 1] x nv)
+      state: State output array (optional).
+        (nroll x nstep x nstate)
+      sensordata: Sensor data output array (optional).
+        (nroll x nstep x nsensordata)
+      chunk_size: Determines threadpool chunk size. If unspecified,
+                  chunk_size = max(1, nroll / (nthread * 10))
+
+    Returns:
+      state:
+        State output array, (nroll x nstep x nstate).
+      sensordata:
+        Sensor data output array, (nroll x nstep x nsensordata).
+
+    Raises:
+      ValueError: bad shapes or sizes.
+    """  # fmt: skip
+    # skip_checks shortcut:
+    #   don't infer nroll/nstep
+    #   don't support singleton expansion
+    #   don't allocate output arrays
+    #   just call rollout and return
+
+    if self.rollout_ is None:
+      raise RuntimeError('rollout requested after thread pool shutdown')
+
+    if skip_checks:
+      self.rollout_.rollout(
+          model,
+          data,
+          nstep,
+          control_spec,
+          initial_state,
+          initial_warmstart,
+          control,
+          state,
+          sensordata,
+          chunk_size,
+      )
+      return state, sensordata
+
+    if not isinstance(model, mujoco.MjModel):
+      model = list(model)
+
+    # check control_spec
+    if control_spec & ~mujoco.mjtState.mjSTATE_USER.value:
+      raise ValueError('control_spec can only contain bits in mjSTATE_USER')
+
+    # check types
+    if nstep and not isinstance(nstep, int):
+      raise ValueError('nstep must be an integer')
+    if chunk_size and not isinstance(chunk_size, int):
+      raise ValueError('chunk_size must be an integer')
+    _check_must_be_numeric(
+        initial_state=initial_state,
+        initial_warmstart=initial_warmstart,
+        control=control,
+        state=state,
+        sensordata=sensordata,
+    )
+
+    # check number of dimensions
+    _check_number_of_dimensions(
+        2, initial_state=initial_state, initial_warmstart=initial_warmstart
+    )
+    _check_number_of_dimensions(
+        3, control=control, state=state, sensordata=sensordata
+    )
+
+    # ensure 2D, make contiguous, row-major (C ordering)
+    initial_state = _ensure_2d(initial_state)
+    initial_warmstart = _ensure_2d(initial_warmstart)
+
+    # ensure 3D, make contiguous, row-major (C ordering)
+    control = _ensure_3d(control)
+    state = _ensure_3d(state)
+    sensordata = _ensure_3d(sensordata)
+
+    # infer nroll, check for incompatibilities
+    nroll = _infer_dimension(
+        0,
+        1,
+        initial_state=initial_state,
+        initial_warmstart=initial_warmstart,
+        control=control,
+        state=state,
+        sensordata=sensordata,
+    )
+    if isinstance(model, list) and nroll == 1:
+      nroll = len(model)
+
+    if isinstance(model, list) and len(model) != nroll:
+      raise ValueError(
+          f'nroll inferred as {nroll} but model is length {len(model)}'
+      )
+    elif not isinstance(model, list):
+      model = [model]  # Use a length 1 list to simplify code below
+
+    if not isinstance(data, list):
+      data = [data]  # Use a length 1 list to simplify code below
+
+    # infer nstep, check for incompatibilities
+    nstep = _infer_dimension(
+        1, nstep or 1, control=control, state=state, sensordata=sensordata
+    )
+
+    # get nstate/ncontrol/nv/nsensordata
+    # check that they are equal across models
+    nstate = mujoco.mj_stateSize(
+        model[0], mujoco.mjtState.mjSTATE_FULLPHYSICS.value
+    )
+    ncontrol = mujoco.mj_stateSize(model[0], control_spec)
+    nv = model[0].nv
+    nsensordata = model[0].nsensordata
+    for m in model[1:]:
+      if (
+          nstate
+          != mujoco.mj_stateSize(m, mujoco.mjtState.mjSTATE_FULLPHYSICS.value)
+          or ncontrol != mujoco.mj_stateSize(m, control_spec)
+          or nv != m.nv
+          or nsensordata != m.nsensordata
+      ):
+        raise ValueError('models are not compatible')
+
+    # check trailing dimensions
+    _check_trailing_dimension(nstate, initial_state=initial_state, state=state)
+    _check_trailing_dimension(ncontrol, control=control)
+    _check_trailing_dimension(nv, initial_warmstart=initial_warmstart)
+    _check_trailing_dimension(nsensordata, sensordata=sensordata)
+
+    # tile input arrays/lists if required (singleton expansion)
+    model = model * nroll if len(model) == 1 else model
+    initial_state = _tile_if_required(initial_state, nroll)
+    initial_warmstart = _tile_if_required(initial_warmstart, nroll)
+    control = _tile_if_required(control, nroll, nstep)
+
+    # allocate output if not provided
+    if state is None:
+      state = np.empty((nroll, nstep, nstate))
+    if sensordata is None:
+      sensordata = np.empty((nroll, nstep, nsensordata))
+
+    # call rollout
+    self.rollout_.rollout(
+        model,
+        data,
+        nstep,
+        control_spec,
+        initial_state,
+        initial_warmstart,
+        control,
+        state,
+        sensordata,
+        chunk_size,
+    )
+
+    # return outputs
+    return state, sensordata
+
+persistent_rollout = None
+def shutdown_persistent_pool():
+  """Shutdown the persistent thread pool that is optionally created by rollout.
+
+  This is called automatically interpreter shutdown, but can also be called manually.
+  """  # fmt: skip
+  global persistent_rollout
+  persistent_rollout = None
+atexit.register(shutdown_persistent_pool)
 
 def rollout(
     model: Union[mujoco.MjModel, Sequence[mujoco.MjModel]],
@@ -36,6 +260,7 @@ def rollout(
     state: Optional[npt.ArrayLike] = None,
     sensordata: Optional[npt.ArrayLike] = None,
     chunk_size: int = None,
+    persistent_pool: bool = False,
 ):
   """Rolls out open-loop trajectories from initial states, get subsequent states and sensor values.
 
@@ -62,6 +287,7 @@ def rollout(
       (nroll x nstep x nsensordata)
     chunk_size: Determines threadpool chunk size. If unspecified,
                 chunk_size = max(1, nroll / (nthread * 10))
+    persistent_pool: Determines if a persistent thread pool is created or reused.
 
   Returns:
     state:
@@ -77,139 +303,35 @@ def rollout(
   #   don't support singleton expansion
   #   don't allocate output arrays
   #   just call rollout and return
-  if skip_checks:
-    _rollout.rollout(
-        model,
-        data,
-        nstep,
-        control_spec,
-        initial_state,
-        initial_warmstart,
-        control,
-        state,
-        sensordata,
-        chunk_size,
-    )
-    return state, sensordata
-
-  if not isinstance(model, mujoco.MjModel):
-    model = list(model)
-
-  # check control_spec
-  if control_spec & ~mujoco.mjtState.mjSTATE_USER.value:
-    raise ValueError('control_spec can only contain bits in mjSTATE_USER')
-
-  # check types
-  if nstep and not isinstance(nstep, int):
-    raise ValueError('nstep must be an integer')
-  if chunk_size and not isinstance(chunk_size, int):
-    raise ValueError('chunk_size must be an integer')
-  _check_must_be_numeric(
-      initial_state=initial_state,
-      initial_warmstart=initial_warmstart,
-      control=control,
-      state=state,
-      sensordata=sensordata,
-  )
-
-  # check number of dimensions
-  _check_number_of_dimensions(
-      2, initial_state=initial_state, initial_warmstart=initial_warmstart
-  )
-  _check_number_of_dimensions(
-      3, control=control, state=state, sensordata=sensordata
-  )
-
-  # ensure 2D, make contiguous, row-major (C ordering)
-  initial_state = _ensure_2d(initial_state)
-  initial_warmstart = _ensure_2d(initial_warmstart)
-
-  # ensure 3D, make contiguous, row-major (C ordering)
-  control = _ensure_3d(control)
-  state = _ensure_3d(state)
-  sensordata = _ensure_3d(sensordata)
-
-  # infer nroll, check for incompatibilities
-  nroll = _infer_dimension(
-      0,
-      1,
-      initial_state=initial_state,
-      initial_warmstart=initial_warmstart,
-      control=control,
-      state=state,
-      sensordata=sensordata,
-  )
-  if isinstance(model, list) and nroll == 1:
-    nroll = len(model)
-
-  if isinstance(model, list) and len(model) != nroll:
-    raise ValueError(
-        f'nroll inferred as {nroll} but model is length {len(model)}'
-    )
-  elif not isinstance(model, list):
-    model = [model]  # Use a length 1 list to simplify code below
-
   if not isinstance(data, list):
     data = [data]  # Use a length 1 list to simplify code below
+  nthread = len(data) if len(data) > 1 else 0
 
-  # infer nstep, check for incompatibilities
-  nstep = _infer_dimension(
-      1, nstep or 1, control=control, state=state, sensordata=sensordata
-  )
+  # Use a persistent thread pool if requested
+  if persistent_pool:
+    global persistent_rollout
+    # Create or restart persistent threadpool
+    if persistent_rollout is None or persistent_rollout.nthread != nthread:
+      persistent_rollout = Rollout(nthread)
+    rollout = persistent_rollout
+  else:
+    rollout = Rollout(nthread)
 
-  # get nstate/ncontrol/nv/nsensordata
-  # check that they are equal across models
-  nstate = mujoco.mj_stateSize(
-      model[0], mujoco.mjtState.mjSTATE_FULLPHYSICS.value
-  )
-  ncontrol = mujoco.mj_stateSize(model[0], control_spec)
-  nv = model[0].nv
-  nsensordata = model[0].nsensordata
-  for m in model[1:]:
-    if (
-        nstate
-        != mujoco.mj_stateSize(m, mujoco.mjtState.mjSTATE_FULLPHYSICS.value)
-        or ncontrol != mujoco.mj_stateSize(m, control_spec)
-        or nv != m.nv
-        or nsensordata != m.nsensordata
-    ):
-      raise ValueError('models are not compatible')
-
-  # check trailing dimensions
-  _check_trailing_dimension(nstate, initial_state=initial_state, state=state)
-  _check_trailing_dimension(ncontrol, control=control)
-  _check_trailing_dimension(nv, initial_warmstart=initial_warmstart)
-  _check_trailing_dimension(nsensordata, sensordata=sensordata)
-
-  # tile input arrays/lists if required (singleton expansion)
-  model = model * nroll if len(model) == 1 else model
-  initial_state = _tile_if_required(initial_state, nroll)
-  initial_warmstart = _tile_if_required(initial_warmstart, nroll)
-  control = _tile_if_required(control, nroll, nstep)
-
-  # allocate output if not provided
-  if state is None:
-    state = np.empty((nroll, nstep, nstate))
-  if sensordata is None:
-    sensordata = np.empty((nroll, nstep, nsensordata))
-
-  # call rollout
-  _rollout.rollout(
-      model,
-      data,
-      nstep,
-      control_spec,
-      initial_state,
-      initial_warmstart,
-      control,
-      state,
-      sensordata,
-      chunk_size,
-  )
+  ret = rollout.rollout(
+    model,
+    data,
+    initial_state,
+    control,
+    control_spec=control_spec,
+    skip_checks=skip_checks,
+    nstep=nstep,
+    initial_warmstart=initial_warmstart,
+    state=state,
+    sensordata=sensordata,
+    chunk_size=chunk_size)
 
   # return outputs
-  return state, sensordata
-
+  return ret
 
 def _check_must_be_numeric(**kwargs):
   for key, value in kwargs.items():

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -33,7 +33,6 @@ class Rollout:
     """  # fmt: skip
     self.nthread = 0 if nthread is None else nthread
     self.rollout_ = _rollout.Rollout(self.nthread)
-    atexit.register(self.shutdown_pool)
 
   def __enter__(self):
     return self

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -35,7 +35,7 @@ def rollout(
     initial_warmstart: Optional[npt.ArrayLike] = None,
     state: Optional[npt.ArrayLike] = None,
     sensordata: Optional[npt.ArrayLike] = None,
-    chunk_divisor: int = 10,
+    chunk_size: int = None,
 ):
   """Rolls out open-loop trajectories from initial states, get subsequent states and sensor values.
 
@@ -60,8 +60,8 @@ def rollout(
       (nroll x nstep x nstate)
     sensordata: Sensor data output array (optional).
       (nroll x nstep x nsensordata)
-    chunk_divisor: Determines threadpool chunk size according to
-                   chunk_size = max(1, nroll / (nthread * chunk_divisor)
+    chunk_size: Determines threadpool chunk size. If unspecified,
+                chunk_size = max(1, nroll / (nthread * 10)
 
   Returns:
     state:
@@ -88,7 +88,7 @@ def rollout(
         control,
         state,
         sensordata,
-        chunk_divisor,
+        chunk_size,
     )
     return state, sensordata
 
@@ -102,6 +102,8 @@ def rollout(
   # check types
   if nstep and not isinstance(nstep, int):
     raise ValueError('nstep must be an integer')
+  if chunk_size and not isinstance(chunk_size, int):
+    raise ValueError('chunk_size must be an integer')
   _check_must_be_numeric(
       initial_state=initial_state,
       initial_warmstart=initial_warmstart,
@@ -202,7 +204,7 @@ def rollout(
       control,
       state,
       sensordata,
-      chunk_divisor,
+      chunk_size,
   )
 
   # return outputs

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -35,6 +35,7 @@ def rollout(
     initial_warmstart: Optional[npt.ArrayLike] = None,
     state: Optional[npt.ArrayLike] = None,
     sensordata: Optional[npt.ArrayLike] = None,
+    chunk_divisor: int = 10,
 ):
   """Rolls out open-loop trajectories from initial states, get subsequent states and sensor values.
 
@@ -59,6 +60,8 @@ def rollout(
       (nroll x nstep x nstate)
     sensordata: Sensor data output array (optional).
       (nroll x nstep x nsensordata)
+    chunk_divisor: Determines threadpool chunk size according to
+                   chunk_size = max(1, nroll / (nthread * chunk_divisor)
 
   Returns:
     state:
@@ -85,6 +88,7 @@ def rollout(
         control,
         state,
         sensordata,
+        chunk_divisor,
     )
     return state, sensordata
 
@@ -198,6 +202,7 @@ def rollout(
       control,
       state,
       sensordata,
+      chunk_divisor,
   )
 
   # return outputs

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -61,7 +61,7 @@ def rollout(
     sensordata: Sensor data output array (optional).
       (nroll x nstep x nsensordata)
     chunk_size: Determines threadpool chunk size. If unspecified,
-                chunk_size = max(1, nroll / (nthread * 10)
+                chunk_size = max(1, nroll / (nthread * 10))
 
   Returns:
     state:

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -562,7 +562,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     model_list = [model] * nroll
     data_list = [mujoco.MjData(model) for i in range(num_workers)]
 
-    with rollout.Rollout(num_workers) as rollout_:
+    with rollout.Rollout(nthread=num_workers) as rollout_:
       for i in range(2):
         rollout_.rollout(
             model_list,
@@ -579,7 +579,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
       np.testing.assert_array_equal(state, py_state)
       np.testing.assert_array_equal(sensordata, py_sensordata)
 
-    rollout_ = rollout.Rollout(num_workers)
+    rollout_ = rollout.Rollout(nthread=num_workers)
     for i in range(2):
       rollout_.rollout(
           model_list,
@@ -595,7 +595,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
       py_state, py_sensordata = py_rollout(model, data, initial_state, control)
       np.testing.assert_array_equal(state, py_state)
       np.testing.assert_array_equal(sensordata, py_sensordata)
-    rollout_.shutdown_pool()
+    rollout_.close()
 
   def test_threading_native_persistent_function(self):
     model = mujoco.MjModel.from_xml_string(TEST_XML)

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -478,7 +478,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     def call_rollout(initial_state, control, state, sensordata):
       rollout.rollout(
           model_list,
-          thread_local.data,
+          [thread_local.data],
           initial_state,
           control,
           skip_checks=True,

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -355,7 +355,7 @@ class MuJoCoRolloutTest(parameterized.TestCase):
         body.pos = body.pos + i
         model.append(spec.compile())
     else:
-      model = [spec.compile() for i in range(nroll)]
+      model = [spec.compile() for _ in range(nroll)]
 
     nstate = mujoco.mj_stateSize(model[0], mujoco.mjtState.mjSTATE_FULLPHYSICS)
     data = mujoco.MjData(model[0])

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -579,6 +579,24 @@ class MuJoCoRolloutTest(parameterized.TestCase):
       np.testing.assert_array_equal(state, py_state)
       np.testing.assert_array_equal(sensordata, py_sensordata)
 
+    rollout_ = rollout.Rollout(num_workers)
+    for i in range(2):
+      rollout_.rollout(
+          model_list,
+          data_list,
+          initial_state,
+          control,
+          nstep=nstep,
+          state=state,
+          sensordata=sensordata,
+      )
+
+      data = mujoco.MjData(model)
+      py_state, py_sensordata = py_rollout(model, data, initial_state, control)
+      np.testing.assert_array_equal(state, py_state)
+      np.testing.assert_array_equal(sensordata, py_sensordata)
+    rollout_.shutdown_pool()
+
   def test_threading_native_persistent_function(self):
     model = mujoco.MjModel.from_xml_string(TEST_XML)
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)

--- a/python/mujoco/threadpool.cc
+++ b/python/mujoco/threadpool.cc
@@ -1,0 +1,87 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mjpc/threadpool.h"
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+#include <absl/base/attributes.h>
+
+namespace mjpc {
+
+ABSL_CONST_INIT thread_local int ThreadPool::worker_id_ = -1;
+
+// ThreadPool constructor
+ThreadPool::ThreadPool(int num_threads) : ctr_(0) {
+  for (int i = 0; i < num_threads; i++) {
+    threads_.push_back(std::thread(&ThreadPool::WorkerThread, this, i));
+  }
+}
+
+// ThreadPool destructor
+ThreadPool::~ThreadPool() {
+  {
+    std::unique_lock<std::mutex> lock(m_);
+    for (int i = 0; i < threads_.size(); i++) {
+      queue_.push(nullptr);
+    }
+    cv_in_.notify_all();
+  }
+  for (auto& thread : threads_) {
+    thread.join();
+  }
+}
+
+// ThreadPool scheduler
+void ThreadPool::Schedule(std::function<void()> task) {
+  std::unique_lock<std::mutex> lock(m_);
+  queue_.push(std::move(task));
+  cv_in_.notify_one();
+}
+
+// ThreadPool worker
+void ThreadPool::WorkerThread(int i) {
+  worker_id_ = i;
+  while (true) {
+    auto task = [&]() {
+      std::unique_lock<std::mutex> lock(m_);
+      cv_in_.wait(lock, [&]() { return !queue_.empty(); });
+      std::function<void()> task = std::move(queue_.front());
+      queue_.pop();
+      cv_in_.notify_one();
+      return task;
+    }();
+    if (task == nullptr) {
+      {
+        std::unique_lock<std::mutex> lock(m_);
+        ++ctr_;
+        cv_ext_.notify_one();
+      }
+      break;
+    }
+    task();
+
+    {
+      std::unique_lock<std::mutex> lock(m_);
+      ++ctr_;
+      cv_ext_.notify_one();
+    }
+  }
+}
+
+}  // namespace mjpc

--- a/python/mujoco/threadpool.cc
+++ b/python/mujoco/threadpool.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 DeepMind Technologies Limited
+// Copyright 2024 DeepMind Technologies Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mjpc/threadpool.h"
+#include "threadpool.h"
 
 #include <condition_variable>
 #include <functional>
@@ -22,7 +22,7 @@
 
 #include <absl/base/attributes.h>
 
-namespace mjpc {
+namespace mujoco::python {
 
 ABSL_CONST_INIT thread_local int ThreadPool::worker_id_ = -1;
 
@@ -84,4 +84,4 @@ void ThreadPool::WorkerThread(int i) {
   }
 }
 
-}  // namespace mjpc
+}  // namespace mujoco::python

--- a/python/mujoco/threadpool.h
+++ b/python/mujoco/threadpool.h
@@ -1,0 +1,81 @@
+// Copyright 2022 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MJPC_THREADPOOL_H_
+#define MJPC_THREADPOOL_H_
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <absl/base/attributes.h>
+
+namespace mjpc {
+
+// ThreadPool class
+class ThreadPool {
+ public:
+  // constructor
+  explicit ThreadPool(int num_threads);
+
+  // destructor
+  ~ThreadPool();
+
+  int NumThreads() const { return threads_.size(); }
+
+  // returns an ID between 0 and NumThreads() - 1. must be called within
+  // worker thread (returns -1 if not).
+  static int WorkerId() { return worker_id_; }
+
+  // ----- methods ----- //
+  // set task for threadpool
+  void Schedule(std::function<void()> task);
+
+  // return number of tasks completed
+  std::uint64_t GetCount() { return ctr_; }
+
+  // reset count to zero
+  void ResetCount() { ctr_ = 0; }
+
+  // wait for count, then return
+  void WaitCount(int value) {
+    std::unique_lock<std::mutex> lock(m_);
+    cv_ext_.wait(lock, [&]() { return this->GetCount() >= value; });
+  }
+
+ private:
+  // ----- methods ----- //
+
+  // execute task with available thread
+  void WorkerThread(int i);
+
+  ABSL_CONST_INIT static thread_local int worker_id_;
+
+  // ----- members ----- //
+  std::vector<std::thread> threads_;
+  std::mutex m_;
+  std::condition_variable cv_in_;
+  std::condition_variable cv_ext_;
+  std::queue<std::function<void()>> queue_;
+  std::uint64_t ctr_;
+};
+
+}  // namespace mjpc
+
+#endif  // MJPC_THREADPOOL_H_

--- a/python/mujoco/threadpool.h
+++ b/python/mujoco/threadpool.h
@@ -1,4 +1,4 @@
-// Copyright 2022 DeepMind Technologies Limited
+// Copyright 2024 DeepMind Technologies Limited
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MJPC_THREADPOOL_H_
-#define MJPC_THREADPOOL_H_
+#ifndef MUJOCO_PYTHON_THREADPOOL_H_
+#define MUJOCO_PYTHON_THREADPOOL_H_
 
 #include <condition_variable>
 #include <cstdint>
@@ -26,7 +26,7 @@
 
 #include <absl/base/attributes.h>
 
-namespace mjpc {
+namespace mujoco::python {
 
 // ThreadPool class
 class ThreadPool {
@@ -76,6 +76,6 @@ class ThreadPool {
   std::uint64_t ctr_;
 };
 
-}  // namespace mjpc
+}  // namespace mujoco::python
 
-#endif  // MJPC_THREADPOOL_H_
+#endif  // MUJOCO_PYTHON_THREADPOOL_H_


### PR DESCRIPTION
`rollout` now accepts a list of MjData of length `nthread`. If passed, the `nroll` rollouts are parallelized.

The thread pool is persistent across calls to rollout, so long as the number of MjData instances is constant.

The thread pool implementation was copied from MJPC. It is not threadsafe. This means that if rollout is using threads, it should not be called from multiple threads.