### PR TITLE
Use errno.h instead of sys/errno.h

### DIFF
--- a/simulate/main.cc
+++ b/simulate/main.cc
@@ -39,7 +39,7 @@ extern "C" {
   #if defined(__APPLE__)
     #include <mach-o/dyld.h>
   #endif
-  #include <sys/errno.h>
+  #include <errno.h>
   #include <unistd.h>
 #endif
 }


### PR DESCRIPTION
As warnings are treated as errors, including `sys/errno.h` fails with musl libc: https://git.musl-libc.org/cgit/musl/tree/include/sys/errno.h

Including `errno.h` should be sufficient.