### PR TITLE
Fix(notebook): corrections in python/least_squares.ipynb

### DIFF
--- a/python/least_squares.ipynb
+++ b/python/least_squares.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "## Least Squares and the Gauss-Newton Hessian\n",
     "\n",
-    "Additional simplification is achieved by a structured objective: $f(x) = \\frac{1}{2} r(x)^T\\cdot r(x)$, which is called the *Least Squares* objective. The vector function $r(x): \\mathbb R^n \\rightarrow \\mathbb R^m$, is called the **residual**, and the optimization problem is referred to as *Nonlinear Least Squares*. For readers with a statistics background, the Least Squares problem lends itself to reinterpertation as **Maximum Likelihood Estimation** of a Gaussian posterior $x^* = \\arg \\max_x p(x)$ with $p(x) \\sim e^{-\\frac{1}{2}r(x)^Tr(x)}$. To see why the least-squares structure is beneficial, consider the gradient and Hessian of the objective. Letting $J$ be the $n \\times m$ **Jacobian** matrix of the residual $J = \\nabla r(x)$ we have\n",
+    "Additional simplification is achieved by a structured objective: $f(x) = \\frac{1}{2} r(x)^T\\cdot r(x)$, which is called the *Least Squares* objective. The vector function $r(x): \\mathbb R^n \\rightarrow \\mathbb R^m$, is called the **residual**, and the optimization problem is referred to as *Nonlinear Least Squares*. For readers with a statistics background, the Least Squares problem lends itself to reinterpretation as **Maximum Likelihood Estimation** of a Gaussian posterior $x^* = \\arg \\max_x p(x)$ with $p(x) \\sim e^{-\\frac{1}{2}r(x)^Tr(x)}$. To see why the least-squares structure is beneficial, consider the gradient and Hessian of the objective. Letting $J$ be the $n \\times m$ **Jacobian** matrix of the residual $J = \\nabla r(x)$ we have\n",
     "$$\n",
     "\\begin{align}\n",
     "g &= J^Tr\\\\\n",
@@ -329,12 +329,12 @@
    "source": [
     "## Implementation notes\n",
     "\n",
-    "1. The residual funciton must be vectorized: besides taking a column vector $x$ and returning the residual $r(x)$, it must accept an $n\\times k$ matrix $X$, returning an $m\\times k$ matrix $R$. The vectorized format is used by the internal finite-difference implementation and can be exploited to speed up the minimization by using multi-threading inside the residual function implementation.\n",
+    "1. The residual function must be vectorized: besides taking a column vector $x$ and returning the residual $r(x)$, it must accept an $n\\times k$ matrix $X$, returning an $m\\times k$ matrix $R$. The vectorized format is used by the internal finite-difference implementation and can be exploited to speed up the minimization by using multi-threading inside the residual function implementation.\n",
     "1. Bounds must be `None` or fully specified for all dimensions of $x$.\n",
     "1. The `jacobian` callback can be supplied by the user and is finite-differenced otherwise. Note that this callback is not made available in the case the user knows the analytic Jacobian (this is very rare in the sysID context), but in case the user wants to implement their own multi-threaded fin-diff callback.\n",
     "1. Automatic forward/backward differencing, chosen to avoid crossing the bounds, with optional central differencing. The fin-diff epsilon `eps` is scaled by the size of the bounds, if provided.\n",
     "1. The termination criterion is based on small step size $||\\delta x|| < \\textrm{tol}$.\n",
-    "1. We use the simple yet affective $\\mu$-search strategy described in [Bazaraa et-al.](https://onlinelibrary.wiley.com/doi/book/10.1002/0471787779). Backtracking $\\mu$-increases are *careful*, attempting to find the smallest $\\mu$ where sufficient reduction is found. $\\mu$-decreases are *aggressive*, allowing fast quadratic convergence to a local minimum.\n",
+    "1. We use the simple yet effective $\\mu$-search strategy described in [Bazaraa et-al.](https://onlinelibrary.wiley.com/doi/book/10.1002/0471787779). Backtracking $\\mu$-increases are *careful*, attempting to find the smallest $\\mu$ where sufficient reduction is found. $\\mu$-decreases are *aggressive*, allowing fast quadratic convergence to a local minimum.\n",
     "1. The user may optionally provide a `norm` different than the quadratic norm (the default), this is covered in more detail below."
    ]
   },
@@ -630,17 +630,17 @@
     "\n",
     "Forward kinematics means computing the Cartesian poses of articulated bodies, given joint angles. This computation is easy and well defined. Inverse Kinematics (IK) tries to do the opposite: Given a desired Cartesian pose of an articulated body (usually called the **end effector**), find the joint angles which put the end effector at this pose. The IK problem can easily be over or under determined:\n",
     "- Over-determined: The end effector cannot reach the desired pose at all, or can match either position or orientation, but not both.\n",
-    "- Under-detemined: The articulated chain has more than the minimum required number of degrees-of-freedom (dofs), so after reaching the target there is still a free subspace (imagine rotating your eblow while your hand and shoulder are fixed).\n",
+    "- Under-determined: The articulated chain has more than the minimum required number of degrees-of-freedom (dofs), so after reaching the target there is still a free subspace (imagine rotating your elbow while your hand and shoulder are fixed).\n",
     "\n",
-    "We adress both of these situations in our implementation below, but first mention features which are currently **not implemented**, but could be added in the future.\n",
-    "1. We currently support only one end-effector and target pose. Adding mutiple targets would be straightforward.\n",
+    "We address both of these situations in our implementation below, but first mention features which are currently **not implemented**, but could be added in the future.\n",
+    "1. We currently support only one end-effector and target pose. Adding multiple targets would be straightforward.\n",
     "2. Our implementation currently does not support quaternions in the kinematic chain (ball and free joints). Adding this is possible and would require a small modification to the `least_squares` function (explicit support for non-Cartesian tangent spaces).\n",
     "3. We only give examples with simple box bounds, which in the IK context means joint range limits. In order to take into account constraints like collision avoidance, one would need to make use of MuJoCo's constraint Jacobians. Please let us know if you'd like to see an example of this.\n",
     "\n",
     "## 7-dof arm\n",
     "\n",
     "Below, we copy the MuJoCo Menagerie's model of Franka's [Panda](https://github.com/google-deepmind/mujoco_menagerie/tree/main/franka_emika_panda#readme), with the following modifications:\n",
-    "1. Intergrated the [scene](https://github.com/google-deepmind/mujoco_menagerie/blob/main/universal_robots_ur5e/scene.xml) elements into a single XML.\n",
+    "1. Integrated the [scene](https://github.com/google-deepmind/mujoco_menagerie/blob/main/universal_robots_ur5e/scene.xml) elements into a single XML.\n",
     "2. Added a \"target\" mocap body and site with 3 colored, non-colliding geoms that overlap with the site frame."
    ]
   },
@@ -1365,7 +1365,7 @@
    "source": [
     "## Smooth motion\n",
     "\n",
-    "It is often the case that one wants to smoothly track a given end-effector trajectory. Let's invent some smooth traget trajectory:"
+    "It is often the case that one wants to smoothly track a given end-effector trajectory. Let's invent some smooth target trajectory:"
    ]
   },
   {
@@ -1523,7 +1523,7 @@
     "id": "fEvXhuv1TrUk"
    },
    "source": [
-    "This looks *much* better, but there are still a few \"glitches\". An esy way to mitigate those is to modify the regularization target to also be the previous solution. We are effectively telling the solver not to stray too far."
+    "This looks *much* better, but there are still a few \"glitches\". An easy way to mitigate those is to modify the regularization target to also be the previous solution. We are effectively telling the solver not to stray too far."
    ]
   },
   {
@@ -1949,7 +1949,7 @@
     "  \"\"\"Residual for target-reaching task.\n",
     "\n",
     "  Args:\n",
-    "    ctrl0T: contatenation of the first and last control vectors.\n",
+    "    ctrl0T: concatenation of the first and last control vectors.\n",
     "    target: target to which the right hand should reach.\n",
     "    T: final time for the rollout.\n",
     "    torque_scale: coefficient by which to scale the torques.\n",
@@ -2291,7 +2291,7 @@
     "id": "J0brs9pG0-8Y"
    },
    "source": [
-    "Now that we are confident in our implemetation, we can see what the solution looks like:"
+    "Now that we are confident in our implementation, we can see what the solution looks like:"
    ]
   },
   {


### PR DESCRIPTION
This PR corrects several spelling errors found within the `python/least_squares.ipynb` tutorial notebook.