### PR TITLE
Add `mjtMeshInertia` to API Reference/Types documentation

### DIFF
--- a/doc/APIreference/APItypes.rst
+++ b/doc/APIreference/APItypes.rst
@@ -695,6 +695,16 @@ Type of inertia inference.
 
 .. mujoco-include:: mjtGeomInertia
 
+
+.. _mjtMeshInertia:
+
+mjtMeshInertia
+~~~~~~~~~~~~~~
+
+Type of mesh inertia.
+
+.. mujoco-include:: mjtMeshInertia
+
 .. _mjtBuiltin:
 
 mjtBuiltin


### PR DESCRIPTION
Adds the missing type `mjtMeshInertia` to API Reference/Types section of the documentation.