### PR TITLE
Fix incorrect method name in WASM demo app #2960

### DIFF
--- a/wasm/demo_app/app.ts
+++ b/wasm/demo_app/app.ts
@@ -208,7 +208,7 @@ class App {
     // Write xml as a file so that mujoco can find it
     (mujoco as any).FS.writeFile('/working/model.xml', xmlContent);
 
-    this.mjModel = mujoco.MjModel.loadFromXML('/working/model.xml');
+    this.mjModel = mujoco.MjModel.mj_loadXML('/working/model.xml');
     if (!app.mjModel) {
       throw new Error('Failed to load model');
     }


### PR DESCRIPTION
https://github.com/google-deepmind/mujoco/issues/2960
Replace loadFromXML with mj_loadXML to match the correct API method name in MjModel. The previous method name was incorrect and would cause the model loading to fail.

This fixes model loading in the WASM demo application.