### PR TITLE
align contact frame to cylinder for sphere-cylinder side collisions

### DIFF
--- a/src/engine/engine_collision_primitive.c
+++ b/src/engine/engine_collision_primitive.c
@@ -354,7 +354,23 @@ int mjc_SphereCylinder(const mjModel* m, const mjData* d,
   // side collision: use sphere-sphere
   if (collide_side) {
     mju_addTo3(a_proj, pos2);
-    return mjraw_SphereSphere(con, margin, pos1, mat1, size1, a_proj, mat2, size2);
+    int ncon = mjraw_SphereSphere(con, margin, pos1, mat1, size1, a_proj, mat2, size2);
+    if (ncon) {
+      // align contact frame: 
+      //    z-axis = contact normal
+      //    y-axis = normal X cylinder axis
+      //    x-axis = y-axis X normal
+      // contact frame defined by z-axis and x-axis
+      mjtNum x_axis[3];
+      mjtNum y_axis[3];
+      mjtNum normal[3] = {con->frame[0], con->frame[1], con->frame[2]};
+      mju_cross(y_axis, normal, axis);  // y-axis = normal X cylinder z-axis
+      mju_normalize3(y_axis);
+      mju_cross(x_axis, y_axis, normal); // x-axis = y-axis X normal
+      mju_normalize3(x_axis);
+      mju_copy(con->frame + 3, x_axis, 3);  // copy x-axis into contact frame
+    }
+    return ncon;
   }
 
   // cap collision: use plane-sphere


### PR DESCRIPTION
This proposed change makes it so that when the side of a cylinder is in contact with a sphere, the contact frame is aligned to the axis of the cylinder. Otherwise, the contact frame seems to have arbitrary alignment because the code simulates a virtual sphere-sphere collision which zeros-out the second axis in the contact frame. The motivation for this change is to make it easier to simulate anisotropic friction on cylinders in contact with spheres. I also opened a discussion about this [here](https://github.com/google-deepmind/mujoco/discussions/2749), but it is so far unanswered:

## Before (inconsistent contact frame alignment):
<img width="1193" height="839" alt="before" src="https://github.com/user-attachments/assets/25e477e8-46d1-4180-bda6-95e23fe3c0ee" />

## After (x-axis of contact frame aligned to z-axis of the cylinder):
<img width="628" height="679" alt="after" src="https://github.com/user-attachments/assets/7d18560d-1129-4f1f-88ad-9db96d530080" />
