### PR TITLE
Tiny fix of the incorrect `humanoid.keys` reference

### DIFF
--- a/python/mjspec.ipynb
+++ b/python/mjspec.ipynb
@@ -2000,7 +2000,7 @@
     "\n",
     "# Delete all key frames to avoid name conflicts\n",
     "while humanoid.keys:\n",
-    "  humanoid.delete(keys[-1])\n",
+    "  humanoid.delete(humanoid.keys[-1])\n",
     "\n",
     "# Create a grid of humanoids by attaching humanoid to spec multiple times\n",
     "for i in range(4):\n",


### PR DESCRIPTION
Fix of a small bug in the mjspec.ipynb notebook

`keys` is used instead of `humanoid.keys`. It leads to the name error `name 'keys' is not defined`