### PR TITLE
Clarify mjs_addDefault usage and document correct default class naming

### DIFF
--- a/doc/includes/references.h
+++ b/doc/includes/references.h
@@ -3463,6 +3463,10 @@ mjsTuple* mjs_addTuple(mjSpec* s);
 mjsKey* mjs_addKey(mjSpec* s);
 mjsPlugin* mjs_addPlugin(mjSpec* s);
 mjsDefault* mjs_addDefault(mjSpec* s, const char* classname, const mjsDefault* parent);
+// Example usage:
+// mjs_addDefault(spec, "myclass", parent);  // Named default
+// mjs_addDefault(spec, nullptr, parent);     // Only for the root unnamed default
+mjsDefault* mjs_addDefault(mjSpec* s, const char* classname, const mjsDefault* parent);
 const char* mjs_setToMotor(mjsActuator* actuator);
 const char* mjs_setToPosition(mjsActuator* actuator, double kp, double kv[1],
                               double dampratio[1], double timeconst[1], double inheritrange);

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -1566,6 +1566,10 @@ MJAPI mjsPlugin* mjs_addPlugin(mjSpec* s);
 
 // Add default.
 // Nullable: parent
+// Add a default class to the model. Pass a non-null classname for named defaults; only one unnamed default is allowed at the top level.
+// Example usage:
+// mjs_addDefault(spec, "myclass", parent);  // Named default
+// mjs_addDefault(spec, nullptr, parent);     // Only for the root unnamed default
 MJAPI mjsDefault* mjs_addDefault(mjSpec* s, const char* classname, const mjsDefault* parent);
 
 

--- a/src/user/user_api.h
+++ b/src/user/user_api.h
@@ -157,7 +157,10 @@ MJAPI mjsKey* mjs_addKey(mjSpec* s);
 // Add plugin.
 MJAPI mjsPlugin* mjs_addPlugin(mjSpec* s);
 
-// Add default.
+// Add a default class to the model. Pass a non-null classname for named defaults; only one unnamed default is allowed at the top level.
+// Example usage:
+// mjs_addDefault(spec, "myclass", parent);  // Named default
+// mjs_addDefault(spec, nullptr, parent);     // Only for the root unnamed default
 MJAPI mjsDefault* mjs_addDefault(mjSpec* s, const char* classname, const mjsDefault* parent);
 
 


### PR DESCRIPTION
This PR updates the documentation and header comments for the mjs_addDefault function to clarify its correct usage. It now explicitly states that only one unnamed default is allowed at the top level, and all other defaults should be named by passing a non-null classname. Example usage is also provided.

This is in regard to issue https://github.com/google-deepmind/mujoco/issues/2707

Changes:

Added a descriptive comment and example usage for mjs_addDefault in:
references.h
mujoco.h
user_api.h
Clarifies that only one unnamed default is allowed at the top level.
Shows how to use named and unnamed defaults correctly.
Motivation:
This change helps prevent user errors and invalid XML generation by making the API contract explicit in the documentation and headers. It addresses confusion around unnamed defaults and ensures users follow MuJoCo’s requirements for default classes.

Checklist:

 Documentation updated
 Example usage provided
 No breaking changes to API