### PR TITLE
Add fixed_iterations option to MJX solver

### DIFF
--- a/mjx/mujoco/mjx/_src/solver.py
+++ b/mjx/mujoco/mjx/_src/solver.py
@@ -598,6 +598,19 @@ def solve(m: Model, d: Data) -> Data:
   ctx = Context.create(m, d)
   if m.opt.iterations == 1:
     ctx = body(ctx)
+
+  elif hasattr(m.opt, 'fixed_iterations') and m.opt.fixed_iterations is not None:
+  # Use fori_loop with static bounds for gradient compatibility
+   def fixed_body_fn(i, ctx):
+    return body(ctx)
+  
+  # This loop runs exactly fixed_iterations times
+   ctx = jax.lax.fori_loop(
+      0, m.opt.fixed_iterations,
+      fixed_body_fn,
+      ctx
+  )  
+    
   else:
     ctx = jax.lax.while_loop(cond, body, ctx)
 

--- a/mjx/mujoco/mjx/_src/solver_test.py
+++ b/mjx/mujoco/mjx/_src/solver_test.py
@@ -25,6 +25,7 @@ from mujoco.mjx._src.types import ConeType
 import numpy as np
 
 
+
 # tolerance for difference between MuJoCo and MJX solver calculations,
 # mostly due to float precision
 _TOLERANCE = 5e-3

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -18,6 +18,7 @@ import enum
 from typing import Tuple, Union
 import warnings
 
+from typing import Optional
 import jax
 import mujoco
 from mujoco.mjx._src.dataclasses import PyTreeNode  # pylint: disable=g-importing-member
@@ -483,6 +484,7 @@ class OptionJAX(PyTreeNode):
   disableactuator: int
   sdf_initpoints: int
   has_fluid_params: bool
+  fixed_iterations: Optional[int] = None 
 
 
 class OptionC(PyTreeNode):


### PR DESCRIPTION
# Add fixed_iterations option to MJX solver

## Purpose
This PR adds a new `fixed_iterations` option to the MJX solver that allows specifying a fixed number of iterations for the solver to use, bypassing the default convergence criteria.

## Why This is Useful
1. **Deterministic Behavior**: Using a fixed number of iterations ensures the solver always performs the same amount of work, making simulations more deterministic.

2. **Gradient-Based Optimization**: When using MJX for gradient-based optimization, the number of iterations in the solver can cause discontinuities in the gradient landscape. Fixed iterations helps create smoother gradients.

3. **Performance Tuning**: Allows users to explicitly control the computational cost vs. accuracy tradeoff.

## Implementation
1. Added a new `fixed_iterations` field to the `OptionJAX` class in `types.py` with a default value of `None`.
2. Modified the solver logic in `solver.py` to check for this parameter and use `jax.lax.fori_loop` with static bounds when it's set.
3.Made necessary modifications to maintain compatibility with existing code
4. The implementation maintains the original behavior when `fixed_iterations` is not specified.

## Usage Example
```python
from mujoco.mjx import load_model_from_xml
from mujoco.mjx.physics import Physics

# Load model
model = load_model_from_xml(xml_string)

# Set fixed iterations
model.opt.fixed_iterations = 4

# Create physics and run simulation
physics = Physics.from_model(model)
state = physics.step(physics.state)