### PR TITLE
Initialize WIN32_FIND_DATAA to prevent uninitialized data usage.

### DIFF
--- a/src/engine/engine_plugin.cc
+++ b/src/engine/engine_plugin.cc
@@ -425,7 +425,7 @@ void mj_loadAllPluginLibraries(const char* directory,
   // define platform-specific strings
 #if defined(_WIN32) || defined(__CYGWIN__)
   const std::string sep = "\\";
-  WIN32_FIND_DATAA find_data;
+  WIN32_FIND_DATAA find_data{};
   HANDLE hfile = FindFirstFileA(
       (directory + sep + "*.dll").c_str(), &find_data);
   if (!hfile) {


### PR DESCRIPTION
On Windows platforms using the simulate.exe, the console outputs garbage characters during startup due to uninitialized WIN32_FIND_DATAA::cFileName in mj_loadAllPluginLibraries.