### PR TITLE
Add missing API breaking change in Changelog of 3.3.7

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -105,6 +105,8 @@ General
    2. Remove ``_full_compat`` from ``mjx.put_data`` and ``mjx.put_model``.
    3. ``nconmax`` and ``njmax`` fields in ``mjx.make_data`` now default to ``None`` instead of -1. ``nconmax`` will be deprecated
       in favor of ``naconmax`` in a future release.
+   4. The ``Simulate::InjectNoise`` method needs to set the target of exponential decay to a value from key_ctrl if a valid key is provided as input, else -1.
+
 
 
 3. Joint decorators and spatial tendons which have limits defined and whose current value (angle or length) exceeds the


### PR DESCRIPTION
https://github.com/google-deepmind/mujoco/commit/401bf431b8b0fe6e0a619412a607b5135dc4ded4#diff-3dc22ceeebd71304c41d349c6d273bda172ea88ff49c772dbdcf51b9b19bbd33R2943

After the above commit, the InjectNoise has a broken API but it was never documented in the changelog