### PR TITLE
style(docs): use American English spelling per STYLEGUIDE

### DIFF
--- a/python/LQR.ipynb
+++ b/python/LQR.ipynb
@@ -298,7 +298,7 @@
    "source": [
     "## Stable standing on one leg\n",
     "\n",
-    "Clearly this initial pose is not stable. We'll try to find a stabilising control law using a [Linear Quadratic Regulator](https://en.wikipedia.org/wiki/Linear%E2%80%93quadratic_regulator)."
+    "Clearly this initial pose is not stable. We'll try to find a stabilizing control law using a [Linear Quadratic Regulator](https://en.wikipedia.org/wiki/Linear%E2%80%93quadratic_regulator)."
    ]
   },
   {
@@ -358,7 +358,7 @@
     "A = \\frac{\\partial f}{\\partial x} \\quad\n",
     "B = \\frac{\\partial f}{\\partial u}\n",
     "$$\n",
-    "In order to perform the linearization, we need to choose some setpoints $x$ and $u$ around which we will linearize. We already know $x$, this is our initial pose of standing on one leg. But what about $u$? How do we find the \"best\" control around which to linearise?\n",
+    "In order to perform the linearization, we need to choose some setpoints $x$ and $u$ around which we will linearize. We already know $x$, this is our initial pose of standing on one leg. But what about $u$? How do we find the \"best\" control around which to linearize?\n",
     "\n",
     "The answer is inverse dynamics."
    ]
@@ -786,7 +786,7 @@
    "source": [
     "### Stable standing\n",
     "\n",
-    "We can now try our stabilising controller.\n",
+    "We can now try our stabilizing controller.\n",
     "\n",
     "Note that in order to apply our gain matrix $K$, we need to use `mj_differentiatePos` which computes the difference of two positions. This is important because the root orientation is given by a length-4 quaternion, while the difference of two quaternions (in the tangent space) is length-3. In MuJoCo notation, positions (`qpos`) are of size `nq` while a position differences (and velocities) are of size `nv`.\n"
    ]
@@ -867,7 +867,7 @@
     "mujoco.mjv_defaultFreeCamera(model, camera)\n",
     "camera.distance = 2.3\n",
     "\n",
-    "# Enable contact force visualisation.\n",
+    "# Enable contact force visualization.\n",
     "scene_option = mujoco.MjvOption()\n",
     "scene_option.flags[mujoco.mjtVisFlag.mjVIS_CONTACTFORCE] = True\n",
     "\n",


### PR DESCRIPTION
This PR updates documentation and comments across several files to use American English spelling conventions, following the project's STYLEGUIDE.md.

**Changes:**
- `linearise` -> `linearize`
- `stabilising` -> `stabilizing`
- `visualisation` -> `visualization`