### PR TITLE
Fix MinGW printf format errors for size_t

### DIFF
--- a/src/engine/engine_util_misc.c
+++ b/src/engine/engine_util_misc.c
@@ -1546,9 +1546,9 @@ const char* mju_writeNumBytes(size_t nbytes) {
     }
   }
   if (i < 6) {
-    mjSNPRINTF(message, "%zu%c", nbytes >> (10*(6-i)), suffix[6-i]);
+    mjSNPRINTF(message, "%llu%c", (unsigned long long)(nbytes >> (10*(6-i))), suffix[6-i]);
   } else {
-    mjSNPRINTF(message, "%zu", nbytes >> (10*(6-i)));
+    mjSNPRINTF(message, "%llu", (unsigned long long)(nbytes >> (10*(6-i))));
   }
   return message;
 }
@@ -1560,13 +1560,14 @@ const char* mju_warningText(int warning, size_t info) {
 
   switch ((mjtWarning) warning) {
   case mjWARN_INERTIA:
-    mjSNPRINTF(str, "Inertia matrix is too close to singular at DOF %zu. Check model.", info);
+    mjSNPRINTF(str, "Inertia matrix is too close to singular at DOF %llu. Check model.", 
+               (unsigned long long)info);
     break;
 
   case mjWARN_CONTACTFULL:
     mjSNPRINTF(str,
                "Too many contacts. The arena memory is full, increase arena memory allocation."
-               "(ncon = %zu)", info);
+               "(ncon = %llu)", (unsigned long long)info);
     break;
 
   case mjWARN_CNSTRFULL:
@@ -1576,24 +1577,28 @@ const char* mju_warningText(int warning, size_t info) {
     break;
 
   case mjWARN_VGEOMFULL:
-    mjSNPRINTF(str, "Pre-allocated visual geom buffer is full. Increase maxgeom above %zu.", info);
+    mjSNPRINTF(str, "Pre-allocated visual geom buffer is full. Increase maxgeom above %llu.", 
+               (unsigned long long)info);
     break;
 
   case mjWARN_BADQPOS:
-    mjSNPRINTF(str, "Nan, Inf or huge value in QPOS at DOF %zu. The simulation is unstable.", info);
+    mjSNPRINTF(str, "Nan, Inf or huge value in QPOS at DOF %llu. The simulation is unstable.", 
+               (unsigned long long)info);
     break;
 
   case mjWARN_BADQVEL:
-    mjSNPRINTF(str, "Nan, Inf or huge value in QVEL at DOF %zu. The simulation is unstable.", info);
+    mjSNPRINTF(str, "Nan, Inf or huge value in QVEL at DOF %llu. The simulation is unstable.", 
+               (unsigned long long)info);
     break;
 
   case mjWARN_BADQACC:
-    mjSNPRINTF(str, "Nan, Inf or huge value in QACC at DOF %zu. The simulation is unstable.", info);
+    mjSNPRINTF(str, "Nan, Inf or huge value in QACC at DOF %llu. The simulation is unstable.", 
+               (unsigned long long)info);
     break;
 
   case mjWARN_BADCTRL:
-    mjSNPRINTF(str, "Nan, Inf or huge value in CTRL at ACTUATOR %zu. The simulation is unstable.",
-               info);
+    mjSNPRINTF(str, "Nan, Inf or huge value in CTRL at ACTUATOR %llu. The simulation is unstable.",
+               (unsigned long long)info);
     break;
 
   default:

--- a/src/thread/thread_pool.cc
+++ b/src/thread/thread_pool.cc
@@ -199,7 +199,7 @@ mjStackInfo* mju_getStackInfoForThread(mjData* d, size_t thread_id) {
   }
 
   if (bytes_per_shard * number_of_shards > total_arena_size_bytes) {
-    mju_error("Arena is not large enough for %zu shards", number_of_shards);
+    mju_error("Arena is not large enough for %llu shards", (unsigned long long)number_of_shards);
   }
 
   uintptr_t result = (end_of_arena_ptr - (thread_id + 1) * bytes_per_shard);
@@ -239,8 +239,8 @@ static void  ConfigureMultiThreadedStack(mjData* d) {
       // abort if the current stack is already larger than the portion of the stack
       // that would be reserved for the main thread
       if ((uintptr_t)end_shard_cursor_ptr > current_limit) {
-        mju_error("mj_bindThreadPool: sharding stack - existing stack larger than shard size: current_size = %zu, "
-                  "max_size = %zu", current_limit, (uintptr_t) end_shard_cursor_ptr);
+        mju_error("mj_bindThreadPool: sharding stack - existing stack larger than shard size: current_size = %llu, "
+                  "max_size = %llu", (unsigned long long)current_limit, (unsigned long long)end_shard_cursor_ptr);
       }
       end_shard_cursor_ptr->top = current_limit;
       end_shard_cursor_ptr->stack_base = d->pbase;

--- a/src/user/user_vfs.cc
+++ b/src/user/user_vfs.cc
@@ -130,8 +130,8 @@ VFS::VFS(mjVFS* vfs) : self_(vfs) {
 VFS::~VFS() {
   if (!open_resources_.empty()) {
     mju_warning(
-        "VFS destroyed with %zu open resources. Resources will be invalidated.",
-        open_resources_.size());
+        "VFS destroyed with %llu open resources. Resources will be invalidated.",
+        (unsigned long long)open_resources_.size());
   }
   for (auto& [ptr, res] : open_resources_) {
     if (res->provider->close) {


### PR DESCRIPTION
This Pull Request fixes build errors on MinGW toolchains that do not correctly support the %zu format specifier.

### Changes
- Replaced %zu with %llu in 	hread_pool.cc, engine_util_misc.c, and user_vfs.cc.
- Cast the corresponding size_t arguments to (unsigned long long) to ensure compatibility across MSVC, MinGW, and other compilers.

Fixes #3039