### PR TITLE
Fix UI mismatch after toggling fullscreen

### DIFF
--- a/simulate/glfw_adapter.cc
+++ b/simulate/glfw_adapter.cc
@@ -202,6 +202,13 @@ void GlfwAdapter::ToggleFullscreen() {
                                 0, vidmode_.width, vidmode_.height,
                                 vidmode_.refreshRate);
   }
+  
+  //Ensure GLFW processes the monitor switch, then update the UI/renderer
+  Glfw().glfwPollEvents();
+  // with the new window size so rendering and input coordinates remain synced.
+  int new_width, new_height;
+  Glfw().glfwGetWindowSize(window_, &new_width, &new_height);
+  OnWindowResize(new_width, new_height);
 }
 
 bool GlfwAdapter::IsLeftMouseButtonPressed() const {


### PR DESCRIPTION
This PR fixes a UI/input mismatch that occurred when toggling from fullscreen to windowed mode. After the toggle, UI widgets were visually rendered at incorrect positions while their clickable areas remained at their previous locations.

Fixes: https://github.com/google-deepmind/mujoco/issues/3015

After (fixed behavior):

https://github.com/user-attachments/assets/33c5a12f-351d-4402-b436-d769df84c41b