### PR TITLE
Fix MinGW build: Replace unsupported %zu format with %llu

### DIFF
--- a/src/thread/thread_pool.cc
+++ b/src/thread/thread_pool.cc
@@ -239,7 +239,7 @@ static void  ConfigureMultiThreadedStack(mjData* d) {
       // abort if the current stack is already larger than the portion of the stack
       // that would be reserved for the main thread
       if ((uintptr_t)end_shard_cursor_ptr > current_limit) {
-        mju_error("mj_bindThreadPool: sharding stack - existing stack larger than shard size: current_size = %zu, "
+        mju_error("mj_bindThreadPool: sharding stack - existing stack larger than shard size: current_size = %llu, "
                   "max_size = %llu", (unsigned long long)current_limit, (unsigned long long)(uintptr_t) end_shard_cursor_ptr);
       }
       end_shard_cursor_ptr->top = current_limit;

--- a/src/thread/thread_pool.cc
+++ b/src/thread/thread_pool.cc
@@ -199,7 +199,7 @@ mjStackInfo* mju_getStackInfoForThread(mjData* d, size_t thread_id) {
   }
 
   if (bytes_per_shard * number_of_shards > total_arena_size_bytes) {
-    mju_error("Arena is not large enough for %zu shards", number_of_shards);
+    mju_error("Arena is not large enough for %llu shards", (unsigned long long)number_of_shards);
   }
 
   uintptr_t result = (end_of_arena_ptr - (thread_id + 1) * bytes_per_shard);
@@ -240,7 +240,7 @@ static void  ConfigureMultiThreadedStack(mjData* d) {
       // that would be reserved for the main thread
       if ((uintptr_t)end_shard_cursor_ptr > current_limit) {
         mju_error("mj_bindThreadPool: sharding stack - existing stack larger than shard size: current_size = %zu, "
-                  "max_size = %zu", current_limit, (uintptr_t) end_shard_cursor_ptr);
+                  "max_size = %llu", (unsigned long long)current_limit, (unsigned long long)(uintptr_t) end_shard_cursor_ptr);
       }
       end_shard_cursor_ptr->top = current_limit;
       end_shard_cursor_ptr->stack_base = d->pbase;


### PR DESCRIPTION
**Summary:** This PR fixes a compilation error when building with MinGW-w64. The compiler treats %zu as an unknown format specifier because it defaults to checking against MSVCRT compatibility, where %z is not supported in older runtimes.

**Bug:** When compiling src/thread/thread_pool.cc with MinGW, the following error occurs:
src/thread/thread_pool.cc:202:47: error: unknown conversion type character ‘z’ in format [-Werror=format=]
mju_error("Arena is not large enough for %zu shards", number_of_shards);

**Fix:** Replaced %zu with %llu and cast the corresponding arguments to unsigned long long. This ensures the format string is valid across all platforms (Windows/MinGW, MSVC, Linux, macOS) without relying on C99 runtime support for %z.

**Verification:** I have verified that this change fixes the build error on a Windows 11 machine using the MinGW64 toolchain.
