### PR TITLE
Export callback globals on Windows

### DIFF
--- a/src/engine/engine_callback.c
+++ b/src/engine/engine_callback.c
@@ -18,14 +18,14 @@
 
 //------------------------- global callback pointers -----------------------------------------------
 
-mjfGeneric mjcb_passive  = 0;
-mjfGeneric mjcb_control  = 0;
-mjfConFilt mjcb_contactfilter = 0;
-mjfSensor mjcb_sensor    = 0;
-mjfTime mjcb_time        = 0;
-mjfAct mjcb_act_bias     = 0;
-mjfAct mjcb_act_gain     = 0;
-mjfAct mjcb_act_dyn      = 0;
+MJAPI mjfGeneric mjcb_passive  = 0;
+MJAPI mjfGeneric mjcb_control  = 0;
+MJAPI mjfConFilt mjcb_contactfilter = 0;
+MJAPI mjfSensor mjcb_sensor    = 0;
+MJAPI mjfTime mjcb_time        = 0;
+MJAPI mjfAct mjcb_act_bias     = 0;
+MJAPI mjfAct mjcb_act_gain     = 0;
+MJAPI mjfAct mjcb_act_dyn      = 0;
 
 
 

--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -49,10 +49,10 @@ static inline void mju_alignedFree(void* ptr) {
 //------------------------- default user handlers --------------------------------------------------
 
 // define and clear handlers
-void (*mju_user_error) (const char*) = 0;
-void (*mju_user_warning) (const char*) = 0;
-void* (*mju_user_malloc) (size_t) = 0;
-void (*mju_user_free) (void*) = 0;
+MJAPI void (*mju_user_error) (const char*) = 0;
+MJAPI void (*mju_user_warning) (const char*) = 0;
+MJAPI void* (*mju_user_malloc) (size_t) = 0;
+MJAPI void (*mju_user_free) (void*) = 0;
 
 
 // restore default processing


### PR DESCRIPTION
This Pull Request fixes linkage issues on Windows where global callback variables were not being correctly exported in the MuJoCo DLL.

### Changes
- Added MJAPI to the definitions of mju_user_error, mju_user_warning, mju_user_malloc, and mju_user_free in engine_util_errmem.c.
- Added MJAPI to the definitions of mjcb_* variables in engine_callback.c.

This ensures these symbols are included in the .lib import library, allowing them to be used by researchers using Rust or other non-MSVC toolchains on Windows.

Fixes #3060