### PR TITLE
Fix dynamic GLFW dispatch

### DIFF
--- a/simulate/glfw_dispatch.cc
+++ b/simulate/glfw_dispatch.cc
@@ -59,7 +59,7 @@ const struct Glfw& Glfw(void* dlhandle) {
       glfw.func = reinterpret_cast<decltype(glfw.func)>(  \
           GetProcAddress(reinterpret_cast<HMODULE>(dlhandle), #func))
   #else
-    if (!dlhandle) dlhandle = dlopen("nullptr", RTLD_GLOBAL | RTLD_NOW);
+    if (!dlhandle) dlhandle = dlopen(nullptr, RTLD_GLOBAL | RTLD_NOW);
     if (!dlhandle) {
       std::cerr << "cannot obtain a shared object handle\n";
       abort();


### PR DESCRIPTION
This removes accidental quotes. With them a library "nullptr" would be tried to open which virtually never exists. With `nullptr` the current program is referenced which was likely intended