### PR TITLE
Add handles for overlaying user text and images to the Passive Viewer

### DIFF
--- a/python/mujoco/simulate.cc
+++ b/python/mujoco/simulate.cc
@@ -149,19 +149,19 @@ class SimulateWrapper {
 
   void ClearFigures() { simulate_->user_figures_.clear(); }
 
-  void SetText(
-      const std::vector<std::tuple<int, int, std::string, std::string>>& overlay_texts) {
+  void SetTexts(
+      const std::vector<std::tuple<int, int, std::string, std::string>>& texts) {
     // Collection of [font, gridpos, text1, text2] tuples for overlay text
-    std::vector<std::tuple<int, int, std::string, std::string>> user_overlay_text;
-    for (const auto& [font, gridpos, text1, text2] : overlay_texts) {
-      user_overlay_text.push_back(std::make_tuple(font, gridpos, text1, text2));
+    std::vector<std::tuple<int, int, std::string, std::string>> user_texts;
+    for (const auto& [font, gridpos, text1, text2] : texts) {
+      user_texts.push_back(std::make_tuple(font, gridpos, text1, text2));
     }
 
-    // Set them all at once to prevent overlay text flickering.
-    simulate_->user_text_ = user_overlay_text;
+    // Set them all at once to prevent text flickering.
+    simulate_->user_texts_ = user_texts;
   }
 
-  void ClearText() { simulate_->user_text_.clear(); }
+  void ClearTexts() { simulate_->user_texts_.clear(); }
 
   void SetImages(
     const std::vector<std::tuple<mjrRect, pybind11::array&>> viewports_images
@@ -303,9 +303,9 @@ PYBIND11_MODULE(_simulate, pymodule) {
       .def("set_figures", &SimulateWrapper::SetFigures,
            py::arg("viewports_figures"))
       .def("clear_figures", &SimulateWrapper::ClearFigures)
-      .def("set_text", &SimulateWrapper::SetText,
+      .def("set_texts", &SimulateWrapper::SetTexts,
            py::arg("overlay_texts"))
-      .def("clear_text", &SimulateWrapper::ClearText)
+      .def("clear_texts", &SimulateWrapper::ClearTexts)
       .def("set_images", &SimulateWrapper::SetImages,
            py::arg("viewports_images"))
       .def("clear_images", &SimulateWrapper::ClearImages)

--- a/python/mujoco/simulate.cc
+++ b/python/mujoco/simulate.cc
@@ -91,6 +91,7 @@ class SimulateWrapper {
 
   void Destroy() {
     if (simulate_) {
+      ClearImages();
       delete simulate_;
       simulate_ = nullptr;
       destroyed_.store(1);
@@ -166,7 +167,7 @@ class SimulateWrapper {
     const std::vector<std::tuple<mjrRect, pybind11::array_t<unsigned char>>>& viewport_images
   ) {
     // Clear previous images to prevent memory leaks
-    simulate_->user_images_.clear();
+    ClearImages();
     
     for (const auto& [viewport, image] : viewport_images) {
       auto buf = image.request();
@@ -190,7 +191,13 @@ class SimulateWrapper {
     }
   }
 
-  void ClearImages() { simulate_->user_images_.clear(); }
+  void ClearImages() { 
+    // Free memory for each image before clearing the vector
+    for (const auto& [viewport, image_ptr] : simulate_->user_images_) {
+      delete[] image_ptr;
+    }
+    simulate_->user_images_.clear(); 
+  }
 
  private:
   mujoco::Simulate* simulate_;

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -25,10 +25,12 @@ import threading
 import time
 from typing import Callable, List, Optional, Tuple, Union
 import weakref
+
 import glfw
+import numpy as np
+
 import mujoco
 from mujoco import _simulate
-import numpy as np
 
 if not glfw._glfw:  # pylint: disable=protected-access
   raise RuntimeError('GLFW dynamic library handle is not available')
@@ -114,7 +116,9 @@ class Handle:
       return sim.viewport
     return None
 
-  def set_figures(self, viewports_figures: List[Tuple[mujoco.MjrRect, mujoco.MjvFigure]]):
+  def set_figures(
+      self, viewports_figures: List[Tuple[mujoco.MjrRect, mujoco.MjvFigure]]
+  ):
     sim = self._sim()
     if sim is not None:
       sim.set_figures(viewports_figures)
@@ -125,8 +129,8 @@ class Handle:
       sim.clear_figures()
 
   def overlay_text(self, overlay_texts: List[Tuple[int, int, str, str]]):
-    """ Overlay text on the viewer.
-    
+    """Overlay text on the viewer.
+
     Args:
       overlay_texts: List of tuples of (font, gridpos, text1, text2)
       let:
@@ -138,17 +142,21 @@ class Handle:
     sim = self._sim()
     if sim is not None:
       sim.overlay_text(overlay_texts)
-  
+
   def clear_overlay_text(self):
     sim = self._sim()
     if sim is not None:
       sim.clear_overlay_text()
 
-  def set_images(self, viewports_images: List[Tuple[mujoco.MjrRect, np.ndarray]]):
+  def set_images(
+      self, viewports_images: List[Tuple[mujoco.MjrRect, np.ndarray]]
+  ):
     sim = self._sim()
     if sim is not None:
       # Nearest neighbor resize
-      resize = lambda a, s: a[(np.arange(s[0]) * a.shape[0]) // s[0]][:, (np.arange(s[1]) * a.shape[1]) // s[1]]
+      resize = lambda a, s: a[(np.arange(s[0]) * a.shape[0]) // s[0]][
+          :, (np.arange(s[1]) * a.shape[1]) // s[1]
+      ]
       resized_viewports_images = []
       for viewport, image in viewports_images:
         targ_shape = (viewport.height, viewport.width)

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -23,9 +23,8 @@ import queue
 import sys
 import threading
 import time
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 import weakref
-
 import glfw
 import mujoco
 from mujoco import _simulate
@@ -115,7 +114,7 @@ class Handle:
       return sim.viewport
     return None
 
-  def set_figures(self, viewports_figures):
+  def set_figures(self, viewports_figures: List[Tuple[mujoco.MjrRect, mujoco.MjvFigure]]):
     sim = self._sim()
     if sim is not None:
       sim.set_figures(viewports_figures)
@@ -124,6 +123,45 @@ class Handle:
     sim = self._sim()
     if sim is not None:
       sim.clear_figures()
+
+  def overlay_text(self, overlay_texts: List[Tuple[int, int, str, str]]):
+    """ Overlay text on the viewer.
+    
+    Args:
+      overlay_texts: List of tuples of (font, gridpos, text1, text2)
+      let:
+        font: Font style from mujoco.mjtFontScale
+        gridpos: Position of text box from mujoco.mjtGridPos
+        text1: Left text column
+        text2: Right text column
+    """
+    sim = self._sim()
+    if sim is not None:
+      sim.overlay_text(overlay_texts)
+  
+  def clear_overlay_text(self):
+    sim = self._sim()
+    if sim is not None:
+      sim.clear_overlay_text()
+
+  def set_images(self, viewports_images: List[Tuple[mujoco.MjrRect, np.ndarray]]):
+    sim = self._sim()
+    if sim is not None:
+      # Nearest neighbor resize
+      resize = lambda a, s: a[(np.arange(s[0]) * a.shape[0]) // s[0]][:, (np.arange(s[1]) * a.shape[1]) // s[1]]
+      resized_viewports_images = []
+      for viewport, image in viewports_images:
+        targ_shape = (viewport.height, viewport.width)
+        resized = resize(image, targ_shape)
+        resized = np.flip(resized, axis=0)
+        resized = np.ascontiguousarray(resized)
+        resized_viewports_images.append((viewport, resized))
+      sim.set_images(resized_viewports_images)
+
+  def clear_images(self):
+    sim = self._sim()
+    if sim is not None:
+      sim.clear_images()
 
   def close(self):
     sim = self._sim()

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -27,10 +27,9 @@ from typing import Callable, List, Optional, Tuple, Union
 import weakref
 
 import glfw
-import numpy as np
-
 import mujoco
 from mujoco import _simulate
+import numpy as np
 
 if not glfw._glfw:  # pylint: disable=protected-access
   raise RuntimeError('GLFW dynamic library handle is not available')

--- a/python/mujoco/viewer.py
+++ b/python/mujoco/viewer.py
@@ -139,12 +139,12 @@ class Handle:
     if sim is not None:
       sim.clear_figures()
 
-  def set_text(self, overlay_texts: Union[Tuple[Optional[int], Optional[int], Optional[str], Optional[str]], 
+  def set_texts(self, texts: Union[Tuple[Optional[int], Optional[int], Optional[str], Optional[str]], 
                                             List[Tuple[Optional[int], Optional[int], Optional[str], Optional[str]]]]):
     """Overlay text on the viewer.
 
     Args:
-      overlay_texts: Single tuple or list of tuples of (font, gridpos, text1, text2)
+      texts: Single tuple or list of tuples of (font, gridpos, text1, text2)
         font: Font style from mujoco.mjtFontScale
         gridpos: Position of text box from mujoco.mjtGridPos
         text1: Left text column, defaults to empty string if None
@@ -153,8 +153,8 @@ class Handle:
     sim = self._sim()
     if sim is not None:
       # Convert single tuple to list if needed
-      if isinstance(overlay_texts, tuple):
-        overlay_texts = [overlay_texts]
+      if isinstance(texts, tuple):
+        texts = [texts]
       
       # Convert None values to empty strings
       default_font = mujoco.mjtFontScale.mjFONTSCALE_150
@@ -164,14 +164,14 @@ class Handle:
                         default_gridpos if gridpos is None else gridpos, 
                          "" if text1 is None else text1,
                          "" if text2 is None else text2)
-                        for font, gridpos, text1, text2 in overlay_texts]
+                        for font, gridpos, text1, text2 in texts]
       
-      sim.set_text(processed_texts)
+      sim.set_texts(processed_texts)
 
-  def clear_text(self):
+  def clear_texts(self):
     sim = self._sim()
     if sim is not None:
-      sim.clear_text()
+      sim.clear_texts()
 
   def set_images(
       self, viewports_images: Union[Tuple[mujoco.MjrRect, np.ndarray],

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -2606,7 +2606,7 @@ void Simulate::Render() {
   }
 
   // overlay text
-  for (auto& [font, gridpos, text1, text2] : this->user_text_) {
+  for (auto& [font, gridpos, text1, text2] : this->user_texts_) {
     ShowOverlayText(this, rect, font, gridpos, text1, text2);
   }
 

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -546,6 +546,14 @@ void ShowFigure(mj::Simulate* sim, mjrRect viewport, mjvFigure* fig){
   mjr_figure(viewport, fig, &sim->platform_ui->mjr_context());
 }
 
+void ShowOverlayText(mj::Simulate* sim, mjrRect viewport, int font, int gridpos, std::string text1, std::string text2){
+  mjr_overlay(font, gridpos, viewport, text1.c_str(), text2.c_str(), &sim->platform_ui->mjr_context());
+}
+
+void ShowImage(mj::Simulate* sim, mjrRect viewport, const unsigned char* image) {
+  mjr_drawPixels(image, nullptr, viewport, &sim->platform_ui->mjr_context());
+}
+
 // load state from history buffer
 static void LoadScrubState(mj::Simulate* sim) {
   // get index into circular buffer
@@ -2595,6 +2603,16 @@ void Simulate::Render() {
   // user figures
   for (auto& [viewport, figure] : this->user_figures_) {
     ShowFigure(this, viewport, &figure);
+  }
+
+  // overlay text
+  for (auto& [font, gridpos, text1, text2] : this->user_text_) {
+    ShowOverlayText(this, rect, font, gridpos, text1, text2);
+  }
+
+  // user images
+  for (auto& [viewport, image] : this->user_images_) {
+    ShowImage(this, viewport, image);
   }
 
   // finalize

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -249,7 +249,7 @@ class Simulate {
   mjvFigure figsize = {};
   mjvFigure figsensor = {};
 
-  // additional user-defined visualization geoms (used in passive mode)
+  // additional user-defined visualization
   mjvScene* user_scn = nullptr;
   mjtByte user_scn_flags_prev_[mjNRNDFLAG];
   std::vector<std::pair<mjrRect, mjvFigure>> user_figures_;

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -253,6 +253,8 @@ class Simulate {
   mjvScene* user_scn = nullptr;
   mjtByte user_scn_flags_prev_[mjNRNDFLAG];
   std::vector<std::pair<mjrRect, mjvFigure>> user_figures_;
+  std::vector<std::tuple<int, int, std::string, std::string>> user_text_;
+  std::vector<std::tuple<mjrRect, unsigned char*>> user_images_;
 
   // OpenGL rendering and UI
   int refresh_rate = 60;

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -253,7 +253,7 @@ class Simulate {
   mjvScene* user_scn = nullptr;
   mjtByte user_scn_flags_prev_[mjNRNDFLAG];
   std::vector<std::pair<mjrRect, mjvFigure>> user_figures_;
-  std::vector<std::tuple<int, int, std::string, std::string>> user_text_;
+  std::vector<std::tuple<int, int, std::string, std::string>> user_texts_;
   std::vector<std::tuple<mjrRect, unsigned char*>> user_images_;
 
   // OpenGL rendering and UI


### PR DESCRIPTION
See issue #2494 

Added the text and image overlay handles in the style of commit [37d759](https://github.com/google-deepmind/mujoco/commit/37d7591ce0d1424f6853dd9293eec1579c8e623f).

This supports:
[Brax PR 584](https://github.com/google/brax/pull/584)
[Playground PR 83](https://github.com/google-deepmind/mujoco_playground/pull/83)