### PR TITLE
Appended MacOS specific information to Getting Started docs

### DIFF
--- a/doc/programming/index.rst
+++ b/doc/programming/index.rst
@@ -62,6 +62,9 @@ now run the precompiled code samples, for example:
      Windows:           simulate ..\model\humanoid\humanoid.xml
      Linux and macOS:   ./simulate ../model/humanoid/humanoid.xml
 
+Note that for macOS exclusively, the distribution is an `Application Bundle <https://developer.apple.com/go/?id=bundle-
+structure>`__. The ``simulate`` binary executable is located inside the bundle in ``MuJoCo.app/Contents/MacOS`` within the DMG disk image. Alternatively, you can double-click ``MuJoCo.app`` to launch the ``simulate`` GUI.
+
 The directory structure is shown below. Users can re-organize it if needed, as well as install the dynamic libraries in
 other directories and set the path accordingly. The only file created automatically is MUJOCO_LOG.TXT in the executable
 directory; it contains error and warning messages, and can be deleted at any time.
@@ -79,10 +82,8 @@ working development environment. We provide a cross-platform `CMake
 <https://github.com/google-deepmind/mujoco/blob/main/sample/CMakeLists.txt>`__ setup that can be used to build sample
 applications independently of the MuJoCo library itself.
 
-On macOS, the DMG disk image contains ``MuJoCo.app``, which you can double-click to launch the ``simulate`` GUI. You can
-also drag ``MuJoCo.app`` into the ``/Application`` on your system, as you would to install any other app. As well as the
-``MuJoCo.app`` `Application Bundle <https://developer.apple.com/go/?id=bundle-
-structure>`__, the DMG includes the ``mujoco.framework`` subdirectory containing the MuJoCo dynamic library and all of
+On MacOS, you can also drag ``MuJoCo.app`` into the ``/Application`` on your system, as you would to install any other app. As well as the
+``MuJoCo.app``, the DMG includes the ``mujoco.framework`` subdirectory containing the MuJoCo dynamic library and all of
 its public headers. If you are using Xcode, you can import it as a framework dependency on your project. (This also
 works for Swift projects without any modification). If you are building manually, you can use ``-F`` and
 ``-framework mujoco`` to specify the header search path and the library search path respectively.

--- a/doc/programming/index.rst
+++ b/doc/programming/index.rst
@@ -82,7 +82,7 @@ working development environment. We provide a cross-platform `CMake
 <https://github.com/google-deepmind/mujoco/blob/main/sample/CMakeLists.txt>`__ setup that can be used to build sample
 applications independently of the MuJoCo library itself.
 
-On MacOS, you can also drag ``MuJoCo.app`` into the ``/Application`` on your system, as you would to install any other app. As well as the
+On MacOS, you can also drag ``MuJoCo.app`` into the ``/Applications`` on your system, as you would to install any other app. As well as the
 ``MuJoCo.app``, the DMG includes the ``mujoco.framework`` subdirectory containing the MuJoCo dynamic library and all of
 its public headers. If you are using Xcode, you can import it as a framework dependency on your project. (This also
 works for Swift projects without any modification). If you are building manually, you can use ``-F`` and


### PR DESCRIPTION
## Changes made

Edited `doc/programming/index.rst`. 
- specified location of `simulate` binary execution file in MacOS
- moved up some MacOS specific information relevant to the `simulate` section

## Additional bug 

I also encountered bug wherein you have to either run absolute path of the `simulate` binary OR when directly in the App Bundle folder otherwise ParseXML will return error - sounds like this is because Application Bundles automatically reset the current working directory to the internal resource folder upon launch, and loses track of the folder I'm running from. Should I add this to docs / patch it or is it minor enough to not matter (user will likely just open XML from GUI rather than CLI)? 

```bash
zacharytang@Mac-mini MuJoCo % ./MuJoCo.app/Contents/MacOS/simulate model/humanoid/humanoid.xml
MuJoCo version 3.4.0
Plugins registered by library 'libsdf_plugin.dylib':
    mujoco.sdf.bolt
    mujoco.sdf.bowl
    mujoco.sdf.gear
    mujoco.sdf.nut
    mujoco.sdf.torus
Plugins registered by library 'libactuator.dylib':
    mujoco.pid
Plugins registered by library 'libsensor.dylib':
    mujoco.sensor.touch_grid
Plugins registered by library 'libelasticity.dylib':
    mujoco.elasticity.cable
ParseXML: Error opening file 'model/humanoid/humanoid.xml': No such file or directory
2025-12-17 04:58:01.444 simulate[57863:669631] +[IMKClient subclass]: chose IMKClient_Modern
2025-12-17 04:58:01.444 simulate[57863:669631] +[IMKInputSession subclass]: chose IMKInputSession_Modern


zacharytang@Mac-mini MuJoCo % cd ./MuJoCo.app/Contents/MacOS/ && ./simulate ../../../model/humanoid/humanoid.xml
MuJoCo version 3.4.0
Plugins registered by library 'libsdf_plugin.dylib':
    mujoco.sdf.bolt
    mujoco.sdf.bowl
    mujoco.sdf.gear
    mujoco.sdf.nut
    mujoco.sdf.torus
Plugins registered by library 'libactuator.dylib':
    mujoco.pid
Plugins registered by library 'libsensor.dylib':
    mujoco.sensor.touch_grid
Plugins registered by library 'libelasticity.dylib':
    mujoco.elasticity.cable
2025-12-17 04:58:24.079 simulate[57867:669963] +[IMKClient subclass]: chose IMKClient_Modern
2025-12-17 04:58:24.079 simulate[57867:669963] +[IMKInputSession subclass]: chose IMKInputSession_Modern
```