### PR TITLE
Add validation script for MuJoCo shared library under tools/

### DIFF
--- a/dist/tools/test_dist_validation.py
+++ b/dist/tools/test_dist_validation.py
@@ -1,0 +1,25 @@
+import os
+import ctypes
+
+def test_mujoco_library():
+    """
+    Validates whether the MuJoCo shared library exists and can be loaded.
+    Update the 'lib_path' according to your operating system.
+    """
+    # 👉 Change this path based on your OS
+    lib_path = "dist/bin/libmujoco.so"       # For Linux
+    # lib_path = "dist/bin/mujoco.dll"       # For Windows
+    # lib_path = "dist/bin/libmujoco.dylib"  # For macOS
+
+    if not os.path.exists(lib_path):
+        raise FileNotFoundError(f"Shared library not found at: {lib_path}")
+
+    try:
+        ctypes.CDLL(lib_path)
+        print(f"✅ MuJoCo library loaded successfully from: {lib_path}")
+    except OSError as e:
+        print("❌ Failed to load MuJoCo library")
+        raise e
+
+if __name__ == "__main__":
+    test_mujoco_library()


### PR DESCRIPTION
This pull request adds a utility script named `test_dist_validation.py` under a new `tools/` directory.

🔍 **Purpose**  
The script helps verify whether the MuJoCo shared library (`.so`, `.dll`, or `.dylib`) located in the `dist/bin/` directory exists and can be successfully loaded using Python’s `ctypes` module. This is useful for:
- Validating builds and prebuilt binaries across platforms (Linux, macOS, Windows)
- Debugging distribution issues
- Supporting development workflows and CI pipelines

📄 **How to Use**
1. Modify the `lib_path` variable in the script to match your platform:
   - `libmujoco.so` for Linux
   - `mujoco.dll` for Windows
   - `libmujoco.dylib` for macOS
2. Run the script using:
   ```bash
   python tools/test_dist_validation.py
