### PR TITLE
Fix quat not used inside composite

### DIFF
--- a/src/user/user_composite.cc
+++ b/src/user/user_composite.cc
@@ -318,7 +318,7 @@ mjsBody* mjCComposite::AddCableBody(mjCModel* model, mjsBody* body, int ix,
                                     double normal[3], double prev_quat[4]) {
   char txt_geom[100], txt_site[100], txt_slide[100];
   char this_body[100], next_body[100], this_joint[100];
-  double dquat[4], this_quat[4];
+  double rquat[4], dquat[4], this_quat[4];
 
   // set flags
   int lastidx = count[0]-2;
@@ -346,6 +346,8 @@ mjsBody* mjCComposite::AddCableBody(mjCModel* model, mjsBody* body, int ix,
 
   // update moving frame
   double length = mjuu_updateFrame(this_quat, normal, edge, tprev, tnext, first);
+  mjuu_mulquat(rquat, quat, this_quat);
+  mjuu_copyvec(this_quat, rquat, 4);
 
   // create body, joint, and geom names
   if (first) {

--- a/test/user/user_composite_test.cc
+++ b/test/user/user_composite_test.cc
@@ -70,5 +70,32 @@ TEST_F(UserCompositeTest, InvalidShape) {
               HasSubstr("The curve array contains an invalid shape"));
 }
 
+TEST_F(UserCompositeTest, QuatRotation) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <composite type="cable" quat="0 0 1 0" initial="none" vertex="
+            0.00  0.   0.
+            0.01  0.   0.
+            0.02  0.   0.
+            0.03  0.   0.
+            0.04  0.   0.">
+        <geom  type="box" size="0.005 0.005 0.005" rgba=".8 .2 .1 1" group="3"/> 
+      </composite>
+    </worldbody>
+  </mujoco>
+  )";
+  std::array<char, 1024> error;
+  mjModel* m = LoadModelFromString(xml, error.data(), error.size());
+  mjData* d = mj_makeData(m);
+  mj_forward(m, d);
+  int body_id = mj_name2id(m, mjOBJ_BODY, "B_first");
+  const double* q = d->xquat + body_id*4;
+  EXPECT_THAT(q[0], ::testing::DoubleEq(0.0));
+  EXPECT_THAT(q[1], ::testing::DoubleEq(0.0));
+  EXPECT_THAT(q[2], ::testing::DoubleEq(1.0));
+  EXPECT_THAT(q[3], ::testing::DoubleEq(0.0));
+}
+
 }  // namespace
 }  // namespace mujoco


### PR DESCRIPTION
# Motivation
`composite` object has parameter `quat`. But it is not actually used anywhere when create the objects. On the contrary, `offset` parameter are used as real off set to all sub objects. So with a reasonable guess, the `quat` should be also used to rotate each sub objects.

# How to reproduce
Simply create a composite and assign a nontrivial `quat`, you will see no rotation is applied.

# Fix
In this patch, an extra rotation is applied to each sub objects. Tests are added for simple checking.