### PR TITLE
BUGFIX: when parsing a unity scene with mujoco element,s the mujoco p…

### DIFF
--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -121,7 +121,7 @@ public struct MjcfOptionFlag {
     mjcf.SetAttribute("frictionloss", FrictionLoss.ToString());
     mjcf.SetAttribute("limit", Limit.ToString());
     mjcf.SetAttribute("contact", Contact.ToString());
-    mjcf.SetAttribute("passive", Passive.ToString());
+   // mjcf.SetAttribute("passive", Passive.ToString());
     mjcf.SetAttribute("gravity", Gravity.ToString());
     mjcf.SetAttribute("clampctrl", ClampCtrl.ToString());
     mjcf.SetAttribute("warmstart", WarmStart.ToString());


### PR DESCRIPTION
…ackage generates a value for the attribute "passive", but the attribute has been droped, it is not valid anymore in unity 3.3.6

this makes old mujoco scenes that work in unity not work anymore when upgrading the mujoco version.