### PR TITLE
Fix AccumulateInertia

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -1739,9 +1739,9 @@ void mjCBody::AccumulateInertia(const mjsBody* other, mjsBody* result) {
   // body_ipose = body_pose * body_ipose
   double other_ipos[3];
   double other_iquat[4];
-  mjuu_copyvec(other_ipos, other->ipos, 3);
-  mjuu_copyvec(other_iquat, other->iquat, 4);
-  mjuu_frameaccum(other_ipos, other_iquat, other->pos, other->quat);
+  mjuu_copyvec(other_ipos, other->pos, 3);
+  mjuu_copyvec(other_iquat, other->quat, 4);
+  mjuu_frameaccum(other_ipos, other_iquat, other->ipos, other->iquat);
 
   // organize data
   double mass[2] = {


### PR DESCRIPTION
The modification is based on the implementation of the [`changeframe` function](https://github.com/google-deepmind/mujoco/blob/9089059517bb313f873787ab3b408ed9df05bccc/src/user/user_model.cc#L3821):

```C++
// change frame to parent body
static void changeframe(double childpos[3], double childquat[4],
                        const double bodypos[3], const double bodyquat[4]) {
  double pos[3], quat[4];
  mjuu_copyvec(pos, bodypos, 3);
  mjuu_copyvec(quat, bodyquat, 4);
  mjuu_frameaccum(pos, quat, childpos, childquat);
  mjuu_copyvec(childpos, pos, 3);
  mjuu_copyvec(childquat, quat, 4);
}
```
This bug can cause incorrect inertia visualization.