### PR TITLE
Avoid memcpy-ing to nullptrs in simulate

### DIFF
--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -2269,20 +2269,22 @@ void Simulate::LoadOnRenderThread() {
   ncam_ = this->m_->ncam;
   nkey_ = this->m_->nkey;
   body_parentid_.resize(this->m_->nbody);
-  std::memcpy(body_parentid_.data(), this->m_->body_parentid,
-              sizeof(this->m_->body_parentid[0]) * this->m_->nbody);
+  if (this->m_->nbody) {
+    std::memcpy(body_parentid_.data(), this->m_->body_parentid,
+                sizeof(this->m_->body_parentid[0]) * this->m_->nbody);
+  }
 
   jnt_type_.resize(this->m_->njnt);
-  std::memcpy(jnt_type_.data(), this->m_->jnt_type,
-              sizeof(this->m_->jnt_type[0]) * this->m_->njnt);
-
   jnt_group_.resize(this->m_->njnt);
-  std::memcpy(jnt_group_.data(), this->m_->jnt_group,
-              sizeof(this->m_->jnt_group[0]) * this->m_->njnt);
-
   jnt_qposadr_.resize(this->m_->njnt);
-  std::memcpy(jnt_qposadr_.data(), this->m_->jnt_qposadr,
-              sizeof(this->m_->jnt_qposadr[0]) * this->m_->njnt);
+  if (this->m_->njnt > 0) {
+    std::memcpy(jnt_type_.data(), this->m_->jnt_type,
+                sizeof(this->m_->jnt_type[0]) * this->m_->njnt);
+    std::memcpy(jnt_group_.data(), this->m_->jnt_group,
+                sizeof(this->m_->jnt_group[0]) * this->m_->njnt);
+    std::memcpy(jnt_qposadr_.data(), this->m_->jnt_qposadr,
+                sizeof(this->m_->jnt_qposadr[0]) * this->m_->njnt);
+  }
 
   jnt_range_.clear();
   jnt_range_.reserve(this->m_->njnt);
@@ -2302,8 +2304,10 @@ void Simulate::LoadOnRenderThread() {
   }
 
   actuator_group_.resize(this->m_->nu);
-  std::memcpy(actuator_group_.data(), this->m_->actuator_group,
-              sizeof(this->m_->actuator_group[0]) * this->m_->nu);
+  if (this->m_->nu) {
+    std::memcpy(actuator_group_.data(), this->m_->actuator_group,
+                sizeof(this->m_->actuator_group[0]) * this->m_->nu);
+  }
 
   actuator_ctrlrange_.clear();
   actuator_ctrlrange_.reserve(this->m_->nu);
@@ -2329,15 +2333,21 @@ void Simulate::LoadOnRenderThread() {
   }
 
   qpos_.resize(this->m_->nq);
-  std::memcpy(qpos_.data(), this->d_->qpos, sizeof(this->d_->qpos[0]) * this->m_->nq);
+  if (this->m_->nq) {
+    std::memcpy(qpos_.data(), this->d_->qpos, sizeof(this->d_->qpos[0]) * this->m_->nq);
+  }
   qpos_prev_ = qpos_;
 
   ctrl_.resize(this->m_->nu);
-  std::memcpy(ctrl_.data(), this->d_->ctrl, sizeof(this->d_->ctrl[0]) * this->m_->nu);
+  if (this->m_->nu) {
+    std::memcpy(ctrl_.data(), this->d_->ctrl, sizeof(this->d_->ctrl[0]) * this->m_->nu);
+  }
   ctrl_prev_ = ctrl_;
 
   eq_active_.resize(this->m_->neq);
-  std::memcpy(eq_active_.data(), this->d_->eq_active, sizeof(this->d_->eq_active[0]) * this->m_->neq);
+  if (this->m_->neq) {
+    std::memcpy(eq_active_.data(), this->d_->eq_active, sizeof(this->d_->eq_active[0]) * this->m_->neq);
+  }
   eq_active_prev_ = eq_active_;
 
   // allocate history buffer: smaller of {2000 states, 100 MB}


### PR DESCRIPTION
This change fixes a case in simulate.cc where `std::memcpy` could be invoked with a nullptr as the destination pointer. While the size argument would be zero in these cases, passing a null pointer to memcpy is still undefined behavior according to the C++ standard.

The updated logic ensures that memcpy is only called when both the destination pointer is valid and the number of bytes to copy is nonzero. This prevents potential undefined behavior and improves robustness.


Though it is very unlikely that anyone would load a model with `nbody=0`, `njnt=0`, and/or `nq=0`, I've still added guards for the respective memcpy calls, additionally to the much more realistic `neq=0` and `nu=0` ones. 