### PR TITLE
Fix Python binding compilation when enable MUJOCO_WITH_USD

### DIFF
--- a/include/mujoco/experimental/usd/utils.h
+++ b/include/mujoco/experimental/usd/utils.h
@@ -22,12 +22,12 @@ namespace mujoco {
 namespace usd {
 
 // Sets a user value on an mjsElement with the key "usd_primpath".
-void SetUsdPrimPathUserValue(mjsElement* element,
+MJAPI void SetUsdPrimPathUserValue(mjsElement* element,
                              const pxr::SdfPath& prim_path);
 
 // Gets the user value associated with the key "usd_primpath" from an
 // mjsElement. Returns empty pxr::SdfPath() if the value is not found.
-pxr::SdfPath GetUsdPrimPathUserValue(mjsElement* element);
+MJAPI pxr::SdfPath GetUsdPrimPathUserValue(mjsElement* element);
 
 }  // namespace usd
 }  // namespace mujoco


### PR DESCRIPTION
When building MuJoCo with enable MUJOCO_WITH_USD, the Python bindings fail to compile due to missing MJAPI declarations on USD utility functions. This occurs because the USD utility functions in include/mujoco/experimental/usd/utils.h are not properly exported when building the shared library.