### PR TITLE
Fix mjcPhysics plugin cmake

### DIFF
--- a/src/experimental/usd/CMakeLists.txt
+++ b/src/experimental/usd/CMakeLists.txt
@@ -175,6 +175,8 @@ add_library(${MJC_PHYSICS_PLUGIN_TARGET_NAME} SHARED)
 target_sources(${MJC_PHYSICS_PLUGIN_TARGET_NAME} PRIVATE
   mjcPhysics/actuatorAPI.cpp
   mjcPhysics/collisionAPI.cpp
+  mjcPhysics/jointAPI.cpp
+  mjcPhysics/keyframe.cpp
   mjcPhysics/meshCollisionAPI.cpp
   mjcPhysics/sceneAPI.cpp
   mjcPhysics/siteAPI.cpp


### PR DESCRIPTION
Recently added joints and keyframes were missing from the cpp listing