### PR TITLE
fix(user_init): use memcpy for gridlayout initialization

### DIFF
--- a/src/user/user_init.c
+++ b/src/user/user_init.c
@@ -267,8 +267,7 @@ void mjs_defaultTexture(mjsTexture* texture) {
   texture->random = 0.01;
   texture->gridsize[0] = texture->gridsize[1] = 1;
   texture->nchannel = 3;
-  char defaultlayout[sizeof(texture->gridlayout)] = "............";
-  strncpy(texture->gridlayout, defaultlayout, sizeof(texture->gridlayout));
+  memcpy(texture->gridlayout, "............", sizeof(texture->gridlayout));
 }
 
 


### PR DESCRIPTION
Hello:

I think that I found a probem with the gridlayout size in the user_init file. The gridlayout field is a fixed 12-byte array that is not null-terminated, so using string functions is semantically incorrect. memcpy explicitly copies exactly sizeof(gridlayout) bytes, which:

- Correctly reflects that gridlayout is binary data, not a C string
- Removes the unnecessary local variable

Note that this triggered an error in the build after adding a workaround for #2904: 
```gcc
/usr/bin/cc -DCCD_STATIC_DEFINE -DEIGEN_MPL2_ONLY -DMC_IMPLEM_ENABLE -DMUJOCO_DLL_EXPORTS -DMUJOCO_TINYOBJLOADER_IMPL -D_GNU_SOURCE -Dmujoco_EXPORTS -I/home/jrivero/code/debian/mujoco/debian/MarchingCubeCpp-f03a1b3 -I/home/jrivero/code/debian/mujoco/debian/TriangleMeshDistance-2cb643d -I/home/jrivero/code/debian/mujoco/include -I/usr/include/libqhull_r -I/home/jrivero/code/debian/mujoco/src -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/home/jrivero/code/debian/mujoco=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -std=c11 -fPIC -fvisibility=hidden -fdata-sections -ffunction-sections -Werror -Wall -Wpedantic -Wimplicit-fallthrough -Wunused -Wvla -Wno-int-in-bool-context -Wno-sign-compare -Wno-unknown-pragmas -Wimplicit-fallthrough=5 -Wno-maybe-uninitialized -MD -MT CMakeFiles/mujoco.dir/src/user/user_init.c.o -MF CMakeFiles/mujoco.dir/src/user/user_init.c.o.d -o CMakeFiles/mujoco.dir/src/user/user_init.c.o -c /home/jrivero/code/debian/mujoco/src/user/user_init.c
/home/jrivero/code/debian/mujoco/src/user/user_init.c: In function ‘mjs_defaultTexture’:
/home/jrivero/code/debian/mujoco/src/user/user_init.c:284:3: error: ‘__builtin_strncpy’ output truncated before terminating nul copying 12 bytes from a string of the same length [-Werror=stringop-truncation]
  284 |   strncpy(texture->gridlayout, defaultlayout, sizeof(texture->gridlayout));
      |   ^
cc1: all warnings being treated as errors
```