### PR TITLE
Solution to issue #2489

### DIFF
--- a/mjx/mujoco/mjx/_src/support.py
+++ b/mjx/mujoco/mjx/_src/support.py
@@ -1064,25 +1064,27 @@ def muscle_dynamics_timescale(
     smoothing_width: jax.Array,
 ) -> jax.Array:
   """Muscle time constant with optional smoothing."""
-  # hard switching
-  tau_hard = jp.where(dctrl > 0, tau_act, tau_deact)
+  def hard_switching(tau_deact, tau_act, dctrl, smoothing_width):
+    tau_hard = jp.where(dctrl > 0, tau_act, tau_deact)
+    return tau_hard
 
-  def _sigmoid(x):
-    # sigmoid function over 0 <= x <= 1 using quintic polynomial
-    # sigmoid: f(x) = 6 * x^5 - 15 * x^4 + 10 * x^3
-    # solution of f(0) = f'(0) = f''(0) = 0, f(1) = 1, f'(1) = f''(1) = 0
-    sol = x * x * x * (3 * x * (2 * x - 5) + 10)
-    sol = jp.where(x <= 0, 0, sol)
-    sol = jp.where(x >= 1, 1, sol)
-    return sol
+  def smooth_smoothing(tau_deact, tau_act, dctrl, smoothing_width):
+    def _sigmoid(x):
+      # sigmoid function over 0 <= x <= 1 using quintic polynomial
+      # sigmoid: f(x) = 6 * x^5 - 15 * x^4 + 10 * x^3
+      # solution of f(0) = f'(0) = f''(0) = 0, f(1) = 1, f'(1) = f''(1) = 0
+      sol = x * x * x * (3 * x * (2 * x - 5) + 10)
+      sol = jp.where(x <= 0, 0, sol)
+      sol = jp.where(x >= 1, 1, sol)
+      return sol
 
-  # smooth switching
-  # scale by width, center around 0.5 midpoint, rescale to bounds
-  tau_smooth = tau_deact + (tau_act - tau_deact) * _sigmoid(
-      dctrl / smoothing_width + 0.5
-  )
+    # scale by width, center around 0.5 midpoint, rescale to bounds
+    tau_smooth = tau_deact + (tau_act - tau_deact) * _sigmoid(
+        dctrl / smoothing_width + 0.5
+    )
+    return tau_smooth
 
-  return jp.where(smoothing_width < mujoco.mjMINVAL, tau_hard, tau_smooth)
+  return jax.lax.cond(smoothing_width < mujoco.mjMINVAL, hard_switching, smooth_smoothing, tau_deact, tau_act, dctrl, smoothing_width)
 
 
 def muscle_dynamics(


### PR DESCRIPTION
I believe this PR resolves issue #2489.

The solution is to perform code branching using the conditional control flow jax.lax.cond instead of jp.where.

From what I understand, jax.lax.cond only evaluates the branch that is used, whereas jp.where evaluates both the used and the unused branches. Consequently, if the unused branch has an NaN, this will cause a problem for jp.where (even though the branch is not executed) but not for jax.lax.cond. 

@Balint-H noted that the NaNs encountered in issue #2489 go away if tausmooth is set to a nonzero value. I believe this is because the computation of tau_smooth involves [dividing by smoothing_width](https://github.com/google-deepmind/mujoco/blob/a209134315dda126a714529bfa80f7478902644d/mjx/mujoco/mjx/_src/support.py#L1082), which gives NaN if smoothing_width = 0 (again, even if the smooth switching branch is not being executed).

If I perform branching with jax.lax.cond (as per this PR), the NaNs go away, even with tausmooth = 0.

To get the MWE provided in issue #2489 to work, I also had to replace jp.where with jax.lax.cond [here](https://github.com/google-deepmind/mujoco/blob/a209134315dda126a714529bfa80f7478902644d/mjx/mujoco/mjx/_src/collision_primitive.py#L118), again because it involves dividing by 0. I have included this change in my PR. More generally, there are quite a lot of jp.where calls in the mjx codebase, and I wonder if these should also be changed to jax.lax.cond?