### PR TITLE
Fix Windows DLL Export for Callback Globals

### DIFF
--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -46,7 +46,15 @@ MJAPI extern void  (*mju_user_error)(const char*);
 MJAPI extern void  (*mju_user_warning)(const char*);
 MJAPI extern void* (*mju_user_malloc)(size_t);
 MJAPI extern void  (*mju_user_free)(void*);
-
+// Accessor functions for user handlers (Windows DLL export compatibility)
+MJAPI void  (*mju_getUserError(void))(const char*);
+MJAPI void  mju_setUserError(void (*handler)(const char*));
+MJAPI void  (*mju_getUserWarning(void))(const char*);
+MJAPI void  mju_setUserWarning(void (*handler)(const char*));
+MJAPI void* (*mju_getUserMalloc(void))(size_t);
+MJAPI void  mju_setUserMalloc(void* (*handler)(size_t));
+MJAPI void  (*mju_getUserFree(void))(void*);
+MJAPI void  mju_setUserFree(void (*handler)(void*));
 
 // callbacks extending computation pipeline
 MJAPI extern mjfGeneric  mjcb_passive;
@@ -57,7 +65,23 @@ MJAPI extern mjfTime     mjcb_time;
 MJAPI extern mjfAct      mjcb_act_dyn;
 MJAPI extern mjfAct      mjcb_act_gain;
 MJAPI extern mjfAct      mjcb_act_bias;
-
+// Accessor functions for callbacks (Windows DLL export compatibility)
+MJAPI mjfGeneric mju_getCallbackPassive(void);
+MJAPI void mju_setCallbackPassive(mjfGeneric handler);
+MJAPI mjfGeneric mju_getCallbackControl(void);
+MJAPI void mju_setCallbackControl(mjfGeneric handler);
+MJAPI mjfConFilt mju_getCallbackContactFilter(void);
+MJAPI void mju_setCallbackContactFilter(mjfConFilt handler);
+MJAPI mjfSensor mju_getCallbackSensor(void);
+MJAPI void mju_setCallbackSensor(mjfSensor handler);
+MJAPI mjfTime mju_getCallbackTime(void);
+MJAPI void mju_setCallbackTime(mjfTime handler);
+MJAPI mjfAct mju_getCallbackActDyn(void);
+MJAPI void mju_setCallbackActDyn(mjfAct handler);
+MJAPI mjfAct mju_getCallbackActGain(void);
+MJAPI void mju_setCallbackActGain(mjfAct handler);
+MJAPI mjfAct mju_getCallbackActBias(void);
+MJAPI void mju_setCallbackActBias(mjfAct handler);
 
 // collision function table
 MJAPI extern mjfCollision mjCOLLISIONFUNC[mjNGEOMTYPES][mjNGEOMTYPES];

--- a/src/engine/engine_callback.c
+++ b/src/engine/engine_callback.c
@@ -40,3 +40,67 @@ void mj_resetCallbacks(void) {
   mjcb_act_gain = 0;
   mjcb_act_dyn  = 0;
 }
+// Getter/setter functions for callbacks (Windows DLL export compatibility)
+mjfGeneric mju_getCallbackPassive(void) {
+  return mjcb_passive;
+}
+
+void mju_setCallbackPassive(mjfGeneric handler) {
+  mjcb_passive = handler;
+}
+
+mjfGeneric mju_getCallbackControl(void) {
+  return mjcb_control;
+}
+
+void mju_setCallbackControl(mjfGeneric handler) {
+  mjcb_control = handler;
+}
+
+mjfConFilt mju_getCallbackContactFilter(void) {
+  return mjcb_contactfilter;
+}
+
+void mju_setCallbackContactFilter(mjfConFilt handler) {
+  mjcb_contactfilter = handler;
+}
+
+mjfSensor mju_getCallbackSensor(void) {
+  return mjcb_sensor;
+}
+
+void mju_setCallbackSensor(mjfSensor handler) {
+  mjcb_sensor = handler;
+}
+
+mjfTime mju_getCallbackTime(void) {
+  return mjcb_time;
+}
+
+void mju_setCallbackTime(mjfTime handler) {
+  mjcb_time = handler;
+}
+
+mjfAct mju_getCallbackActDyn(void) {
+  return mjcb_act_dyn;
+}
+
+void mju_setCallbackActDyn(mjfAct handler) {
+  mjcb_act_dyn = handler;
+}
+
+mjfAct mju_getCallbackActGain(void) {
+  return mjcb_act_gain;
+}
+
+void mju_setCallbackActGain(mjfAct handler) {
+  mjcb_act_gain = handler;
+}
+
+mjfAct mju_getCallbackActBias(void) {
+  return mjcb_act_bias;
+}
+
+void mju_setCallbackActBias(mjfAct handler) {
+  mjcb_act_bias = handler;
+}

--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -62,7 +62,38 @@ void mju_clearHandlers(void) {
   mju_user_malloc = 0;
   mju_user_free = 0;
 }
+// Getter/setter functions for user handlers (Windows DLL export compatibility)
+void (*mju_getUserError(void))(const char*) {
+  return mju_user_error;
+}
 
+void mju_setUserError(void (*handler)(const char*)) {
+  mju_user_error = handler;
+}
+
+void (*mju_getUserWarning(void))(const char*) {
+  return mju_user_warning;
+}
+
+void mju_setUserWarning(void (*handler)(const char*)) {
+  mju_user_warning = handler;
+}
+
+void* (*mju_getUserMalloc(void))(size_t) {
+  return mju_user_malloc;
+}
+
+void mju_setUserMalloc(void* (*handler)(size_t)) {
+  mju_user_malloc = handler;
+}
+
+void (*mju_getUserFree(void))(void*) {
+  return mju_user_free;
+}
+
+void mju_setUserFree(void (*handler)(void*)) {
+  mju_user_free = handler;
+}
 //------------------------- internal-only handlers -------------------------------------------------
 
 typedef void (*callback_fn)(const char*);


### PR DESCRIPTION
Fixes.https://github.com/google-deepmind/mujoco/issues/3060

Issue
On Windows with non-MSVC compilers (e.g., Rust with MinGW), MuJoCo callback symbols (mju_user_* and mjcb_*) fail to link. The import library only contains __imp_ symbols, not direct symbols, causing link errors like:

error LNK2019: unresolved external symbol mju_user_error referenced in function...
Root Cause
Windows __declspec(dllimport/dllexport) treats global variables differently from functions:

Functions: Creates both direct symbol AND __imp_ entry
Global Variables: Only creates __imp_ entry in import library
Non-MSVC linkers expect direct symbols and fail when they're missing.

Solution
Added getter/setter accessor functions for all callback globals. Functions export correctly on Windows because __declspec creates proper linkable symbols for them.

