### PR TITLE
Fix crash in python usd.exporter for geoms with invalid names

### DIFF
--- a/python/mujoco/usd/exporter.py
+++ b/python/mujoco/usd/exporter.py
@@ -25,6 +25,7 @@ import mujoco.usd.shapes as shapes_module
 import numpy as np
 from PIL import Image as im
 from PIL import ImageOps
+import re
 
 # TODO: b/288149332 - Remove once USD Python Binding works well with pytype.
 # pytype: disable=module-attr
@@ -517,6 +518,10 @@ class USDExporter:
       geom_name += "_geom"
     elif geom.objtype == mujoco.mjtObj.mjOBJ_TENDON:
       geom_name += f"_tendon_segid{geom.segid}"
+
+    # Collapse duplicate/leading/trailing slashes in geom names (e.g. /robot//arm/)
+    # Valid in mujoco, not valid for USD file and will cause a crash
+    geom_name = re.sub(r'/+', '/', geom_name.strip('/'))
 
     return geom_name
 


### PR DESCRIPTION
Geom names with odd slash placement (e.g. "robot//arm") are valid in mujoco and in the XML format, but are not valid in the USD format and will cause the exporter to crash with an invalid path error.

`Error in 'pxrInternal_v0_25_5__pxrReserved__::UsdStage::_IsValidPathForCreatingPrim' at line 3771 in file /Users/runner/work/OpenUSD/OpenUSD/pxr/usd/usd/stage.cpp : 'Path must be an absolute path: <>'`

This PR adds a regex substitution to the exporter to get rid of leading/trailing/duplicate slashes in geom names.

Has the possible edge case of geoms vanishing from the final usd file if two separate geoms use the same name with extra slashes (e.g. "robot/box" and "robot//box"), which render as separate geoms in mujoco.