### PR TITLE
FIX: HeightField import crashes Unity plugin

### DIFF
--- a/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
+++ b/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
@@ -91,6 +91,10 @@ public class MjHeightFieldShape : IMjShape {
 
     mjcf.SetAttribute("hfield", assetName);
     PrepareHeightMap();
+    if (MinimumHeight <= 0) {
+      Debug.Log($"Adjusting MinimumHeight from {MinimumHeight} to 0.01f for MuJoCo compatibility");
+      MinimumHeight = 0.01f;
+    }
   }
 
   public void FromMjcf(XmlElement mjcf) {

--- a/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
+++ b/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
@@ -112,7 +112,7 @@ public class MjHeightFieldShape : IMjShape {
 
     RenderTexture.active = null;
     if (ExportImage) {
-      if (minimumHeight > 0.0001)
+      if (minimumHeight < 0.0001)
         Debug.LogWarning("Due to assumptions in MuJoCo heightfields, terrains should have a " +
                          "minimum heightmap value of 0.");
       File.WriteAllBytes(FullHeightMapPath, texture.EncodeToPNG());

--- a/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
+++ b/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
@@ -92,7 +92,7 @@ public class MjHeightFieldShape : IMjShape {
     mjcf.SetAttribute("hfield", assetName);
     PrepareHeightMap();
     if (MinimumHeight <= 0) {
-      Debug.Log($"Adjusting MinimumHeight from {MinimumHeight} to 0.01f for MuJoCo compatibility");
+      // Unity imports hfields with min height = 0, which MuJoCo can't handle
       MinimumHeight = 0.01f;
     }
   }

--- a/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
+++ b/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
@@ -93,7 +93,8 @@ public class MjHeightFieldShape : IMjShape {
     PrepareHeightMap();
     if (MinimumHeight <= 0) {
       // Unity imports hfields with min height = 0, which MuJoCo can't handle
-      MinimumHeight = 0.01f;
+      // Use a small fraction of max height, or a small constant
+      MinimumHeight = Mathf.Max(0.0001f, MaximumHeight * 0.0001f);
     }
   }
 

--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -51,7 +51,11 @@ public class MjMeshFilter : MonoBehaviour {
     Tuple<Vector3[], int[]> meshData = _geom.BuildMesh();
     if (meshData == null)
     {
-      throw new ArgumentException("Unsupported geom shape detected");
+      Debug.LogWarning(
+          $"[Mujoco] Unsupported geom shape detected on '{gameObject.name}' (type: {_geom.ShapeType}). " +
+          "Skipping mesh generation."
+      );
+      return;
     }
 
     DisposeCurrentMesh();

--- a/unity/Runtime/Components/Shapes/MjMeshFilter.cs
+++ b/unity/Runtime/Components/Shapes/MjMeshFilter.cs
@@ -52,7 +52,7 @@ public class MjMeshFilter : MonoBehaviour {
     if (meshData == null)
     {
       Debug.LogWarning(
-          $"[Mujoco] Unsupported geom shape detected on '{gameObject.name}' (type: {_geom.ShapeType}). " +
+          $"Unsupported geom shape detected on '{gameObject.name}' (type: {_geom.ShapeType}). " +
           "Skipping mesh generation."
       );
       return;


### PR DESCRIPTION
Importing height fields with the Unity plugin causes the program to crash. Fixes issue in discussion #2824 

Fixed:
- MjHeightFieldShape.BuildMesh() returns null, which crashed the program
- Unity imports height fields with 0 minimum depth, which crashes mujoco
- The condition which is supposed to check for this had the incorrect inequality, making this issue difficult to debug

Changes:
- MjMeshFilter: Replace exception with graceful null handling when BuildMesh() returns null (e.g., for HeightFields)
- MjHeightFieldShape: Dynamically set minimum height as a function of maximum height
- MjHeightFieldShape: Change direction of inequality to trigger properly

Testing:
- Ran all included tests, 11 were failing with current release
- No new failures with my changes
- I have these outputs saved, if required

Note: This is my first PR on an open-source project. Please feel free to share any feedback you may have, as it will help me make better contributions in the future. Thanks!