### PR TITLE
Speed up ray mesh by taking minimum instead of appending all distances

### DIFF
--- a/mjx/mujoco/mjx/_src/ray.py
+++ b/mjx/mujoco/mjx/_src/ray.py
@@ -207,15 +207,16 @@ def _ray_mesh(
     dist = jax.vmap(_ray_triangle, in_axes=(0, None, None, None))(
         vert, pnt[i], vec[i], basis[i]
     )
-    dists.append(dist)
-    geom_ids.append(np.repeat(geom_id[i], dist.size))
+    dists.append(jp.min(dist))
+    geom_ids.append(geom_id[i])
 
-  dists = jp.concatenate(dists)
+  dists = jp.array(dists)
   min_id = jp.argmin(dists)
   # Grab the best distance amongst all meshes, bypassing the argmin in `ray`.
   # This avoids having to compute the best distance per mesh.
   dist = dists[min_id, None]
-  id_ = jp.array(np.concatenate(geom_ids))[min_id, None]
+  geom_ids_array = jp.array(geom_ids)
+  id_ = geom_ids_array[min_id, None]
 
   return dist, id_
 


### PR DESCRIPTION
I was using the `ray_mesh` code and found that it is appending all the distances from every triangle in the geom. Would it be more efficient if we append only the minimum of the distances (along with the corresponding id) rather than all the distances and ids? It might seem small but could easily add up with complicated mesh geoms having hundreds of thousands of triangles overall.

Changes:
- Append the minimum distance instead of all distances (and the geom_id only once)
- Obtain the minimum dist from the smaller array containing minimum distances instead of the array of all distances