### PR TITLE
Fix island discovery with multiple coupled trees

### DIFF
--- a/src/engine/engine_island.c
+++ b/src/engine/engine_island.c
@@ -412,12 +412,12 @@ void mj_island(const mjModel* m, mjData* d) {
 
   mj_markStack(d);
 
-  // allocate edge array, nJ is an upper bound
-  int* edge = mjSTACKALLOC(d, 2*nJ, int);
+  // allocate edge array, 2*nJ is an upper bound
+  int* edge = mjSTACKALLOC(d, 4*nJ, int);
 
   // get tree-tree edges and rownnz counts from efc arrays
   int* rownnz = mjSTACKALLOC(d, ntree, int);  // number of edges per tree
-  int nedge = findEdges(m, d, rownnz, edge, nJ);
+  int nedge = findEdges(m, d, rownnz, edge, 2*nJ);
 
   // compute starting address of tree's column indices while resetting rownnz
   int* rowadr = mjSTACKALLOC(d, ntree, int);


### PR DESCRIPTION
This Pull Request fixes a crash in the MuJoCo engine when loading models with equality constraints that couple many bodies (e.g., complex tendon equalities).

### The Problem
During island discovery, the engine builds an adjacency graph of bodies (trees). The temporary edge array was sized to hold at most 
J (number of non-zeros in the constraint Jacobian) edges. However, when a single constraint row involves $ distinct trees, it can contribute up to (k-1)$ edges to the graph. If (k-1) > k$, the edge array can be too small even if  \le nJ$.

### The Fix
Increased the size of the temporary edge array from 
J edges to 2*nJ edges (and 4*nJ integers). This provides a safe upper bound for any configuration of constraints.

Fixes #3073