### PR TITLE
Fix broken model.vis repr

### DIFF
--- a/python/mujoco/structs.cc
+++ b/python/mujoco/structs.cc
@@ -1415,7 +1415,27 @@ PYBIND11_MODULE(_structs, m) {
   mjVisual.def("__deepcopy__", [](const MjVisualWrapper& other, py::dict) {
     return MjVisualWrapper(other);
   });
-  DefineStructFunctions(mjVisual);
+  mjVisual.def("__eq__", StructsEqual<MjVisualWrapper>);
+  // Special __repr__ implementation for MjVisual, since:
+  // 1. Types under MjVisual confuse StructRepr;
+  // 2. StructRepr does not handle the indentation of nested structs well.
+  mjVisual.def("__repr__", [](py::object self) {
+    std::ostringstream result;
+    result << "<"
+      << self.attr("__class__").attr("__name__").cast<std::string_view>();
+#define X(type, var) \
+    result << "\n  " #var ": "; \
+    StructReprImpl<type>(self.attr(#var), result, 2);
+  X(raw::MjVisualGlobal, global_)
+  X(raw::MjVisualQuality, quality)
+  X(MjVisualHeadlightWrapper, headlight)
+  X(raw::MjVisualMap, map)
+  X(raw::MjVisualScale, scale)
+  X(MjVisualRgbaWrapper, rgba)
+#undef X
+    result << "\n>";
+    return result.str();
+  });
 
   py::class_<raw::MjVisualGlobal> mjVisualGlobal(mjVisual, "Global");
   mjVisualGlobal.def("__copy__", [](const raw::MjVisualGlobal& other) {

--- a/python/mujoco/structs.h
+++ b/python/mujoco/structs.h
@@ -1206,8 +1206,7 @@ bool StructsEqual(pybind11::object lhs, pybind11::object rhs) {
 
 // Returns a string representation of a struct like object.
 template <typename T>
-std::string StructRepr(pybind11::object self) {
-  std::ostringstream result;
+void StructReprImpl(pybind11::object self, std::ostringstream& result, int indent) {
   result << "<"
          << self.attr("__class__").attr("__name__").cast<std::string_view>();
   for (pybind11::handle f : Dir<T>()) {
@@ -1216,10 +1215,16 @@ std::string StructRepr(pybind11::object self) {
       continue;
     }
 
-    result << "\n  " << name << ": "
+    result << "\n" << std::string(indent + 2, ' ') << name << ": "
            << self.attr(f).attr("__repr__")().cast<std::string_view>();
   }
-  result << "\n>";
+  result << "\n" << std::string(indent, ' ') << ">";
+}
+
+template <typename T>
+std::string StructRepr(pybind11::object self) {
+  std::ostringstream result;
+  StructReprImpl<T>(self, result, 0);
   return result.str();
 }
 


### PR DESCRIPTION
Closes #2488 

```
>>> model.vis
<MjVisual
  global_: <Global
    azimuth: 90.0
    realtime: 1.0
  >
  quality: <Quality
    numquads: 4
    shadowsize: 4096
  >
  headlight: <Headlight
    active: 1
    specular: array([0.5, 0.5, 0.5], dtype=float32)
  >
  map: <Map
    actuatortendon: 2.0
    znear: 0.009999999776482582
  >
  scale: <Scale
    actuatorlength: 0.699999988079071
    slidercrank: 0.20000000298023224
  >
  rgba: <Rgba
    actuator: array([0.2 , 0.25, 0.2 , 1.  ], dtype=float32)
    slidercrank: array([0.5, 0.3, 0.8, 1. ], dtype=float32)
  >
>
```