### PR TITLE
Fix case-insensitive handling of STL and OBJ file extensions in Unity…

### DIFF
--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -153,7 +153,7 @@ public class MjImporterWithAssets : MjcfImporter {
     var assetReferenceName = MjEngineTool.Sanitize(unsanitizedAssetReferenceName);
     var sourceFilePath = Path.Combine(_sourceMeshesDir, fileName);
 
-    if (Path.GetExtension(sourceFilePath) != ".obj" && Path.GetExtension(sourceFilePath) != ".stl") {
+    if (Path.GetExtension(sourceFilePath).ToLowerInvariant() != ".obj" && Path.GetExtension(sourceFilePath).ToLowerInvariant() != ".stl") {
       throw new NotImplementedException("Type of mesh file not yet supported. " +
                                         "Please convert to binary STL or OBJ. " +
                                         $"Attempted to load: {sourceFilePath}");
@@ -194,11 +194,11 @@ public class MjImporterWithAssets : MjcfImporter {
   private void CopyMeshAndRescale(
       string sourceFilePath, string targetFilePath, Vector3 scale) {
     var originalMeshBytes = File.ReadAllBytes(sourceFilePath);
-    if (Path.GetExtension(sourceFilePath) == ".stl") {
+    if (Path.GetExtension(sourceFilePath).ToLowerInvariant() == ".stl") {
       var mesh = StlMeshParser.ParseBinary(originalMeshBytes, scale);
       var rescaledMeshBytes = StlMeshParser.SerializeBinary(mesh);
       File.WriteAllBytes(targetFilePath, rescaledMeshBytes);
-    } else if (Path.GetExtension(sourceFilePath) == ".obj") {
+    } else if (Path.GetExtension(sourceFilePath).ToLowerInvariant() == ".obj") {
       ObjMeshImportUtility.CopyAndScaleOBJFile(sourceFilePath, targetFilePath, scale);
     } else {
       throw new NotImplementedException($"Extension {Path.GetExtension(sourceFilePath)} " +


### PR DESCRIPTION
The Unity importer was rejecting uppercase .STL and .OBJ files (commonly used in mujoco_menagerie or unitree_mujoco) due to case-sensitive extension checks. Modified MjImporterWithAssets to use ToLower() when comparing file extensions, allowing both lowercase and uppercase variants. 

### System Used:
-MacOS 26.2
-Unity 6.3 LTS (6000.3.2f1) | Will work on Unity 2022.3 LTS and later
-MuJoCo 3.4.0 | Unity Plugin 3.4.0 


### **Context:** 
I'm using the Unity plug-in for a personnel project and research while studying at UdeM. The Mujoco Plugin has no issues when running with Mj Object in the scene. But, while importing scene from major repo. For instance, I tried [mujoco_menagerie](https://github.com/google-deepmind/mujoco_menagerie) with the unitree_g1 xml file. Same instance was happening with [unitree_mujoco](https://github.com/unitreerobotics/unitree_mujoco.git). 

In those XML files, the meshes are importing as .STL files. On Mac, which is case-sensitive the files are not processed as binary STL, throwing errors `"Type of mesh file not yet supported. Please convert to binary STL or OBJ. "` 

### **Fix:**
-Added .toLowerInvariant() on line 156, 197 and 201 to fix this instance. 


Notes: From my understanding of the contribution guidelines, this is a very simple fix, so I did not push precise test for this update. I made two different tests on two different Mac. If requires I have no problem to added small test on nunit.