### PR TITLE
Expose viewer module when importing mujoco

### DIFF
--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -61,6 +61,7 @@ from mujoco._specs import *
 from mujoco._structs import *
 from mujoco.gl_context import *
 from mujoco.renderer import Renderer
+from mujoco.viewer import *
 
 MjStruct: TypeAlias = Union[
     _specs.MjsBody,


### PR DESCRIPTION
```
(base) wesleymaa@MacBook-Pro ~ % python
Python 3.11.11 | packaged by conda-forge | (main, Dec  5 2024, 14:21:42) [Clang 18.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mujoco
>>> mujoco.viewer
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'mujoco' has no attribute 'viewer'
>>> 
```

The `mujoco.viewer` module is not re-imported, so code that tries to call it will fail. This is obscured on MacOS because using `mjpython` seems to add the module to path already or otherwise import it. 

This PR re-imports `mujoco.viewer`

```
(base) wesleymaa@MacBook-Pro ~ % mjpython
Python 3.11.11 | packaged by conda-forge | (main, Dec  5 2024, 14:21:42) [Clang 18.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mujoco
>>> mujoco.viewer
<module 'mujoco.viewer' from '/Users/wesleymaa/.conda/envs/ksim/lib/python3.11/site-packages/mujoco/viewer.py'>
```