### PR TITLE
Add note to docs regarding sensor information

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -5941,6 +5941,7 @@ corresponding to body accelerations and interaction forces. Some of these quanti
 certain sensors (force, acceleration etc.) but even if no such sensors are defined in the model, these quantities
 themselves are "features" that could be of interest to the user.
 
+Note that the sensor outputs are all provided per simulation timestep. This means that if you simulate `n` times from the last control input until the next one, the sensor output will only show the last timestep.
 
 .. _sensor-touch:
 

--- a/doc/computation/index.rst
+++ b/doc/computation/index.rst
@@ -1721,6 +1721,8 @@ Force/acceleration
 The stages below compute quantities that depend on :ref:`user inputs<geInput>`. Due to the sequential nature
 of the pipeline, the actual dependence is on the entire :ref:`integration state<geIntegrationState>`.
 
+Note that the sensor outputs are all provided per simulation timestep. This means that if you simulate `n` times from the last control input until the next one, the sensor output will only show the last timestep.
+
 19. Compute the actuator forces and activation dynamics if defined: :ref:`mj_fwdActuation`
 20. Compute the joint acceleration resulting from all forces except for the (still unknown) constraint forces:
     :ref:`mj_fwdAcceleration`


### PR DESCRIPTION
I encountered an issue when using Mujoco Playground, where the simulation would be run `n` times between each control input, where `n = ctrl_dt / sim_dt`.

This made the sensor data obtained a bit confusing, and there was no mention of this as a potential issue in any of the docs.
Hence I made a note with this PR.

The original issue which led me to this was #2596.