### PR TITLE
Fix MinGW compatibility and Windows-specific crashes

### DIFF
--- a/cmake/MujocoLinkOptions.cmake
+++ b/cmake/MujocoLinkOptions.cmake
@@ -23,16 +23,12 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,/STACK:16777216)
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD)
-      if(SUPPORTS_LLD)
-        set(EXTRA_LINK_OPTIONS
-            ${EXTRA_LINK_OPTIONS}
-            -fuse-ld=lld-link
-            -Wl,/OPT:REF
-            -Wl,/OPT:ICF
-        )
+      check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      if(SUPPORTS_LLD_LINK)
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld-link -Wl,/STACK:16777216 -Wl,/OPT:REF -Wl,/OPT:ICF)
+      else()
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--stack,16777216)
       endif()
     else()
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")

--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -51,6 +51,8 @@ endif()
 
 include(MujocoLinkOptions)
 get_mujoco_extra_link_options(EXTRA_LINK_OPTIONS)
+list(FILTER EXTRA_LINK_OPTIONS EXCLUDE REGEX "STACK")
+list(FILTER EXTRA_LINK_OPTIONS EXCLUDE REGEX "stack")
 add_link_options(${EXTRA_LINK_OPTIONS})
 
 include(MujocoMacOS)

--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -99,7 +99,7 @@ void mju_writeLog(const char* type, const char* msg) {
 
 #if defined(_POSIX_C_SOURCE) || defined(__APPLE__) || defined(__STDC_VERSION_TIME_H__) || defined(__EMSCRIPTEN__)
     localtime_r(&rawtime, &timeinfo);
-#elif _MSC_VER
+#elif defined(_WIN32)
     localtime_s(&timeinfo, &rawtime);
 #elif __STDC_LIB_EXT1__
     localtime_s(&rawtime, &timeinfo);
@@ -207,8 +207,10 @@ void* mju_malloc(size_t size) {
   // default allocator
   else {
     // pad size to multiple of 64
-    if ((size%64)) {
-      size += 64 - (size%64);
+    if (size == 0) {
+      size = 64;
+    } else if ((size % 64)) {
+      size += 64 - (size % 64);
     }
 
     // allocate

--- a/src/user/user_resource.cc
+++ b/src/user/user_resource.cc
@@ -32,7 +32,7 @@
   #include <unistd.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
   #define stat _stat
 #endif
 


### PR DESCRIPTION
# PR Description: Fix MinGW Compatibility and Windows-Specific Crashes

This Pull Request addresses several critical issues discovered in the MuJoCo physics engine, specifically regarding Windows build stability and runtime robustness when using MinGW or Python.

## Issues Fixed

### 1. MinGW 'stat' Redefinition (#3038)
*   **Problem**: MuJoCo was forcing a #define stat _stat on all Windows platforms. MinGW-w64 provides its own POSIX-compliant stat implementation, leading to a redefinition conflict.
*   **Fix**: Wrapped the definition in !defined(__MINGW32__) to ensure MinGW uses its built-in headers correctly.

### 2. MinGW Stack Flag Syntax (#3011)
*   **Problem**: The increase in Windows stack size used the MSVC-style /STACK flag. The standard MinGW linker (ld) does not recognize this syntax, causing a build failure.
*   **Fix**: Updated MujocoLinkOptions.cmake to detect the linker and use --stack,16777216 for MinGW.

### 3. Python Binding Crashes (#3011)
*   **Problem**: Applying a large stack size to a DLL (shared library) is non-standard on Windows and causes the Python interpreter to crash immediately when the MuJoCo module is loaded.
*   **Fix**: Filtered out stack-related flags from the Python binding modules. Stack management is now correctly left to the host executable (e.g., python.exe).

### 4. Thread-safe 'localtime' for MinGW (#3037)
*   **Problem**: The engine was using _MSC_VER to gate the use of localtime_s. MinGW does not define this macro but does provide the Windows-native localtime_s.
*   **Fix**: Replaced the check with defined(_WIN32) to allow all Windows compilers to use the secure time function.

### 5. Zero-sized Allocation Crash (#2992)
*   **Problem**: On Windows, _aligned_malloc(0) returns NULL. MuJoCo interpreted this as a fatal out-of-memory error, causing crashes on models with empty arrays.
*   **Fix**: Updated mju_malloc to ensure a minimum allocation of 64 bytes for any 0-sized request.

---

## Verification
*   Validated that the source code changes follow the repository's cross-platform conventions.
*   Verified that the CMake logic correctly handles the distinction between MSVC and MinGW toolchains.
*   Ensured that Python bindings remain unaffected on other platforms (macOS/Linux).

These changes significantly improve the accessibility of MuJoCo for developers on Windows using open-source toolchains.
