### PR TITLE
Fix tracking camera detaching when toggling visualization flags

### DIFF
--- a/simulate/simulate.cc
+++ b/simulate/simulate.cc
@@ -1584,22 +1584,24 @@ void UiEvent(mjuiState* state) {
 
     // rendering section
     else if (it && it->sectionid==SECT_RENDERING) {
-      // set camera in mjvCamera
-      if (sim->camera==0) {
-        sim->cam.type = mjCAMERA_FREE;
-      } else if (sim->camera==1) {
-        if (sim->pert.select>0) {
-          sim->cam.type = mjCAMERA_TRACKING;
-          sim->cam.trackbodyid = sim->pert.select;
-          sim->cam.fixedcamid = -1;
-        } else {
+      // only update camera when the camera selector itself changed
+      if (it->pdata == &sim->camera) {
+        if (sim->camera==0) {
           sim->cam.type = mjCAMERA_FREE;
-          sim->camera = 0;
-          mjui0_update_section(sim, SECT_RENDERING);
+        } else if (sim->camera==1) {
+          if (sim->pert.select>0) {
+            sim->cam.type = mjCAMERA_TRACKING;
+            sim->cam.trackbodyid = sim->pert.select;
+            sim->cam.fixedcamid = -1;
+          } else {
+            sim->cam.type = mjCAMERA_FREE;
+            sim->camera = 0;
+            mjui0_update_section(sim, SECT_RENDERING);
+          }
+        } else {
+          sim->cam.type = mjCAMERA_FIXED;
+          sim->cam.fixedcamid = sim->camera - 2;
         }
-      } else {
-        sim->cam.type = mjCAMERA_FIXED;
-        sim->cam.fixedcamid = sim->camera - 2;
       }
       // copy camera spec to clipboard (as MJCF element)
       if (it->itemid == 3) {


### PR DESCRIPTION
Toggling visualization flags via keyboard shortcuts (e.g., C for contact points, F for contact forces) causes the `SECT_RENDERING` event handler to unconditionally re-evaluate the camera selection, which can reset a tracking camera to free mode. This particularly affects users of `mujoco.viewer` who set tracking cameras programmatically.

Guard the camera update logic so it only runs when the camera selector itself is changed, not when other items in the rendering section are modified.