### PR TITLE
Fix WASM demo app to use mj_loadXML instead of deprecated loadFromXML

### DIFF
--- a/wasm/demo_app/app.ts
+++ b/wasm/demo_app/app.ts
@@ -208,7 +208,7 @@ class App {
     // Write xml as a file so that mujoco can find it
     (mujoco as any).FS.writeFile('/working/model.xml', xmlContent);
 
-    this.mjModel = mujoco.MjModel.loadFromXML('/working/model.xml');
+    this.mjModel = mujoco.MjModel.mj_loadXML('/working/model.xml');
     if (!app.mjModel) {
       throw new Error('Failed to load model');
     }


### PR DESCRIPTION
The demo app was using the old loadFromXML API which was renamed to mj_loadXML in commit https://github.com/google-deepmind/mujoco/commit/49394d57d9827ccfeebdf585542e559691c0cb50 (Nov 19, 2025) as part of a broader effort to align WASM bindings with native C API naming conventions.

This change updates the demo to use the current API, fixing the error:
`TypeError: mujoco.MjModel.loadFromXML is not a function`

Fixes https://github.com/google-deepmind/mujoco/issues/2960