### PR TITLE
BUGFIX: Adds a fix for parsing gridlayout

### DIFF
--- a/src/xml/xml_native_reader.cc
+++ b/src/xml/xml_native_reader.cc
@@ -3264,6 +3264,7 @@ void mjXReader::Asset(XMLElement* section, const mjVFS* vfs) {
           throw mjXError(elem, "gridlayout length must match gridsize");
         }
 
+        memset(texture->gridlayout, 0, sizeof(texture->gridlayout));
         memcpy(texture->gridlayout, text.data(), text.length());
       }
 

--- a/test/xml/xml_native_reader_test.cc
+++ b/test/xml/xml_native_reader_test.cc
@@ -1967,6 +1967,26 @@ TEST_F(XMLReaderTest, ResizeKeyframeAfterParsing) {
   mj_deleteVFS(vfs.get());
 }
 
+TEST_F(XMLReaderTest, CheckTextureGridlayoutParsing) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <asset>
+      <texture name="test_skybox" type="skybox" file="dummy_image.png" gridsize="2 4" gridlayout="LFRB.D.."/>
+    </asset>
+  </mujoco>
+  )";
+
+  std::array<char, 1024> error;
+  mjSpec* spec = mj_parseXMLString(xml, 0, error.data(), error.size());
+  EXPECT_THAT(spec, NotNull()) << error.data();
+  auto skybox_spec = mjs_asTexture(mjs_findElement(spec, mjOBJ_TEXTURE, "test_skybox"));
+  EXPECT_THAT(skybox_spec, NotNull()) << error.data();
+  EXPECT_EQ(std::strlen(skybox_spec->gridlayout), 8);
+  EXPECT_TRUE(std::strcmp(skybox_spec->gridlayout, "LFRB.D..") == 0);
+
+  mj_deleteSpec(spec);
+}
+
 // ----------------------- test camera parsing ---------------------------------
 
 TEST_F(XMLReaderTest, CameraInvalidFovyAndSensorsize) {


### PR DESCRIPTION
- Resets the `gridlayout` string to zeros with `memset` to avoid taking the extra characters that are not copied when using `memcpy` with a shorter string
- Adds a test for this when using `mjSpec`

Here is a short Python script that uses `mjSpec`. Note that after saving the model the `gridlayout` string in the XML file contains some extra dots, instead of the value `LFRB.D..` it gets the value `LLFRB.D......`.

```python
from pathlib import Path

import mujoco as mj

CURRENT_DIR = Path(__file__).parent

SKYBOX_NAME = "SkyOakland"

XML_STRING = """
<mujoco model="test-scene">
  <visual>
    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
    <rgba haze="0.15 0.25 0.35 1"/>
    <global azimuth="120" elevation="-20"/>
  </visual>

  <asset>
    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
    <texture name="SkyOakland" type="skybox" file="{texname}" gridsize="2 4" gridlayout="LFRB.D.."/>
    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
      markrgb="0.8 0.8 0.8" width="300" height="300"/>
    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
  </asset>

  <worldbody>
    <light pos="1 -1 1.5" dir="-1 1 -1" diffuse="0.5 0.5 0.5" directional="true"/>
    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
  </worldbody>
</mujoco>
"""


def main() -> int:
    skybox_texture_path = CURRENT_DIR / f"{SKYBOX_NAME}.png"
    model_str = XML_STRING.format(texname=skybox_texture_path.as_posix())

    spec: mj.MjSpec = mj.MjSpec.from_string(model_str)
    print(f"gridlayout: {spec.texture(SKYBOX_NAME).gridlayout}")
    print(f"gridsize: {spec.texture(SKYBOX_NAME).gridsize}")

    _ = spec.compile()
    test_model_path = CURRENT_DIR / "test_model.xml"
    with open(test_model_path, "w") as fhandle:
        fhandle.write(spec.to_xml())

    try:
        _ = mj.MjModel.from_xml_path(test_model_path.as_posix())
    except Exception as e:
        print(f"Got error while opening the saved model: {e}")

    return 0


if __name__ == "__main__":
    raise SystemExit(main())

```


I ran into this issue when using mjSpec to convert a scene that contained a skybox. Here's an [example](https://github.com/wpumacay/mujoco/blob/9be2d5f50a095ffad0f46f9800ffeddbae45b738/test/wilbert/cpp/test_gridlayout.cpp#L1) in C++. When printing the `gridlayout` field it prints the string with the extra `.` characters