### PR TITLE
pre-commit: lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+# Run pre-commit hooks on files changed in the PR only.
+name: lint
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer


### PR DESCRIPTION
# Pre-commit Hooks Summary

Hooks configured in [.pre-commit-config.yaml](file:///usr/local/google/home/taylorhowell/research/mujoco/.pre-commit-config.yaml), run on every PR via [lint.yml](file:///usr/local/google/home/taylorhowell/research/mujoco/.github/workflows/lint.yml).

---

## `trailing-whitespace`

Detects and removes trailing spaces/tabs at the end of lines.

```diff
-int x = 5;··
+int x = 5;
```

## `end-of-file-fixer`

Ensures every file ends with exactly one newline, and removes excess trailing blank lines.

```diff
 // last line of code
-}⏎
-⏎
-⏎
+}⏎
```