### PR TITLE
Use localtime_r when __linux__ is defined

### DIFF
--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -197,7 +197,7 @@ static void mju_localTimeStr(char* buf, int buf_sz) {
   struct tm timeinfo;
   time(&rawtime);
 
-#if defined(_POSIX_C_SOURCE) || defined(__APPLE__) || defined(__STDC_VERSION_TIME_H__) || defined(__EMSCRIPTEN__)
+#if defined(_POSIX_C_SOURCE) || defined(__APPLE__) || defined(__STDC_VERSION_TIME_H__) || defined(__EMSCRIPTEN__) || defined(__linux__)
   localtime_r(&rawtime, &timeinfo);
 #elif defined(_WIN32)
   localtime_s(&timeinfo, &rawtime);


### PR DESCRIPTION
This is another fix required when using musl libc on Alpine Linux. `_POSIX_C_SOURCE` is not defined automatically. Using `__linux__` helps with this. An alternative would be to define `_POSIX_C_SOURCE` ourselves.