### PR TITLE
add MUJOCO_USE_SYSTEM_TINYXML2 CMake option

### DIFF
--- a/cmake/MujocoDependencies.cmake
+++ b/cmake/MujocoDependencies.cmake
@@ -149,24 +149,30 @@ target_include_directories(
 target_compile_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
 target_link_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 
-set(tinyxml2_BUILD_TESTING OFF)
-findorfetch(
-  USE_SYSTEM_PACKAGE
-  OFF
-  PACKAGE_NAME
-  tinyxml2
-  LIBRARY_NAME
-  tinyxml2
-  GIT_REPO
-  https://github.com/leethomason/tinyxml2.git
-  GIT_TAG
-  ${MUJOCO_DEP_VERSION_tinyxml2}
-  TARGETS
-  tinyxml2
-  EXCLUDE_FROM_ALL
-)
-target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
+option(TINYXML2_USE_SYSTEM_PACKAGE "Use the system's tinyxml2" OFF)
+if(TINYXML2_USE_SYSTEM_PACKAGE)
+  find_package(tinyxml2 REQUIRED)
+  add_library(tinyxml2 ALIAS tinyxml2::tinyxml2)
+else()
+  set(tinyxml2_BUILD_TESTING OFF)
+  findorfetch(
+    USE_SYSTEM_PACKAGE
+    OFF
+    PACKAGE_NAME
+    tinyxml2
+    LIBRARY_NAME
+    tinyxml2
+    GIT_REPO
+    https://github.com/leethomason/tinyxml2.git
+    GIT_TAG
+    ${MUJOCO_DEP_VERSION_tinyxml2}
+    TARGETS
+    tinyxml2
+    EXCLUDE_FROM_ALL
+  )
+  target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
+  target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
+endif()
 
 findorfetch(
   USE_SYSTEM_PACKAGE

--- a/cmake/MujocoDependencies.cmake
+++ b/cmake/MujocoDependencies.cmake
@@ -150,26 +150,25 @@ target_compile_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
 target_link_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 
 option(MUJOCO_USE_SYSTEM_TINYXML2 "Use the system's tinyxml2" OFF)
+set(tinyxml2_BUILD_TESTING OFF)
+findorfetch(
+  USE_SYSTEM_PACKAGE
+  ${MUJOCO_USE_SYSTEM_TINYXML2}
+  PACKAGE_NAME
+  tinyxml2
+  LIBRARY_NAME
+  tinyxml2
+  GIT_REPO
+  https://github.com/leethomason/tinyxml2.git
+  GIT_TAG
+  ${MUJOCO_DEP_VERSION_tinyxml2}
+  TARGETS
+  tinyxml2
+  EXCLUDE_FROM_ALL
+)
 if(MUJOCO_USE_SYSTEM_TINYXML2)
-  find_package(tinyxml2 REQUIRED)
   add_library(tinyxml2 ALIAS tinyxml2::tinyxml2)
 else()
-  set(tinyxml2_BUILD_TESTING OFF)
-  findorfetch(
-    USE_SYSTEM_PACKAGE
-    OFF
-    PACKAGE_NAME
-    tinyxml2
-    LIBRARY_NAME
-    tinyxml2
-    GIT_REPO
-    https://github.com/leethomason/tinyxml2.git
-    GIT_TAG
-    ${MUJOCO_DEP_VERSION_tinyxml2}
-    TARGETS
-    tinyxml2
-    EXCLUDE_FROM_ALL
-  )
   target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
   target_link_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 endif()

--- a/cmake/MujocoDependencies.cmake
+++ b/cmake/MujocoDependencies.cmake
@@ -149,8 +149,8 @@ target_include_directories(
 target_compile_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
 target_link_options(qhullstatic_r PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
 
-option(TINYXML2_USE_SYSTEM_PACKAGE "Use the system's tinyxml2" OFF)
-if(TINYXML2_USE_SYSTEM_PACKAGE)
+option(MUJOCO_USE_SYSTEM_TINYXML2 "Use the system's tinyxml2" OFF)
+if(MUJOCO_USE_SYSTEM_TINYXML2)
   find_package(tinyxml2 REQUIRED)
   add_library(tinyxml2 ALIAS tinyxml2::tinyxml2)
 else()


### PR DESCRIPTION
This PR introduces a CMake option ~~TINYXML2_USE_SYSTEM_PACKAGE~~ MUJOCO_USE_SYSTEM_TINYXML2 (default OFF) to allow users to link against a system-provided installation (via find_package(tinyxml2 REQUIRED)) of tinyxml2 instead of always fetching and building MuJoCo’s bundled copy.

Motivation:

If the client program also uses tinyxml2 e.g. links to the system's version of tinyxml2, symbol clashes can occur, especially if the versions are slightly different, which leads to crashes.