### PR TITLE
Fix `__muloti4` linker error on Clang 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
               -G Ninja
               -DCMAKE_C_COMPILER:STRING=clang-13
               -DCMAKE_CXX_COMPILER:STRING=clang++-13
+              -DCMAKE_EXE_LINKER_FLAGS:STRING=-rtlib=compiler-rt
+              -DCMAKE_SHARED_LINKER_FLAGS:STRING=-rtlib=compiler-rt              
               -DMUJOCO_HARDEN:BOOL=ON
             tmpdir: "/tmp"
           - os: macos-15


### PR DESCRIPTION
Add linker flags for Clang 13 in build configuration.