### PR TITLE
Add Rust bindings to MuJoCo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ These packages give users of various languages access to MuJoCo functionality:
 - **Swift**: [swift-mujoco](https://github.com/liuliu/swift-mujoco)
 - **Java**: [mujoco-java](https://github.com/CommonWealthRobotics/mujoco-java)
 - **Julia**: [MuJoCo.jl](https://github.com/JamieMair/MuJoCo.jl)
+- **Rust**: [MuJoCo-rs](https://github.com/davidhozic/mujoco-rs), includes: a native viewer, renderer, views (joint, geom, etc.).
 
 ### Converters
 


### PR DESCRIPTION
Adds a link to Rust  MuJoCo bindings, [MuJoCo-rs](https://github.com/davidhozic/mujoco-rs).

The bindings include high-level constructions, such as views into joint, geom, etc., attributes, a native viewer, renderer, and other higher-level wrappers around base bindings.

Soon, model editing will be supported too, currently it's missing getters and setters for moat elements.