### PR TITLE
Improve wording for WASM Windows support status

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -15,8 +15,8 @@ TypeScript.
 > section. Also note that development has primarily taken place on Linux using
 > Google Chrome. If you're working on a different OS or browser, you may
 > encounter some rough edges. We have successfully tested the bindings on MacOS
-> in CI but as of November 13th 2025 Windows in untested (the instructions here
-> have worked on one Windows 11 machine but have failed on other machines)._
+> in CI but as of November 13th 2025, Windows support remains experimental
+> (installation succeeded on one Windows 11 machine but failed on others)._
 
 ## Prerequisites
 


### PR DESCRIPTION
Updated the README to replace anecdotal installation results with more standard "experimental" terminology. This clarifies that Windows support is currently in early stages and performance may vary by environment, without relying on specific machine-test facts.