### PR TITLE
Update plugin loading to specify winmode for CDLL call

### DIFF
--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -207,7 +207,7 @@ def _load_all_bundled_plugins():
   for directory, _, filenames in os.walk(PLUGINS_DIR):
     for filename in filenames:
       if os.path.splitext(filename)[-1] in [".dll", ".dylib", ".so"]:
-        PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename)))
+        PLUGIN_HANDLES.append(ctypes.CDLL(os.path.join(directory, filename), winmode=0))
       elif filename == "__init__.py":
         pass
       else:


### PR DESCRIPTION
Currently in `__init__.py` no `winmode` is specified, which can result in DLL loading issues on Windows: https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python/64472088#64472088

Specifying `winmode=0` uses a traditional Windows DLL search order. We think this could fix issues like #2275 