### PR TITLE
Enable PDF and HTML downloads on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,11 @@
 
 version: 2
 
-# TODO(robotics-simulation): pdf format fails to build on readthedocs
-# formats:
-#   - pdf
+# Enable downloadable documentation formats
+formats:
+  - pdf
+  - htmlzip
+  - epub
 
 build:
   os: ubuntu-24.04

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -242,3 +242,18 @@ katex_options = 'macros: {' + katex_macros + '}'
 
 # Add LaTeX macros for LATEX builder
 latex_elements = {'preamble': latex_macros}
+
+# -- Options for LaTeX/PDF output ---------------------------------------------
+
+# Use xelatex for better Unicode support (required for KaTeX symbols)
+latex_engine = 'xelatex'
+
+# Furo theme doesn't support LaTeX builds, use manual theme for PDF
+latex_theme = 'manual'
+
+# Configure PDF output
+latex_elements.update({
+    'papersize': 'letterpaper',
+    'pointsize': '10pt',
+    'extraclassoptions': 'openany,oneside',
+})


### PR DESCRIPTION
## Summary
This PR enables downloadable documentation formats (PDF, HTML zip, ePub) on ReadTheDocs.

Fixes #470

## Problem
Users cannot download MuJoCo documentation for offline use. PDF builds were previously disabled due to build failures (see TODO comment in .readthedocs.yml line 6).

## Solution
- Enabled formats in .readthedocs.yml: pdf, htmlzip, epub
- Configured xelatex engine in doc/conf.py for proper Unicode/math symbol handling
- Set latex_theme to manual for PDF compatibility (Furo theme is HTML-only)

## Changes
- .readthedocs.yml: Uncommented and configured formats section
- doc/conf.py: Added LaTeX/PDF build configuration

## Testing
- Verified LaTeX build generates files successfully
- Configuration syntax validated locally
- ReadTheDocs will build and verify PDF generation

## Benefits
- Users can download documentation as PDF for offline reading
- Better accessibility with multiple download formats
- Matches standard ReadTheDocs documentation features