### PR TITLE
feat(renderer): add update_hfield, update_mesh, update_texture methods with tests

### DIFF
--- a/python/mujoco/renderer.py
+++ b/python/mujoco/renderer.py
@@ -304,6 +304,75 @@ the clause:
         self._scene,
     )
 
+  def update_hfield(self, hfieldid: int) -> None:
+    """Updates a height field in GPU memory.
+
+    Call this method after modifying `model.hfield_data` to upload the changes
+    to the GPU so they are reflected in subsequent renders.
+
+    Args:
+      hfieldid: The ID of the height field to update.
+
+    Raises:
+      RuntimeError: if called after close().
+      ValueError: if hfieldid is out of range.
+    """
+    if self._mjr_context is None:
+      raise RuntimeError('update_hfield cannot be called after close.')
+    if hfieldid < 0 or hfieldid >= self._model.nhfield:
+      raise ValueError(
+          f'hfieldid {hfieldid} is out of range [0, {self._model.nhfield}).'
+      )
+    if self._gl_context:
+      self._gl_context.make_current()
+    _render.mjr_uploadHField(self._model, self._mjr_context, hfieldid)
+
+  def update_mesh(self, meshid: int) -> None:
+    """Updates a mesh in GPU memory.
+
+    Call this method after modifying mesh vertex data to upload the changes
+    to the GPU so they are reflected in subsequent renders.
+
+    Args:
+      meshid: The ID of the mesh to update.
+
+    Raises:
+      RuntimeError: if called after close().
+      ValueError: if meshid is out of range.
+    """
+    if self._mjr_context is None:
+      raise RuntimeError('update_mesh cannot be called after close.')
+    if meshid < 0 or meshid >= self._model.nmesh:
+      raise ValueError(
+          f'meshid {meshid} is out of range [0, {self._model.nmesh}).'
+      )
+    if self._gl_context:
+      self._gl_context.make_current()
+    _render.mjr_uploadMesh(self._model, self._mjr_context, meshid)
+
+  def update_texture(self, texid: int) -> None:
+    """Updates a texture in GPU memory.
+
+    Call this method after modifying `model.tex_data` to upload the changes
+    to the GPU so they are reflected in subsequent renders.
+
+    Args:
+      texid: The ID of the texture to update.
+
+    Raises:
+      RuntimeError: if called after close().
+      ValueError: if texid is out of range.
+    """
+    if self._mjr_context is None:
+      raise RuntimeError('update_texture cannot be called after close.')
+    if texid < 0 or texid >= self._model.ntex:
+      raise ValueError(
+          f'texid {texid} is out of range [0, {self._model.ntex}).'
+      )
+    if self._gl_context:
+      self._gl_context.make_current()
+    _render.mjr_uploadTexture(self._model, self._mjr_context, texid)
+
   def close(self) -> None:
     """Frees the resources used by the renderer.
 

--- a/python/mujoco/renderer_test.py
+++ b/python/mujoco/renderer_test.py
@@ -157,6 +157,162 @@ class MuJoCoRendererTest(parameterized.TestCase):
       with self.assertRaises(ValueError):
         renderer.render(out=np.zeros((*failing_render_size, 3), np.uint8))
 
+  def test_update_hfield_out_of_range(self):
+    xml = """
+<mujoco>
+  <asset>
+    <hfield name="terrain" nrow="3" ncol="3" size="1 1 1 1"/>
+  </asset>
+  <worldbody>
+    <geom type="hfield" hfield="terrain"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_hfield(-1)
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_hfield(model.nhfield)
+
+  def test_update_hfield_after_close(self):
+    xml = """
+<mujoco>
+  <asset>
+    <hfield name="terrain" nrow="3" ncol="3" size="1 1 1 1"/>
+  </asset>
+  <worldbody>
+    <geom type="hfield" hfield="terrain"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    renderer = mujoco.Renderer(model, 50, 50)
+    renderer.close()
+    with self.assertRaisesRegex(RuntimeError, 'after close'):
+      renderer.update_hfield(0)
+
+  def test_update_hfield_succeeds(self):
+    xml = """
+<mujoco>
+  <asset>
+    <hfield name="terrain" nrow="3" ncol="3" size="1 1 1 1"/>
+  </asset>
+  <worldbody>
+    <geom type="hfield" hfield="terrain"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      # Should not raise
+      renderer.update_hfield(0)
+
+  def test_update_mesh_out_of_range(self):
+    xml = """
+<mujoco>
+  <asset>
+    <mesh name="box" vertex="0 0 0  1 0 0  0 1 0  0 0 1"/>
+  </asset>
+  <worldbody>
+    <geom type="mesh" mesh="box"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_mesh(-1)
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_mesh(model.nmesh)
+
+  def test_update_mesh_after_close(self):
+    xml = """
+<mujoco>
+  <asset>
+    <mesh name="box" vertex="0 0 0  1 0 0  0 1 0  0 0 1"/>
+  </asset>
+  <worldbody>
+    <geom type="mesh" mesh="box"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    renderer = mujoco.Renderer(model, 50, 50)
+    renderer.close()
+    with self.assertRaisesRegex(RuntimeError, 'after close'):
+      renderer.update_mesh(0)
+
+  def test_update_mesh_succeeds(self):
+    xml = """
+<mujoco>
+  <asset>
+    <mesh name="box" vertex="0 0 0  1 0 0  0 1 0  0 0 1"/>
+  </asset>
+  <worldbody>
+    <geom type="mesh" mesh="box"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      # Should not raise
+      renderer.update_mesh(0)
+
+  def test_update_texture_out_of_range(self):
+    xml = """
+<mujoco>
+  <asset>
+    <texture name="tex" type="2d" builtin="checker" width="8" height="8"/>
+    <material name="mat" texture="tex"/>
+  </asset>
+  <worldbody>
+    <geom type="box" size="1 1 1" material="mat"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_texture(-1)
+      with self.assertRaisesRegex(ValueError, 'out of range'):
+        renderer.update_texture(model.ntex)
+
+  def test_update_texture_after_close(self):
+    xml = """
+<mujoco>
+  <asset>
+    <texture name="tex" type="2d" builtin="checker" width="8" height="8"/>
+    <material name="mat" texture="tex"/>
+  </asset>
+  <worldbody>
+    <geom type="box" size="1 1 1" material="mat"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    renderer = mujoco.Renderer(model, 50, 50)
+    renderer.close()
+    with self.assertRaisesRegex(RuntimeError, 'after close'):
+      renderer.update_texture(0)
+
+  def test_update_texture_succeeds(self):
+    xml = """
+<mujoco>
+  <asset>
+    <texture name="tex" type="2d" builtin="checker" width="8" height="8"/>
+    <material name="mat" texture="tex"/>
+  </asset>
+  <worldbody>
+    <geom type="box" size="1 1 1" material="mat"/>
+  </worldbody>
+</mujoco>
+"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    with mujoco.Renderer(model, 50, 50) as renderer:
+      # Should not raise
+      renderer.update_texture(0)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
adds `update_hfield()`, `update_mesh()`, and `update_texture()` methods to the renderer class, enabling GPU memory updates after modifying model assets without recreating the renderer.

these methods wrap the corresponding `mjr_upload*` C functions with proper validation and GL context handling. includes comprehensive unit tests covering success cases, boundary validation, and error conditions.

partially addresses the issue <a hred="https://github.com/google-deepmind/mujoco/issues/1410">#1410</a> (the `update_hfield()` request)