### PR TITLE
Fix zero-size malloc and memcpy

### DIFF
--- a/src/engine/engine_setconst.c
+++ b/src/engine/engine_setconst.c
@@ -588,10 +588,13 @@ static void set0(mjModel* m, mjData* d) {
   // compute dof_M0 for CRB algorithm
   mj_setM0(m, d);
 
-  // save flex_rigid, temporarily make all flexes non-rigid
-  mjtByte* rigid = mju_malloc(m->nflex);
-  memcpy(rigid, m->flex_rigid, m->nflex);
-  memset(m->flex_rigid, 0, m->nflex);
+  mjtByte* flex_rigid_cache = NULL;
+  if (m->nflex > 0) {
+    // save flex_rigid, temporarily make all flexes non-rigid
+    flex_rigid_cache = mju_malloc(m->nflex);
+    memcpy(flex_rigid_cache, m->flex_rigid, m->nflex);
+    memset(m->flex_rigid, 0, m->nflex);
+  }
 
   // run remaining computations
   mj_tendon(m, d);
@@ -600,9 +603,11 @@ static void set0(mjModel* m, mjData* d) {
   mj_flex(m, d);
   mj_transmission(m, d);
 
-  // restore flex rigidity
-  memcpy(m->flex_rigid, rigid, m->nflex);
-  mju_free(rigid);
+  if (flex_rigid_cache) {
+    // restore flex rigidity
+    memcpy(m->flex_rigid, flex_rigid_cache, m->nflex);
+    mju_free(flex_rigid_cache);
+  }
 
   // restore camera and light mode
   for (int i=0; i < m->ncam; i++) {


### PR DESCRIPTION
When running some our internal code under `valgrind`, I ran into warnings inside Mujoco's `set0` function:

```
==720211== Thread 2:
==720211== Unsafe allocation with size of zero is implementation-defined
==720211==    at 0x4901C8B: memalign (vg_replace_malloc.c:2026)
==720211==    by 0x4A42AE7: mju_malloc (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x4A30CDC: set0 (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x4A336B2: mj_setConst (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x4AD6AB6: mjCModel::TryCompile(mjModel_*&, mjData_*&, mjVFS_ const*) (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x4AD2FA2: mjCModel::Compile(mjVFS_ const*, mjModel_**) (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x4B2CAEB: mj_loadXML (in /home/BOSDYN/rdeits/Projects/mujoco/build/lib/libmujoco.so.3.4.1)
==720211==    by 0x40123D8: (anonymous namespace)::LoadModel(char const*, mujoco::Simulate&) (in /home/BOSDYN/rdeits/Projects/mujoco/build/bin/simulate)
==720211==    by 0x40172EF: PhysicsThread(mujoco::Simulate*, char const*) (in /home/BOSDYN/rdeits/Projects/mujoco/build/bin/simulate)
==720211==    by 0x4DF2252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==720211==    by 0x50DFAC2: start_thread (pthread_create.c:442)
==720211==    by 0x5170A83: clone (clone.S:100)
```

I can reproduce this by running the `simulate` binary after building from source:

```
~/apps/valgrind-3.26.0/build/bin/valgrind ./bin/simulate <my robot model.xml>
```

The issue is that `m->nflex` can be zero, in which case we end up calling `aligned_alloc` with a size of zero. I can't find clear information on whether that's allowed or not -- some sources say yes, others say no. The `memcpy` on the subsequent line is also suspect: If `malloc` returns null (which I think it's allowed to for zero size), then even a zero-size `memcpy` is undefined behavior with a null destination. 

This change resolves the valgrind warning in `set0`. Note that we do still see some warnings inside `libnvidia-glcore` both before and after this change. 