### PR TITLE
Fix const qualifier error in engine_print.c for GCC 14+ compatibility

### DIFF
--- a/src/engine/engine_print.c
+++ b/src/engine/engine_print.c
@@ -480,7 +480,7 @@ static bool validateFloatFormat(const char* float_format) {
   // flag characters. allow at most one of each flag
   const char flag_characters[] = "-+ #0";
   int flag_character_counts[sizeof(flag_characters)] = { 0 };
-  char* c;
+  const char* c;
   while (c = strchr(flag_characters, float_format[cur_idx]), c != NULL) {
     int flag_idx = (c - flag_characters)/sizeof(char);
     flag_character_counts[flag_idx]++;


### PR DESCRIPTION
Change 'c' variable to const char* to fix -Werror=discarded-qualifiers in validateFloatFormat function. GCC 14+ introduced stricter type checking defaults, flagging this assignment as an error.

This PR fixes
```
mujoco/src/engine/engine_print.c:484:12: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]  484 |   while (c = strchr(flag_characters, float_format[cur_idx]), c != NULL) {
```

Tested on
- Linux: GCC 15.2.1 (x64)
- Windows: MSVC 19.50.35723 (x64)
- macOS: Apple Clang 17.0.0 (clang-1700.6.3.2) (arm64)