### PR TITLE
Add option to disable keyboard shortcuts in viewer

### DIFF
--- a/python/mujoco/simulate.cc
+++ b/python/mujoco/simulate.cc
@@ -455,6 +455,11 @@ PYBIND11_MODULE(_simulate, pymodule) {
                     CallIfNotNull(+[](mujoco::Simulate& sim, int enabled) {
                       sim.ui1_enable = enabled;
                     }),
+                    py::call_guard<py::gil_scoped_release>())
+      .def_property("keyboard_ui", GetIfNotNull(&mujoco::Simulate::keyboard_ui),
+                    CallIfNotNull(+[](mujoco::Simulate& sim, int enabled) {
+                      sim.keyboard_ui = enabled;
+                    }),
                     py::call_guard<py::gil_scoped_release>());
 
   pymodule.def("set_glfw_dlhandle", [](std::uintptr_t dlhandle) {

--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -1661,7 +1661,7 @@ void UiEvent(mjuiState* state) {
   }
 
   // shortcut not handled by UI
-  if (state->type==mjEVENT_KEY && state->key!=0) {
+  if (state->type==mjEVENT_KEY && state->key!=0 && sim->keyboard_ui) {
     switch (state->key) {
     case ' ':                   // Mode
       if (!sim->is_passive_ && sim->m_) {

--- a/simulate/simulate.h
+++ b/simulate/simulate.h
@@ -189,6 +189,7 @@ class Simulate {
   int font = 0;
   int ui0_enable = 1;
   int ui1_enable = 1;
+  int keyboard_ui = 1;  // enable keyboard shortcuts
   int help = 0;
   int info = 0;
   int profiler = 0;


### PR DESCRIPTION
## Summary
- Add `handle_keyboard` parameter to `launch()` and `launch_passive()` functions
- When set to `False`, built-in keyboard shortcuts (e.g., 'W' for wireframe, space for pause) are disabled
- Useful for robot teleoperation where keyboard inputs should be handled by user code

Closes #2953

## Changes
- `simulate/simulate.h`: Add `keyboard_ui` flag
- `simulate/simulate.cc`: Check flag before processing keyboard events
- `python/mujoco/simulate.cc`: Expose `keyboard_ui` property in Python bindings
- `python/mujoco/viewer.py`: Add `handle_keyboard` parameter to launch functions

## Example usage
```python
# Disable keyboard shortcuts for teleoperation
viewer = mujoco.viewer.launch_passive(
    model, data,
    handle_keyboard=False,  # Disable built-in shortcuts
    key_callback=my_teleop_callback  # Handle keys in user code
)
```

## Test plan
- [x] Code follows existing patterns for `ui0_enable`/`ui1_enable`
- [x] Ran `pyink` and `isort` for style compliance
- [ ] Manual testing with passive viewer (requires display)