### PR TITLE
Fix Frame Issue in mjCBody::AccumulateInertia

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -2263,7 +2263,7 @@ void mjCBody::AccumulateInertia(const mjsBody* other, mjsBody* result) {
   };
   double iquat[2][4] = {
     {result->iquat[0], result->iquat[1], result->iquat[2], result->iquat[3]},
-    {other->iquat[0], other->iquat[1], other->iquat[2], other->iquat[3]}
+    {other_iquat[0], other_iquat[1], other_iquat[2], other_iquat[3]}
   };
 
   // compute total mass


### PR DESCRIPTION
Fixes #2982

Issue
When fusestatic="true" is enabled, child body inertias are incorrectly accumulated when the child body has a rotation relative to the parent. The bug was introduced in commit 7932b4b.

The problem occurs in mjCBody::AccumulateInertia where the child body's inertial orientation is not properly transformed to the parent's coordinate frame before combining inertias.

Solution
Changed line 2266 in 
src/user/user_objects.cc
 to use the transformed quaternion other_iquat instead of the untransformed other->iquat.

Before:

double iquat[2][4] = {
  {result->iquat[0], result->iquat[1], result->iquat[2], result->iquat[3]},
  {other->iquat[0], other->iquat[1], other->iquat[2], other->iquat[3]}  //  Untransformed
};
After:

double iquat[2][4] = {
  {result->iquat[0], result->iquat[1], result->iquat[2], result->iquat[3]},
  {other_iquat[0], other_iquat[1], other_iquat[2], other_iquat[3]}  // Properly transformed
};