### PR TITLE
Keyframe validation fixes

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -4067,30 +4067,36 @@ void mjCModel::StoreKeyframes(mjCModel* dest) {
     info.mpos = !key->spec_mpos_.empty();
     info.mquat = !key->spec_mquat_.empty();
     dest->key_pending_.push_back(info);
-    if (!key->spec_qpos_.empty() && key->spec_qpos_.size() != nq) {
-      throw mjCError(nullptr, "Keyframe '%s' has invalid qpos size, got %d, should be %d",
-                     key->name.c_str(), key->spec_qpos_.size(), nq);
+
+    // Only validate if the model has already been compiled, otherwise the spec may not include
+    // all data.
+    if (compiled) {
+      if (!key->spec_qpos_.empty() && key->spec_qpos_.size() != nq) {
+        throw mjCError(nullptr, "Keyframe '%s' has invalid qpos size, got %d, should be %d",
+                      key->name.c_str(), key->spec_qpos_.size(), nq);
+      }
+      if (!key->spec_qvel_.empty() && key->spec_qvel_.size() != nv) {
+        throw mjCError(nullptr, "Keyframe %s has invalid qvel size, got %d, should be %d",
+                      key->name.c_str(), key->spec_qvel_.size(), nv);
+      }
+      if (!key->spec_act_.empty() && key->spec_act_.size() != na) {
+        throw mjCError(nullptr, "Keyframe %s has invalid act size, got %d, should be %d",
+                      key->name.c_str(), key->spec_act_.size(), na);
+      }
+      if (!key->spec_ctrl_.empty() && key->spec_ctrl_.size() != nu) {
+        throw mjCError(nullptr, "Keyframe %s has invalid ctrl size, got %d, should be %d",
+                      key->name.c_str(), key->spec_ctrl_.size(), nu);
+      }
+      if (!key->spec_mpos_.empty() && key->spec_mpos_.size() != 3*nmocap) {
+        throw mjCError(nullptr, "Keyframe %s has invalid mpos size, got %d, should be %d",
+                      key->name.c_str(), key->spec_mpos_.size(), 3*nmocap);
+      }
+      if (!key->spec_mquat_.empty() && key->spec_mquat_.size() != 4*nmocap) {
+        throw mjCError(nullptr, "Keyframe %s has invalid mquat size, got %d, should be %d",
+                      key->name.c_str(), key->spec_mquat_.size(), 4*nmocap);
+      }
     }
-    if (!key->spec_qvel_.empty() && key->spec_qvel_.size() != nv) {
-      throw mjCError(nullptr, "Keyframe %s has invalid qvel size, got %d, should be %d",
-                     key->name.c_str(), key->spec_qvel_.size(), nv);
-    }
-    if (!key->spec_act_.empty() && key->spec_act_.size() != na) {
-      throw mjCError(nullptr, "Keyframe %s has invalid act size, got %d, should be %d",
-                     key->name.c_str(), key->spec_act_.size(), na);
-    }
-    if (!key->spec_ctrl_.empty() && key->spec_ctrl_.size() != nu) {
-      throw mjCError(nullptr, "Keyframe %s has invalid ctrl size, got %d, should be %d",
-                     key->name.c_str(), key->spec_ctrl_.size(), nu);
-    }
-    if (!key->spec_mpos_.empty() && key->spec_mpos_.size() != 3*nmocap) {
-      throw mjCError(nullptr, "Keyframe %s has invalid mpos size, got %d, should be %d",
-                     key->name.c_str(), key->spec_mpos_.size(), 3*nmocap);
-    }
-    if (!key->spec_mquat_.empty() && key->spec_mquat_.size() != 4*nmocap) {
-      throw mjCError(nullptr, "Keyframe %s has invalid mquat size, got %d, should be %d",
-                     key->name.c_str(), key->spec_mquat_.size(), 4*nmocap);
-    }
+
     SaveState(info.name, key->spec_qpos_.data(), key->spec_qvel_.data(),
               key->spec_act_.data(), key->spec_ctrl_.data(),
               key->spec_mpos_.data(), key->spec_mquat_.data());

--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -4049,8 +4049,12 @@ void mjCModel::StoreKeyframes(mjCModel* dest) {
       "To prevent this, compile the child model before attaching it again.");
   }
 
-  // do not change compilation quantities in case the user wants to recompile preserving the state
+  // rebuild tree lists so that SaveDofOffsets computes correct sizes even when including
+  // things like `replicate` tags.
   if (!compiled) {
+    ResetTreeLists();
+    MakeTreeLists();
+    ProcessLists(/*checkrepeat=*/false);
     SaveDofOffsets(/*computesize=*/true);
     ComputeReference();
   }


### PR DESCRIPTION
Potential fix for https://github.com/google-deepmind/mujoco/issues/3071.

This modifies the `StoreKeyframes` function in two ways. The first is to rebuild the tree prior to calling `SaveDofOffsets`, just so that it has an up-to-date set of joints over which to iterate. The second is to make keyframe validation check to only run if the model has already been compiled. I think this might be counter to the fix that was added for https://github.com/google-deepmind/mujoco/issues/2365, but shouldn't keyframes with joints from replicate tags still be valid?

Confirmed it fixes the issue in the ticket, and the other user model tests pass. That said, I'm not sure what the larger consequences of this change are.