### PR TITLE
Fix(engine_util_solve): potentially overflowing call to snprintf

### DIFF
--- a/src/engine/engine_util_solve.c
+++ b/src/engine/engine_util_solve.c
@@ -1388,11 +1388,15 @@ int mju_boxQPoption(mjtNum* res, mjtNum* R, int* index,               // outputs
 
     // print iteration info
     if (log) {
-      logptr += snprintf(log+logptr, logsz-logptr,
-                         "iter %-3d:  |grad|: %-8.2g  reduction: %-8.2g  improvement: %-8.4g  "
-                         "linesearch: %g^%-2d  factorized: %d  nfree: %d\n",
-                         iter+1, mju_sqrt(norm2), oldvalue-value, improvement,
-                         backtrack, nstep-1, factorize, nfree);
+      int n = snprintf(log+logptr, logsz-logptr,
+                       "iter %-3d:  |grad|: %-8.2g  reduction: %-8.2g  improvement: %-8.4g  "
+                       "linesearch: %g^%-2d  factorized: %d  nfree: %d\n",
+                       iter+1, mju_sqrt(norm2), oldvalue-value, improvement,
+                       backtrack, nstep-1, factorize, nfree);
+      if (n < 0 || n >= logsz - logptr) {
+        break;  // Stop logging if buffer is exceeded
+      }
+      logptr += n;
     }
 
     // accept candidate
@@ -1406,9 +1410,13 @@ int mju_boxQPoption(mjtNum* res, mjtNum* R, int* index,               // outputs
 
   // print final info
   if (log) {
-    snprintf(log+logptr, logsz-logptr, "BOXQP: %s.\n"
-             "iterations= %d,  factorizations= %d,  |grad|= %-12.6g, final value= %-12.6g\n",
-             status_string[status+1], iter, nfactor, mju_sqrt(norm2), value);
+    int n = snprintf(log+logptr, logsz-logptr, "BOXQP: %s.\n"
+                     "iterations= %d,  factorizations= %d,  |grad|= %-12.6g, final value= %-12.6g\n",
+                     status_string[status+1], iter, nfactor, mju_sqrt(norm2), value);
+    if (n < 0 || n >= logsz - logptr) {
+      return;  // Stop logging if buffer is exceeded
+    }
+    logptr += n;
   }
 
   // return nf or -1 if failure


### PR DESCRIPTION
https://github.com/google-deepmind/mujoco/blob/fe81373ffe7e648a5cecef16c8cb72dac38fcfa6/src/engine/engine_util_solve.c#L1391-L1411

Fix the issue, the return value of `snprintf` should be checked to ensure that the formatted string fits within the remaining buffer space. If the return value indicates that the buffer size is exceeded, the code should handle this gracefully, such as by truncating the log message or stopping further logging.

The fix involves:
1. Capturing the return value of `snprintf`.
2. Validating the return value to ensure it is non-negative and does not exceed the remaining buffer size (`logsz-logptr`).
3. Breaking out of the logging loop or truncating the log message if the buffer size is exceeded.


The return value of a call to `snprintf` is the number of characters that would have been written to the buffer assuming there was sufficient space. In the event that the operation reaches the end of the buffer and more than one character is discarded, the return value will be greater than the buffer size. This can cause incorrect behavior.

```c
#define BUF_SIZE (32)

int main(int argc, char *argv[])
{
	char buffer[BUF_SIZE];
	size_t pos = 0;
	int i;

	for (i = 0; i < argc; i++)
	{
		pos += snprintf(buffer + pos, BUF_SIZE - pos, "%s", argv[i]);
			// BUF_SIZE - pos may overflow
	}
}
```

#### References
[snprintf](http://www.cplusplus.com/reference/cstdio/snprintf/)
[The trouble with snprintf](https://access.redhat.com/blogs/766093/posts/1976193)

