### PR TITLE
Fix use-after-free during EGL shutdown

### DIFF
--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -65,6 +65,12 @@ def create_initialized_egl_device_display():
 EGL_DISPLAY = None
 
 
+def _free_display():
+    global EGL_DISPLAY
+    EGL.eglTerminate(EGL_DISPLAY)
+    EGL_DISPLAY = None
+
+
 EGL_ATTRIBUTES = (
     EGL.EGL_RED_SIZE, 8,
     EGL.EGL_GREEN_SIZE, 8,
@@ -99,7 +105,7 @@ class GLContext:
           "driver does not support the PLATFORM_DEVICE extension, which is "
           "required for creating a headless rendering context."
         )
-      atexit.register(EGL.eglTerminate, EGL_DISPLAY)
+      atexit.register(_free_display)
     EGL.eglChooseConfig(
         EGL_DISPLAY,
         EGL_ATTRIBUTES,
@@ -125,7 +131,7 @@ class GLContext:
   def free(self):
     """Frees resources associated with this context."""
     global EGL_DISPLAY
-    if self._context:
+    if EGL_DISPLAY and self._context:
       current_context = EGL.eglGetCurrentContext()
       if current_context and self._context.address == current_context.address:
         EGL.eglMakeCurrent(EGL_DISPLAY, EGL.EGL_NO_SURFACE,


### PR DESCRIPTION
`atexit` is used to `eglTerminate` the `EGL_DISPLAY` Any context created using that will fail in `glDestroyContext` because a stale display is used, i.e. one that was already terminated.

Avoid this by setting `EGL_DISPLAY` back to `None` after termination and checking for that before using.

This can be reproduced with `MUJOCO_GL=egl python -c 'import mujoco; c = mujoco.GLContext(1280, 960)'`

This throws:
```
Traceback (most recent call last):
  File "/data/cat/ws/s3248973-gputest/venv/lib/python3.11/site-packages/mujoco/egl/__init__.py", line 148, in __del__
  File "/data/cat/ws/s3248973-gputest/venv/lib/python3.11/site-packages/mujoco/egl/__init__.py", line 143, in free
  File "/data/cat/ws/s3248973-gputest/venv/lib/python3.11/site-packages/OpenGL/platform/baseplatform.py", line 488, in __call__
  File "/data/cat/ws/s3248973-gputest/venv/lib/python3.11/site-packages/OpenGL/error.py", line 231, in glCheckError
OpenGL.raw.EGL._errors.EGLError: <exception str() failed>
```