### PR TITLE
Fix MinGW stat redefinition and thread-safe localtime

### DIFF
--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -99,7 +99,7 @@ void mju_writeLog(const char* type, const char* msg) {
 
 #if defined(_POSIX_C_SOURCE) || defined(__APPLE__) || defined(__STDC_VERSION_TIME_H__) || defined(__EMSCRIPTEN__)
     localtime_r(&rawtime, &timeinfo);
-#elif _MSC_VER
+#elif defined(_WIN32)
     localtime_s(&timeinfo, &rawtime);
 #elif __STDC_LIB_EXT1__
     localtime_s(&rawtime, &timeinfo);

--- a/src/user/user_vfs.cc
+++ b/src/user/user_vfs.cc
@@ -15,7 +15,7 @@
 #include "user/user_vfs.h"
 
 #include <sys/stat.h>
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #define stat _stat
 #endif
 


### PR DESCRIPTION
This Pull Request addresses POSIX compatibility and thread-safety issues when building with MinGW-w64.

### Changes
- Wrapped the #define stat _stat definition in !defined(__MINGW32__). MinGW-w64 provides its own POSIX-compliant stat implementation, and forcing the MSVC-style redefinition causes conflict.
- Replaced the _MSC_VER check with defined(_WIN32) when selecting localtime_s. MinGW provides the Windows-native thread-safe localtime_s function but does not define _MSC_VER.

Fixes #3038 and #3037