### PR TITLE
Makes busy wait in thread pool optional to prevent unnecessary high cpu loads 

### DIFF
--- a/doc/APIreference/functions.rst
+++ b/doc/APIreference/functions.rst
@@ -2903,6 +2903,15 @@ Adds a thread pool to mjData and configures it for multi-threaded use.
 
 Enqueue a task in a thread pool.
 
+.. _mju_threadPoolSetBusyWait:
+
+`mju_threadPoolSetBusyWait <#mju_threadPoolSetBusyWait>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. mujoco-include:: mju_threadPoolSetBusyWait
+
+Set whether the thread pool should busy-wait for its task queue. Set to 1 to busy-wait, or 0 to use sleep.
+
 .. _mju_threadPoolDestroy:
 
 `mju_threadPoolDestroy <#mju_threadPoolDestroy>`__

--- a/doc/includes/references.h
+++ b/doc/includes/references.h
@@ -3420,6 +3420,7 @@ const mjpResourceProvider* mjp_getResourceProvider(const char* resource_name);
 const mjpResourceProvider* mjp_getResourceProviderAtSlot(int slot);
 mjThreadPool* mju_threadPoolCreate(size_t number_of_threads);
 void mju_bindThreadPool(mjData* d, void* thread_pool);
+void mju_threadPoolSetBusyWait(mjThreadPool* thread_pool, int busy_wait);
 void mju_threadPoolEnqueue(mjThreadPool* thread_pool, mjTask* task);
 void mju_threadPoolDestroy(mjThreadPool* thread_pool);
 void mju_defaultTask(mjTask* task);

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -1429,6 +1429,9 @@ MJAPI void mju_bindThreadPool(mjData* d, void* thread_pool);
 // Enqueue a task in a thread pool.
 MJAPI void mju_threadPoolEnqueue(mjThreadPool* thread_pool, mjTask* task);
 
+// Set whether the thread pool should use busy-waiting for its task queue.
+MJAPI void mju_threadPoolSetBusyWait(mjThreadPool* thread_pool, int busy_wait);
+
 // Destroy a thread pool.
 MJAPI void mju_threadPoolDestroy(mjThreadPool* thread_pool);
 

--- a/python/mujoco/introspect/functions.py
+++ b/python/mujoco/introspect/functions.py
@@ -8911,6 +8911,24 @@ FUNCTIONS: Mapping[str, FunctionDecl] = dict([
          ),
          doc='Enqueue a task in a thread pool.',
      )),
+    ('mju_threadPoolSetBusyWait',
+     FunctionDecl(
+         name='mju_threadPoolSetBusyWait',
+         return_type=ValueType(name='void'),
+         parameters=(
+             FunctionParameterDecl(
+                 name='thread_pool',
+                 type=PointerType(
+                     inner_type=ValueType(name='mjThreadPool'),
+                 ),
+             ),
+             FunctionParameterDecl(
+                 name='busy_wait',
+                 type=ValueType(name='int'),
+             ),
+         ),
+         doc='Set whether the thread pool should busy-waiting for its task queue.',
+     )),
     ('mju_threadPoolDestroy',
      FunctionDecl(
          name='mju_threadPoolDestroy',

--- a/src/thread/thread_pool.cc
+++ b/src/thread/thread_pool.cc
@@ -129,6 +129,10 @@ class ThreadPoolImpl : public mjThreadPool {
     thread_pool_bound_ = true;
   }
 
+  void SetQueueBusyWait(int busy_wait) {
+    lockless_queue_.SetBusyWait(busy_wait > 0);
+  }
+
   ~ThreadPoolImpl() { Shutdown(); }
 
  private:
@@ -276,6 +280,11 @@ size_t mju_threadPoolNumberOfThreads(mjThreadPool* thread_pool) {
 size_t mju_threadPoolCurrentWorkerId(mjThreadPool* thread_pool) {
   auto thread_pool_impl = static_cast<ThreadPoolImpl*>(thread_pool);
   return thread_pool_impl->GetWorkerId();
+}
+
+void mju_threadPoolSetBusyWait(mjThreadPool* thread_pool, int busy_wait) {
+  auto thread_pool_impl = static_cast<ThreadPoolImpl*>(thread_pool);
+  thread_pool_impl->SetQueueBusyWait(busy_wait);
 }
 
 // start a task in the threadpool

--- a/src/thread/thread_pool.h
+++ b/src/thread/thread_pool.h
@@ -65,6 +65,9 @@ MJAPI size_t mju_threadPoolCurrentWorkerId(mjThreadPool* thread_pool);
 // Enqueue a task in a thread pool.
 MJAPI void mju_threadPoolEnqueue(mjThreadPool* thread_pool, mjTask* task);
 
+// Set whether the thread pool should use busy-waiting for its task queue.
+MJAPI void mju_threadPoolSetBusyWait(mjThreadPool* thread_pool, int busy_wait);
+
 // Locks the allocation mutex to protect Arena allocations.
 MJAPI void mju_threadPoolLockAllocMutex(mjThreadPool* thread_pool);
 


### PR DESCRIPTION
Using a thread pool with $n > 1$ workers substantially raises the CPU usage. This is mainly due to the worker queue using `std::this_thread::yield` [right here](https://github.com/google-deepmind/mujoco/blob/7d5b360dea2d5a45eef1ae3e71536b5d8b5860a1/src/thread/thread_queue.h#L94C29-L94C34).
Especially in a nearly idle simulation state (e.g. when pausing in Simulate-like programs), this unnecessarily increases CPU load with $n$ cores at 100% load. 

My proposed solution is to introduce an option to toggle busy waiting, which would opt for `std::this_thread::sleep` if disabled. This would retain the option to use `yield` instead of `sleep` if speed is more important. Although, I think that sleeping should be the default fit for most use cases.

Let me know your thoughts on this