### PR TITLE
Fix MinGW build failure due to incorrect /STACK flag

### DIFF
--- a/cmake/MujocoLinkOptions.cmake
+++ b/cmake/MujocoLinkOptions.cmake
@@ -17,13 +17,17 @@ include(CheckCSourceCompiles)
 # Gets the appropriate linker options for building MuJoCo, based on features available on the
 # linker.
 function(get_mujoco_extra_link_options OUTPUT_VAR)
+  if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(MINGW TRUE)
+  else()
+    set(MINGW FALSE)
+  endif()
   if(MSVC)
-    set(EXTRA_LINK_OPTIONS /OPT:REF /OPT:ICF=5 /STACK:16777216)
+    set(EXTRA_LINK_OPTIONS /OPT:REF /OPT:ICF=5)
   else()
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,/STACK:16777216)
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
       if(SUPPORTS_LLD)
@@ -59,6 +63,12 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
         endif()
       endif()
     endif()
+  endif()
+
+  if(MSVC)
+    list(APPEND EXTRA_LINK_OPTIONS /STACK:16777216)
+  elseif(MINGW)
+    list(APPEND EXTRA_LINK_OPTIONS -Wl,--stack,16777216)
   endif()
 
   set("${OUTPUT_VAR}"


### PR DESCRIPTION
Fixes #3040.

The build was failing on MinGW because the linker was receiving the MSVC-style `/STACK` flag, which is treated as a file path by `ld`. this pr:
1.  Explicitly detects MinGW (GNU compiler on Windows).
2.  Applies the correct GCC linker flag `-Wl,--stack,16777216` when building with MinGW.
3.  Preserves the existing `/STACK` flag for MSVC.