### PR TITLE
mjvGeom: comment about mesh IDs

### DIFF
--- a/include/mujoco/mjvisualize.h
+++ b/include/mujoco/mjvisualize.h
@@ -226,7 +226,8 @@ typedef struct mjvGLCamera_ mjvGLCamera;
 struct mjvGeom_ {                 // abstract geom
   // type info
   int      type;                  // geom type (mjtGeom)
-  int      dataid;                // mesh, hfield or plane id; -1: none
+  int      dataid;                // mesh, hfield or plane id; -1: none; mesh: (id * 2 or id 2 + 1 (convex hull))
+
   int      objtype;               // mujoco object type; mjOBJ_UNKNOWN for decor
   int      objid;                 // mujoco object id; -1 for decor
   int      category;              // visual category


### PR DESCRIPTION
Updates the comment for ``dataid`` within ``mjvGeom``. When drawing meshes via [``mjv_initGeom``](https://github.com/google-deepmind/mujoco/blob/main/src/engine/engine_vis_visualize.c#L393), it is unclear how to draw meshes as no examples or documentation exist apart from the comment in [``mujoco/src/engine/engine_vis_visualize.c``](https://github.com/google-deepmind/mujoco/blob/2386dfd7da41dc4f97e5d3d00bef4f130047c2c3/src/engine/engine_vis_visualize.c#L1375).