### PR TITLE
Fix MinGW stack flag syntax and Python binding crashes

### DIFF
--- a/cmake/MujocoLinkOptions.cmake
+++ b/cmake/MujocoLinkOptions.cmake
@@ -23,16 +23,12 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,/STACK:16777216)
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD)
-      if(SUPPORTS_LLD)
-        set(EXTRA_LINK_OPTIONS
-            ${EXTRA_LINK_OPTIONS}
-            -fuse-ld=lld-link
-            -Wl,/OPT:REF
-            -Wl,/OPT:ICF
-        )
+      check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      if(SUPPORTS_LLD_LINK)
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld-link -Wl,/STACK:16777216 -Wl,/OPT:REF -Wl,/OPT:ICF)
+      else()
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--stack,16777216)
       endif()
     else()
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")

--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -51,6 +51,8 @@ endif()
 
 include(MujocoLinkOptions)
 get_mujoco_extra_link_options(EXTRA_LINK_OPTIONS)
+list(FILTER EXTRA_LINK_OPTIONS EXCLUDE REGEX "STACK")
+list(FILTER EXTRA_LINK_OPTIONS EXCLUDE REGEX "stack")
 add_link_options(${EXTRA_LINK_OPTIONS})
 
 include(MujocoMacOS)

--- a/sample/cmake/MujocoLinkOptions.cmake
+++ b/sample/cmake/MujocoLinkOptions.cmake
@@ -23,16 +23,12 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,/STACK:16777216)
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD)
-      if(SUPPORTS_LLD)
-        set(EXTRA_LINK_OPTIONS
-            ${EXTRA_LINK_OPTIONS}
-            -fuse-ld=lld-link
-            -Wl,/OPT:REF
-            -Wl,/OPT:ICF
-        )
+      check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      if(SUPPORTS_LLD_LINK)
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld-link -Wl,/STACK:16777216 -Wl,/OPT:REF -Wl,/OPT:ICF)
+      else()
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--stack,16777216)
       endif()
     else()
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")

--- a/simulate/cmake/MujocoLinkOptions.cmake
+++ b/simulate/cmake/MujocoLinkOptions.cmake
@@ -23,16 +23,12 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,/STACK:16777216)
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD)
-      if(SUPPORTS_LLD)
-        set(EXTRA_LINK_OPTIONS
-            ${EXTRA_LINK_OPTIONS}
-            -fuse-ld=lld-link
-            -Wl,/OPT:REF
-            -Wl,/OPT:ICF
-        )
+      check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      if(SUPPORTS_LLD_LINK)
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld-link -Wl,/STACK:16777216 -Wl,/OPT:REF -Wl,/OPT:ICF)
+      else()
+        set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--stack,16777216)
       endif()
     else()
       set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")


### PR DESCRIPTION
This Pull Request addresses issues with linker flag syntax on MinGW and prevents crashes when loading MuJoCo as a Python module on Windows.

### Changes
- Updated MujocoLinkOptions.cmake to detect the linker type. It now uses /STACK:16777216 for lld-link and --stack,16777216 for the standard MinGW ld linker.
- Filtered out stack-related flags from the Python binding modules. Applying stack size to a shared library (DLL) is non-standard on Windows and causes immediate crashes in the Python interpreter.

Fixes #3011