### PR TITLE
Fix MJSpec tutorial undefined variable in random humanoid poses

### DIFF
--- a/python/mjspec.ipynb
+++ b/python/mjspec.ipynb
@@ -2000,7 +2000,7 @@
     "\n",
     "# Delete all key frames to avoid name conflicts\n",
     "while humanoid.keys:\n",
-    "  humanoid.delete(keys[-1])\n",
+    "  humanoid.delete(humanoid.keys[-1])\n",
     "\n",
     "# Create a grid of humanoids by attaching humanoid to spec multiple times\n",
     "for i in range(4):\n",


### PR DESCRIPTION
In the MJSpec tutorial under the "Humanoid with randomized heads and arm poses", the code tries to delete key frames using an undefined `keys` variable. This is meant to refer to the `humanoid` spec key frames. Changed to `humanoid.keys`.