### PR TITLE
Add override_existing flag for plugin loader

### DIFF
--- a/include/mujoco/mjplugin.h
+++ b/include/mujoco/mjplugin.h
@@ -182,4 +182,14 @@ typedef struct mjSDF_ mjSDF;
 // function pointer type for mj_loadAllPluginLibraries callback
 typedef void (*mjfPluginLibraryLoadCallback)(const char* filename, int first, int count);
 
+// MODIFIED: Updated function signature to support override_existing parameter
+// load plugins from a dynamic library
+void mj_loadPluginLibrary(const char* path, int override_existing);
+
+// MODIFIED: Updated function signature to support override_existing parameter
+// scan a directory and load all dynamic libraries
+void mj_loadAllPluginLibraries(const char* directory,
+                               mjfPluginLibraryLoadCallback callback,
+                               int override_existing);
+
 #endif  // MUJOCO_INCLUDE_MJPLUGIN_H_


### PR DESCRIPTION
This PR adds an optional `override_existing` flag to:
- mj_loadPluginLibrary
- mj_loadAllPluginLibraries

It allows overriding plugins with the same name that are already registered.