### PR TITLE
Fix URDF scaled mesh re-use

### DIFF
--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -620,7 +620,7 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
       }
 
       // if it is not the first mesh with this name, append index
-      if(i > 0) {
+      if (i > 0) {
         meshname = meshname + std::to_string(i);
       }
     }

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -629,7 +629,7 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
       pmesh->scale[1] = meshscale[1];
       pmesh->scale[2] = meshscale[2];
     }
-    mjs_setString(pgeom->meshname, meshname.c_str());
+    mjs_setString(pgeom->meshname, pmesh->name->c_str());
   }
 
   else {

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -607,6 +607,8 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
             mesh->scale[1] == meshscale[1] &&
             mesh->scale[2] == meshscale[2]) {
           pmesh = mesh;
+	  if (i>0)
+            meshname = meshname + std::to_string(i);
           break;
         }
         i++;
@@ -629,7 +631,7 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
       pmesh->scale[1] = meshscale[1];
       pmesh->scale[2] = meshscale[2];
     }
-    mjs_setString(pgeom->meshname, pmesh->name->c_str());
+    mjs_setString(pgeom->meshname, meshname.c_str());
   }
 
   else {

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -607,8 +607,6 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
             mesh->scale[1] == meshscale[1] &&
             mesh->scale[2] == meshscale[2]) {
           pmesh = mesh;
-	  if (i>0)
-            meshname = meshname + std::to_string(i);
           break;
         }
         i++;
@@ -619,8 +617,13 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
         pmesh = mjs_addMesh(spec, 0);
         meshes[meshname].push_back(pmesh);
         meshname = meshname + std::to_string(i);
-        newmesh = true;
+        newmesh = true;      
       }
+      else if(i>0)
+      {
+        meshname = meshname + std::to_string(i);
+      }
+
     }
 
     // set fields

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -616,14 +616,13 @@ mjsGeom* mjXURDF::Geom(XMLElement* geom_elem, mjsBody* pbody, bool collision) {
       if (i == meshes[meshname].size()) {
         pmesh = mjs_addMesh(spec, 0);
         meshes[meshname].push_back(pmesh);
-        meshname = meshname + std::to_string(i);
-        newmesh = true;      
-      }
-      else if(i>0)
-      {
-        meshname = meshname + std::to_string(i);
+        newmesh = true;
       }
 
+      // if it is not the first mesh with this name, append index
+      if(i > 0) {
+        meshname = meshname + std::to_string(i);
+      }
     }
 
     // set fields


### PR DESCRIPTION
I noticed a bug that occurs when re-using meshes with different scaling in a URDF. The meshes are cached correctly, but when a certain scaling is reused the first-imported mesh is selected again. This because the meshname set in the geom ends up being the one of the original mesh and not of the cached one.
I implemented a small fix, it is just a one-line fix.