### PR TITLE
Add missing option 'quadratic' to dof brackets

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -3565,7 +3565,7 @@ saving the XML:
 
 .. _body-flexcomp-dof:
 
-:at:`dof`: :at-val:`[full, radial, trilinear], "full"`
+:at:`dof`: :at-val:`[full, radial, trilinear, quadratic], "full"`
    The parametrization of the flex's degrees of freedom (dofs). See the video on the right illustrating the
    different parametrizations with deformable spheres. The three models in the video are respectively
    `sphere_full <https://github.com/google-deepmind/mujoco/blob/main/model/flex/sphere_full.xml>`__,


### PR DESCRIPTION
The added 'quadratic' option was only added in the body of the [``body/flexcomp/dof``](https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-flexcomp) documentation.

This also adds it to the brackets of available options.