### PR TITLE
fix(notebook): corrections in python notebooks

### DIFF
--- a/python/mjspec.ipynb
+++ b/python/mjspec.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "# <h1><center>Model Editing  <a href=\"https://colab.research.google.com/github/google-deepmind/mujoco/blob/main/python/mjspec.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" width=\"140\" align=\"center\"/></a></center></h1>\n",
     "\n",
-    "This notebook provides an introductory tutorial for model editing in MuJoCo using the `mjSpec` API. This notebook assumes that the reader is already familiar with MuJoCo basic concepts, as demostrated in the [introductory tutorial](https://github.com/google-deepmind/mujoco?tab=readme-ov-file#getting-started). Documentation for this API can be found in the [Model Editing](https://mujoco.readthedocs.io/en/latest/programming/modeledit.html) chapter in the documentation (C API) and in the [Python chapter](https://mujoco.readthedocs.io/en/latest/python.html#model-editing). Here we use the Python API.\n",
+    "This notebook provides an introductory tutorial for model editing in MuJoCo using the `mjSpec` API. This notebook assumes that the reader is already familiar with MuJoCo basic concepts, as demonstrated in the [introductory tutorial](https://github.com/google-deepmind/mujoco?tab=readme-ov-file#getting-started). Documentation for this API can be found in the [Model Editing](https://mujoco.readthedocs.io/en/latest/programming/modeledit.html) chapter in the documentation (C API) and in the [Python chapter](https://mujoco.readthedocs.io/en/latest/python.html#model-editing). Here we use the Python API.\n",
     "\n",
     "The goal of the API is to allow users to easily interact with and modify MuJoCo\n",
     "models in Python, similarly to what the JavaScript DOM does for HTML.\n",
@@ -635,7 +635,7 @@
    "outputs": [],
    "source": [
     "def add_hfield(spec=None, hsize=10, vsize=4):\n",
-    "  \"\"\" Function that adds a heighfield with countours\"\"\"\n",
+    "  \"\"\" Function that adds a height field with contours\"\"\"\n",
     "\n",
     "  # Initialize spec\n",
     "  if spec is None:\n",

--- a/python/rollout.ipynb
+++ b/python/rollout.ipynb
@@ -1599,7 +1599,7 @@
     "\n",
     "Here we will produce a similar plot to compare MJX and with `rollout`. On a 5800X3D and 4090 the benchmark takes about 16.5 minutes to run.\n",
     "\n",
-    "**Note:** These results are not directly comparable since with the plot in the documentation because, in particular, the batch size was redued from 8192 to 4096 in order to fit the batch on a 4090."
+    "**Note:** These results are not directly comparable since with the plot in the documentation because, in particular, the batch size was reduced from 8192 to 4096 in order to fit the batch on a 4090."
    ]
   },
   {


### PR DESCRIPTION
This PR corrects a couple of spelling errors (`demostrated` -> `demonstrated`, `redued` -> `reduced`, `countours` -> `contours`) found within the `python/rollout.ipynb` and `python/mjspec.ipynb` tutorial notebooks.