### PR TITLE
Enable energy for warp

### DIFF
--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -234,7 +234,6 @@ def _put_option(
   for i in range(mujoco.mjtEnableBit.mjNENABLE):
     if o.enableflags & 2**i and 2 ** i not in set(types.EnableBit):
       raise NotImplementedError(f'{mujoco.mjtEnableBit(2**i)}')
-  
   if o.enableflags & types.EnableBit.ENERGY and impl == types.Impl.JAX:
     raise NotImplementedError('ENERGY enable flag not implemented for JAX backend.')
   

--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -236,7 +236,7 @@ def _put_option(
       raise NotImplementedError(f'{mujoco.mjtEnableBit(2**i)}')
   if o.enableflags & types.EnableBit.ENERGY and impl == types.Impl.JAX:
     raise NotImplementedError('ENERGY enable flag not implemented for JAX backend.')
-  
+
   fields = {
       f.name: getattr(o, f.name, None)
       for f in types.Option.fields()

--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -234,7 +234,10 @@ def _put_option(
   for i in range(mujoco.mjtEnableBit.mjNENABLE):
     if o.enableflags & 2**i and 2 ** i not in set(types.EnableBit):
       raise NotImplementedError(f'{mujoco.mjtEnableBit(2**i)}')
-
+  
+  if o.enableflags & types.EnableBit.ENERGY and impl == types.Impl.JAX:
+    raise NotImplementedError('ENERGY enable flag not implemented for JAX backend.')
+  
   fields = {
       f.name: getattr(o, f.name, None)
       for f in types.Option.fields()

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -95,6 +95,7 @@ class EnableBit(enum.IntFlag):
   # required by the C implementation only, ignored otherwise: MULTICCD
   MULTICCD = mujoco.mjtEnableBit.mjENBL_MULTICCD
   SLEEP = mujoco.mjtEnableBit.mjENBL_SLEEP
+  ENERGY = mujoco.mjtEnableBit.mjENBL_ENERGY
 
 
 class JointType(enum.IntEnum):

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -91,8 +91,9 @@ class EnableBit(enum.IntFlag):
   """
 
   INVDISCRETE = mujoco.mjtEnableBit.mjENBL_INVDISCRETE
-  # unsupported: OVERRIDE, ENERGY, FWDINV, ISLAND
+  # unsupported: OVERRIDE, FWDINV, ISLAND
   # required by the C implementation only, ignored otherwise: MULTICCD
+  # ENERGY: supported by C and warp implementation, unsupported by jax.
   ENERGY = mujoco.mjtEnableBit.mjENBL_ENERGY
   MULTICCD = mujoco.mjtEnableBit.mjENBL_MULTICCD
   SLEEP = mujoco.mjtEnableBit.mjENBL_SLEEP

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -93,9 +93,9 @@ class EnableBit(enum.IntFlag):
   INVDISCRETE = mujoco.mjtEnableBit.mjENBL_INVDISCRETE
   # unsupported: OVERRIDE, ENERGY, FWDINV, ISLAND
   # required by the C implementation only, ignored otherwise: MULTICCD
+  ENERGY = mujoco.mjtEnableBit.mjENBL_ENERGY
   MULTICCD = mujoco.mjtEnableBit.mjENBL_MULTICCD
   SLEEP = mujoco.mjtEnableBit.mjENBL_SLEEP
-  ENERGY = mujoco.mjtEnableBit.mjENBL_ENERGY
 
 
 class JointType(enum.IntEnum):


### PR DESCRIPTION
I noticed that energy is implemented in MJW but can not be enabled due to missing type. This will fix that.