### PR TITLE
Allow run/pause toggling from passive UI and handle, closes #2481

### DIFF
--- a/python/mujoco/simulate.cc
+++ b/python/mujoco/simulate.cc
@@ -277,8 +277,10 @@ PYBIND11_MODULE(_simulate, pymodule) {
       .def_property_readonly("busywait",
                              GetIfNotNull(&mujoco::Simulate::busywait),
                              py::call_guard<py::gil_scoped_release>())
-      .def_property_readonly("run", GetIfNotNull(&mujoco::Simulate::run),
-                             py::call_guard<py::gil_scoped_release>())
+      .def_property("run",
+                    GetIfNotNull(&mujoco::Simulate::run),
+                    SetIfNotNull(&mujoco::Simulate::run),
+                    py::call_guard<py::gil_scoped_release>())
 
       .def_property_readonly("exitrequest",
                              CallIfNotNull(+[](mujoco::Simulate& sim) {

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -115,6 +115,21 @@ class Handle:
       return sim.viewport
     return None
 
+  @property
+  def run(self):
+    sim = self._sim()
+    if sim is not None:
+      return sim.run
+    return None
+
+  @run.setter
+  def run(self, value):
+    if value != 0 and value != 1:
+      raise ValueError('run must be 0 or 1')
+    sim = self._sim()
+    with sim.lock():
+      sim.run = value
+
   def set_figures(self, viewports_figures):
     sim = self._sim()
     if sim is not None:

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -1553,7 +1553,7 @@ void UiEvent(mjuiState* state) {
   if (state->type==mjEVENT_KEY && state->key!=0) {
     switch (state->key) {
     case ' ':                   // Mode
-      if (!sim->is_passive_ && sim->m_) {
+      if (sim->m_ || sim->is_passive_) {
         sim->run = 1 - sim->run;
         sim->pert.active = 0;
 
@@ -2122,7 +2122,7 @@ void Simulate::Sync() {
   // clear timers once profiler info has been copied
   ClearTimers(d_);
 
-  if (this->run || this->is_passive_) {
+  if (this->run) {
     // clear old perturbations, apply new
     mju_zero(d_->xfrc_applied, 6*m_->nbody);
     mjv_applyPerturbPose(m_, d_, &this->pert, 0);  // mocap bodies only

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -289,7 +289,7 @@ class Simulate {
   // simulation section of UI
   const mjuiDef def_simulation[14] = {
     {mjITEM_SECTION,   "Simulation",    mjPRESERVE, nullptr,     "AS"},
-    {mjITEM_RADIO,     "",              5, &this->run,           "Pause\nRun"},
+    {mjITEM_RADIO,     "",              2, &this->run,           "Pause\nRun"},
     {mjITEM_BUTTON,    "Reset",         2, nullptr,              " #259"},
     {mjITEM_BUTTON,    "Reload",        5, nullptr,              "CL"},
     {mjITEM_BUTTON,    "Align",         2, nullptr,              "CA"},


### PR DESCRIPTION
Closes #2481.

The actual behavior of paused simulation in passive viewers is up to the user. To work as intended, the user should check `handle.run` to choose between `mj_step` and `mj_forward`:
```python
import time
import mujoco, mujoco.viewer
model = mujoco.MjModel.from_xml_string("""
<mujoco>
    <worldbody>
        <body name="box" pos="0 0 0">
            <joint type="slide" axis="1 0 0"/>
            <geom type="box" size="1 1 1" rgba="1 0 0 1"/>
        </body>
        <body name="sphere" pos="3 0 0">
            <joint type="free"/>
            <geom type="sphere" size="1" rgba="0 1 0 1"/>
        </body>
    </worldbody>
</mujoco>
""")
data = mujoco.MjData(model)
handle = mujoco.viewer.launch_passive(model, data)
while handle.is_running():
    if handle.run:
        mujoco.mj_step(model, data)
    else:
        # Forward to reflect direct position perturb
        mujoco.mj_forward(model, data)
    handle.sync()
    time.sleep(0.001)
```
When the simulation is paused, the user can apply direct qpos manipulation and pose perturbation in the simulator.

Several concerns:
1. The `Handle` class already has a method `is_running` to check if the simulation window is running or exited, while the `simulator` uses `run=1/0` to indicate run/pause. The naming would potentially cause confusion.
2. **(Off-topic)** The following line does not quite make sense to me (and opposite to several other cases above and below). Should `!sim->is_passive_` be `sim->is_passive_`?

    https://github.com/google-deepmind/mujoco/blob/14dc6fd33b9fbeb88d09bbde397c558f0f8b52d4/simulate/simulate.cc#L1620