### PR TITLE
[Unity plugin] Add support for OBJ file import from MuJoCo scenes

### DIFF
--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -174,7 +174,14 @@ public class MjImporterWithAssets : MjcfImporter {
       throw new Exception(
         $"Trying to import mesh {unsanitizedAssetReferenceName} but {assetPath} already exists.");
     }
+
     AssetDatabase.ImportAsset(assetPath);
+    ModelImporter importer = AssetImporter.GetAtPath(assetPath) as ModelImporter;
+    if (importer != null && !importer.isReadable) {
+      importer.isReadable = true;
+      importer.SaveAndReimport();
+    }
+
     var copiedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(assetPath);
     if (copiedMesh == null) {
       throw new Exception($"Mesh {assetPath} was not imported.");
@@ -283,12 +290,12 @@ public class MjImporterWithAssets : MjcfImporter {
         // We use the geom's name, guaranteed to be unique, as the asset name.
         // If geom is nameless, use a random number.
         var name =
-          MjEngineTool.Sanitize(parentNode.GetStringAttribute(
-              "name", defaultValue: $"{UnityEngine.Random.Range(0, 1000000)}"));
-        var assetPath = Path.Combine(_targetAssetDir, name + ".mat");
+            MjEngineTool.Sanitize(parentNode.GetStringAttribute(
+                "name", defaultValue: $"{UnityEngine.Random.Range(0, 1000000)}"));
+        var assetPath = Path.Combine(_targetAssetDir, name+".mat");
         if (AssetDatabase.LoadMainAssetAtPath(assetPath) != null) {
           throw new Exception(
-            $"Creating a material asset for the geom {name}, but {assetPath} already exists.");
+              $"Creating a material asset for the geom {name}, but {assetPath} already exists.");
         }
         AssetDatabase.CreateAsset(material, assetPath);
         AssetDatabase.SaveAssets();
@@ -297,6 +304,7 @@ public class MjImporterWithAssets : MjcfImporter {
         material = DefaultMujocoMaterial;
       }
     }
+    if (parentNode.GetFloatAttribute("group") > 2) renderer.enabled = false;
     renderer.sharedMaterial = material;
   }
 }

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -290,12 +290,12 @@ public class MjImporterWithAssets : MjcfImporter {
         // We use the geom's name, guaranteed to be unique, as the asset name.
         // If geom is nameless, use a random number.
         var name =
-            MjEngineTool.Sanitize(parentNode.GetStringAttribute(
-                "name", defaultValue: $"{UnityEngine.Random.Range(0, 1000000)}"));
+          MjEngineTool.Sanitize(parentNode.GetStringAttribute(
+            "name", defaultValue: $"{UnityEngine.Random.Range(0, 1000000)}"));
         var assetPath = Path.Combine(_targetAssetDir, name+".mat");
         if (AssetDatabase.LoadMainAssetAtPath(assetPath) != null) {
           throw new Exception(
-              $"Creating a material asset for the geom {name}, but {assetPath} already exists.");
+            $"Creating a material asset for the geom {name}, but {assetPath} already exists.");
         }
         AssetDatabase.CreateAsset(material, assetPath);
         AssetDatabase.SaveAssets();

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -159,8 +159,8 @@ public class MjImporterWithAssets : MjcfImporter {
                                         $"Attempted to load: {sourceFilePath}");
     }
 
-    var targetFilePath = Path.Combine(_targetMeshesDir, assetReferenceName 
-                                                        + Path.GetExtension(sourceFilePath));
+    var targetFilePath =
+        Path.Combine(_targetMeshesDir, assetReferenceName + Path.GetExtension(sourceFilePath));
     if (File.Exists(targetFilePath)) {
       File.Delete(targetFilePath);
     }

--- a/unity/Editor/Importer/ObjMeshImportUtility.cs
+++ b/unity/Editor/Importer/ObjMeshImportUtility.cs
@@ -1,0 +1,94 @@
+// Copyright 2019 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace Mujoco {
+
+  /// <summary>
+  /// Scale vertex data manually line by line. We skip normals. Parameter vertex points
+  /// (`vp`) was unclear to me how to properly scale them, if you use them and notice an
+  /// issue please report it.
+  /// </summary>
+  public static class ObjMeshImportUtility {
+    private static Vector3 ToXZY(float x, float y, float z) => new Vector3(x, z, y);
+
+    public static void CopyAndScaleOBJFile(string sourceFilePath, string targetFilePath,
+        Vector3 scale, bool flipFaces=false) {
+      // OBJ files are human readable
+      string[] lines = File.ReadAllLines(sourceFilePath);
+      StringBuilder outputBuilder = new StringBuilder();
+      // Culture info for consistent decimal point handling
+      CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+
+      scale = ToXZY(scale.x, scale.y, scale.z);
+      foreach (string line in lines) {
+        if (line.StartsWith("v ")) // Vertex line
+        {
+          // Split the line into components
+          string[] parts = line.Split(' ');
+          if (parts.Length >= 4) {
+            // Scale the vertex
+            float x = -float.Parse(parts[1], invariantCulture) * scale.x;
+            float y = float.Parse(parts[2], invariantCulture) * scale.y;
+            float z = float.Parse(parts[3], invariantCulture) * scale.z;
+
+            var swizzled = ToXZY(x, y, z);
+            outputBuilder.AppendLine(
+                $"v {swizzled.x.ToString(invariantCulture)} {swizzled.y.ToString(invariantCulture)} {swizzled.z.ToString(invariantCulture)}");
+          }
+        } else if (line.StartsWith("vn ")) {
+          string[] parts = line.Split(' ');
+          if (parts.Length >= 4) {
+            float x = -float.Parse(parts[1], invariantCulture);
+            float y = float.Parse(parts[2], invariantCulture);
+            float z = float.Parse(parts[3], invariantCulture);
+
+            var swizzled = ToXZY(x, y, z);
+            outputBuilder.AppendLine(
+                $"vn {swizzled.x.ToString(invariantCulture)} {swizzled.y.ToString(invariantCulture)} {swizzled.z.ToString(invariantCulture)}");
+          }
+        } else if (line.StartsWith("f ") && flipFaces) {
+          string[] parts = line.Split(' ');
+          if (parts.Length >= 4) {
+            outputBuilder.Append(parts[0] + " ");
+
+            // Apply same vertex order as STL parser: [0,2,1]
+            var face = parts.Skip(1).ToArray();
+            if (face.Length >= 3) {
+              outputBuilder.Append(face[0] + " ");  // vertex 0
+              outputBuilder.Append(face[2] + " ");  // vertex 2
+              outputBuilder.Append(face[1]);        // vertex 1
+
+              // Append any remaining vertices in original order
+              for (int i = 3; i < face.Length; i++) {
+                outputBuilder.Append(" " + face[i]);
+              }
+            }
+            outputBuilder.AppendLine();
+          }
+        } else {
+          // Copy non-vertex lines as-is
+          outputBuilder.AppendLine(line);
+        }
+      }
+      // Write the scaled OBJ to the target file
+      File.WriteAllText(targetFilePath, outputBuilder.ToString());
+    }
+  }
+}

--- a/unity/Editor/Importer/ObjMeshImportUtility.cs
+++ b/unity/Editor/Importer/ObjMeshImportUtility.cs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using UnityEditor;
 using UnityEngine;
 
 namespace Mujoco {
@@ -32,7 +30,7 @@ public static class ObjMeshImportUtility {
 
   public static void CopyAndScaleOBJFile(string sourceFilePath, string targetFilePath,
       Vector3 scale) {
-    // OBJ files are human readable
+    // OBJ files are human-readable
     string[] lines = File.ReadAllLines(sourceFilePath);
     StringBuilder outputBuilder = new StringBuilder();
     // Culture info for consistent decimal point handling

--- a/unity/Editor/Importer/ObjMeshImportUtility.cs
+++ b/unity/Editor/Importer/ObjMeshImportUtility.cs
@@ -11,84 +11,85 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using UnityEditor;
 using UnityEngine;
 
 namespace Mujoco {
 
-  /// <summary>
-  /// Scale vertex data manually line by line. We skip normals. Parameter vertex points
-  /// (`vp`) was unclear to me how to properly scale them, if you use them and notice an
-  /// issue please report it.
-  /// </summary>
-  public static class ObjMeshImportUtility {
-    private static Vector3 ToXZY(float x, float y, float z) => new Vector3(x, z, y);
+/// <summary>
+/// Scale vertex data manually line by line. We skip normals. Warning: Parameter vertex points
+/// (`vp`) were unclear to me how to handle with scaling, if you use them and notice an issue
+/// please report it.
+/// </summary>
+public static class ObjMeshImportUtility {
+  private static Vector3 ToXZY(float x, float y, float z) => new Vector3(x, z, y);
 
-    public static void CopyAndScaleOBJFile(string sourceFilePath, string targetFilePath,
-        Vector3 scale, bool flipFaces=false) {
-      // OBJ files are human readable
-      string[] lines = File.ReadAllLines(sourceFilePath);
-      StringBuilder outputBuilder = new StringBuilder();
-      // Culture info for consistent decimal point handling
-      CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+  public static void CopyAndScaleOBJFile(string sourceFilePath, string targetFilePath,
+      Vector3 scale) {
+    // OBJ files are human readable
+    string[] lines = File.ReadAllLines(sourceFilePath);
+    StringBuilder outputBuilder = new StringBuilder();
+    // Culture info for consistent decimal point handling
+    CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+    scale = ToXZY(scale.x, scale.y, scale.z);
+    foreach (string line in lines) {
+      if (line.StartsWith("v ")) // Vertex line
+      {
+        // Split the line into components
+        string[] parts = line.Split(' ');
+        if (parts.Length >= 4) {
+          // Scale the vertex. It is unclear to me why flipping along x axis was necessary,
+          // but without it meshes were incorrectly oriented.
+          float x = -float.Parse(parts[1], invariantCulture) * scale.x;
+          float y = float.Parse(parts[2], invariantCulture) * scale.y;
+          float z = float.Parse(parts[3], invariantCulture) * scale.z;
 
-      scale = ToXZY(scale.x, scale.y, scale.z);
-      foreach (string line in lines) {
-        if (line.StartsWith("v ")) // Vertex line
-        {
-          // Split the line into components
-          string[] parts = line.Split(' ');
-          if (parts.Length >= 4) {
-            // Scale the vertex
-            float x = -float.Parse(parts[1], invariantCulture) * scale.x;
-            float y = float.Parse(parts[2], invariantCulture) * scale.y;
-            float z = float.Parse(parts[3], invariantCulture) * scale.z;
-
-            var swizzled = ToXZY(x, y, z);
-            outputBuilder.AppendLine(
-                $"v {swizzled.x.ToString(invariantCulture)} {swizzled.y.ToString(invariantCulture)} {swizzled.z.ToString(invariantCulture)}");
-          }
-        } else if (line.StartsWith("vn ")) {
-          string[] parts = line.Split(' ');
-          if (parts.Length >= 4) {
-            float x = -float.Parse(parts[1], invariantCulture);
-            float y = float.Parse(parts[2], invariantCulture);
-            float z = float.Parse(parts[3], invariantCulture);
-
-            var swizzled = ToXZY(x, y, z);
-            outputBuilder.AppendLine(
-                $"vn {swizzled.x.ToString(invariantCulture)} {swizzled.y.ToString(invariantCulture)} {swizzled.z.ToString(invariantCulture)}");
-          }
-        } else if (line.StartsWith("f ") && flipFaces) {
-          string[] parts = line.Split(' ');
-          if (parts.Length >= 4) {
-            outputBuilder.Append(parts[0] + " ");
-
-            // Apply same vertex order as STL parser: [0,2,1]
-            var face = parts.Skip(1).ToArray();
-            if (face.Length >= 3) {
-              outputBuilder.Append(face[0] + " ");  // vertex 0
-              outputBuilder.Append(face[2] + " ");  // vertex 2
-              outputBuilder.Append(face[1]);        // vertex 1
-
-              // Append any remaining vertices in original order
-              for (int i = 3; i < face.Length; i++) {
-                outputBuilder.Append(" " + face[i]);
-              }
-            }
-            outputBuilder.AppendLine();
-          }
-        } else {
-          // Copy non-vertex lines as-is
-          outputBuilder.AppendLine(line);
+          var swizzled = ToXZY(x, y, z);
+          outputBuilder.AppendLine(
+              $"v {swizzled.x.ToString(invariantCulture)} "+
+              $"{swizzled.y.ToString(invariantCulture)} "+
+              $"{swizzled.z.ToString(invariantCulture)}");
         }
+      } else if (line.StartsWith("vn ")) {
+        // We swizzle the normals too
+        string[] parts = line.Split(' ');
+        if (parts.Length >= 4) {
+          float x = -float.Parse(parts[1], invariantCulture);
+          float y = float.Parse(parts[2], invariantCulture);
+          float z = float.Parse(parts[3], invariantCulture);
+
+          var swizzled = ToXZY(x, y, z);
+          outputBuilder.AppendLine(
+              $"vn {swizzled.x.ToString(invariantCulture)} "+
+              $"{swizzled.y.ToString(invariantCulture)} "+
+              $"{swizzled.z.ToString(invariantCulture)}");
+        }
+      } else if (line.StartsWith("f ") && scale.x*scale.y*scale.z < 0) {
+        // Faces definition, flip face by reordering vertices
+        string[] parts = line.Split(' ');
+        if (parts.Length >= 4) {
+          outputBuilder.Append(parts[0]+" ");
+          var face = parts.Skip(1).ToArray();
+          if (face.Length >= 3) {
+            outputBuilder.Append(face[0]+" ");
+            outputBuilder.Append(face[2]+" ");
+            outputBuilder.Append(face[1]);
+          }
+          outputBuilder.AppendLine();
+        }
+      } else {
+        // Copy non-vertex lines as-is
+        outputBuilder.AppendLine(line);
       }
-      // Write the scaled OBJ to the target file
-      File.WriteAllText(targetFilePath, outputBuilder.ToString());
     }
+    // Write the scaled OBJ to the target file
+    File.WriteAllText(targetFilePath, outputBuilder.ToString());
   }
+}
 }

--- a/unity/Editor/Importer/ObjMeshImportUtility.cs.meta
+++ b/unity/Editor/Importer/ObjMeshImportUtility.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/Editor/Importer/ObjMeshImportUtility.cs.meta
+++ b/unity/Editor/Importer/ObjMeshImportUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adec9978c00bb934eb8bf974c26193e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -41,17 +41,17 @@ public class MjMeshFilter : MonoBehaviour {
       return;
     }
 
-    _shapeChangeStamp = currentChangeStamp;
-    Tuple<Vector3[], int[]> meshData = _geom.BuildMesh();
-
-    if (meshData == null) {
-      throw new ArgumentException("Unsupported geom shape detected");
-    }
-
     if(_geom.ShapeType == MjShapeComponent.ShapeTypes.Mesh) { 
       MjMeshShape meshShape = _geom.Shape as MjMeshShape;
       _meshFilter.sharedMesh = meshShape.Mesh;
       return;
+    }
+
+    _shapeChangeStamp = currentChangeStamp;
+    Tuple<Vector3[], int[]> meshData = _geom.BuildMesh();
+    if (meshData == null)
+    {
+      throw new ArgumentException("Unsupported geom shape detected");
     }
 
     DisposeCurrentMesh();

--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -41,7 +41,7 @@ public class MjMeshFilter : MonoBehaviour {
       return;
     }
 
-    if(_geom.ShapeType == MjShapeComponent.ShapeTypes.Mesh) { 
+    if(_geom.ShapeType == MjShapeComponent.ShapeTypes.Mesh) {
       MjMeshShape meshShape = _geom.Shape as MjMeshShape;
       _meshFilter.sharedMesh = meshShape.Mesh;
       return;
@@ -67,7 +67,6 @@ public class MjMeshFilter : MonoBehaviour {
       uvs[i] = new Vector2(mesh.vertices[i].x, mesh.vertices[i].z);
     }
     mesh.uv = uvs;
-    
     mesh.RecalculateNormals();
     mesh.RecalculateTangents();
   }

--- a/unity/Runtime/Components/Shapes/MjMeshShape.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshShape.cs
@@ -36,7 +36,7 @@ public class MjMeshShape : IMjShape {
     var assetName = MjEngineTool.Sanitize(
         mjcf.GetStringAttribute("mesh", defaultValue: string.Empty));
     if (!string.IsNullOrEmpty(assetName)) {
-      Mesh = (Mesh)Resources.Load(assetName);
+      Mesh = Resources.Load<Mesh>(assetName);
     }
   }
 


### PR DESCRIPTION
This feature handles OBJ mesh assets referenced in MJCF. It applies the scale to the OBJ mesh then saves it as a local asset in the project, after swizzling the mesh coordinates. An additional step is taken to enable read-write of mesh data from obj files. We flip around mesh faces if the scale has an odd number of negative numbers. In fact this is a missing detail from the STL parser, will add a fix for that soon in a separate PR.

A related feature included is by default now the mesh renderer is turned of Geoms with group >=3 (default function with Simulate). This will make imported scenes appear more similar to what is expected from the Simulate UI (commonly collision geoms are hidden by default using this approach).

This now enables importing many more menagerie models to Unity.

Addresses #2372