### PR TITLE
Declare runtime dependency on typing_extensions

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "glfw",
     "numpy",
     "pyopengl",
+    "typing_extensions",
 ]
 dynamic = ["readme", "scripts"]
 


### PR DESCRIPTION
It is not only a development dependency. It is needed by `python/mujoco/__init__.py` at runtime.