### PR TITLE
Fix ResolveReferences for Empty Sidesites

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -6267,7 +6267,7 @@ void mjCTendon::ResolveReferences(const mjCModel* m) {
     try {
       // look for wrapped element with namespace
       path[i]->name = prefix + pname + suffix;
-      path[i]->sidesite = prefix + psidesite + suffix;
+      path[i]->sidesite = psidesite.empty() ? psidesite : prefix + psidesite + suffix;
       path[i]->ResolveReferences(m);
     } catch(mjCError) {
       // remove namespace from wrap names

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -909,9 +909,10 @@ static constexpr char xml_child[] = R"(
         <frame name="cframe">
           <body name="body">
             <joint type="hinge" name="hinge"/>
-            <geom class="cylinder" material="material"/>
+            <geom name="cylinder" class="cylinder" material="material"/>
             <light mode="targetbody" target="targetbody"/>
             <site name="site" material="material"/>
+            <site name="othersite" material="material"/>
             <body name="targetbody"/>
             <body/>
           </body>
@@ -933,6 +934,11 @@ static constexpr char xml_child[] = R"(
       <fixed name="fixed">
         <joint joint="hinge" coef="2"/>
       </fixed>
+      <spatial name="spatial">
+        <site site="site"/>
+        <geom geom="cylinder"/>
+        <site site="othersite"/>
+      </spatial>
     </tendon>
 
     <actuator>
@@ -976,9 +982,10 @@ TEST_F(MujocoTest, AttachSame) {
     <worldbody>
       <body name="body">
         <joint type="hinge" name="hinge"/>
-        <geom class="cylinder" material="material"/>
+        <geom name="cylinder" class="cylinder" material="material"/>
         <light mode="targetbody" target="targetbody"/>
         <site name="site" material="material"/>
+        <site name="othersite" material="material"/>
         <body name="targetbody"/>
         <body/>
       </body>
@@ -989,9 +996,10 @@ TEST_F(MujocoTest, AttachSame) {
       <frame name="frame" pos=".1 0 0" euler="0 90 0">
         <body name="attached-body-1">
           <joint type="hinge" name="attached-hinge-1"/>
-          <geom class="cylinder" material="material"/>
+          <geom name="attached-cylinder-1" class="cylinder" material="material"/>
           <light mode="targetbody" target="attached-targetbody-1"/>
           <site name="attached-site-1" material="material"/>
+          <site name="attached-othersite-1" material="material"/>
           <body name="attached-targetbody-1"/>
           <body/>
         </body>
@@ -1008,9 +1016,19 @@ TEST_F(MujocoTest, AttachSame) {
       <fixed name="fixed">
         <joint joint="hinge" coef="2"/>
       </fixed>
+      <spatial name="spatial">
+        <site site="site"/>
+        <geom geom="cylinder"/>
+        <site site="othersite"/>
+      </spatial>
       <fixed name="attached-fixed-1">
         <joint joint="attached-hinge-1" coef="2"/>
       </fixed>
+      <spatial name="attached-spatial-1">
+        <site site="attached-site-1"/>
+        <geom geom="attached-cylinder-1"/>
+        <site site="attached-othersite-1"/>
+      </spatial>
     </tendon>
 
     <actuator>
@@ -1132,9 +1150,10 @@ TEST_F(MujocoTest, AttachDifferent) {
         <frame name="frame" pos=".1 0 0" euler="0 90 0">
           <body name="attached-body-1">
             <joint type="hinge" name="attached-hinge-1"/>
-            <geom class="attached-cylinder-1" material="attached-material-1"/>
+            <geom name="attached-cylinder-1" class="attached-cylinder-1" material="attached-material-1"/>
             <light mode="targetbody" target="attached-targetbody-1"/>
             <site name="attached-site-1" material="attached-material-1"/>
+            <site name="attached-othersite-1" material="attached-material-1"/>
             <body name="attached-targetbody-1"/>
             <body/>
           </body>
@@ -1150,6 +1169,11 @@ TEST_F(MujocoTest, AttachDifferent) {
       <fixed name="attached-fixed-1">
         <joint joint="attached-hinge-1" coef="2"/>
       </fixed>
+      <spatial name="attached-spatial-1">
+        <site site="attached-site-1"/>
+        <geom geom="attached-cylinder-1"/>
+        <site site="attached-othersite-1"/>
+      </spatial>
     </tendon>
 
     <actuator>
@@ -1271,9 +1295,10 @@ TEST_F(MujocoTest, AttachFrame) {
           <frame name="cframe">
             <body name="attached-body-1">
               <joint type="hinge" name="attached-hinge-1"/>
-              <geom class="attached-cylinder-1" material="attached-material-1"/>
+              <geom name="attached-cylinder-1" class="attached-cylinder-1" material="attached-material-1"/>
               <light mode="targetbody" target="attached-targetbody-1"/>
               <site name="attached-site-1" material="attached-material-1"/>
+              <site name="attached-othersite-1" material="attached-material-1"/>
               <body name="attached-targetbody-1"/>
               <body/>
             </body>
@@ -1290,6 +1315,11 @@ TEST_F(MujocoTest, AttachFrame) {
       <fixed name="attached-fixed-1">
         <joint joint="attached-hinge-1" coef="2"/>
       </fixed>
+      <spatial name="attached-spatial-1">
+        <site site="attached-site-1"/>
+        <geom geom="attached-cylinder-1"/>
+        <site site="attached-othersite-1"/>
+      </spatial>
     </tendon>
 
     <actuator>


### PR DESCRIPTION
Hello! This PR should fix the issue I raised over here: #3119 

### The Problem
* Define a model containing a `spatial` tendon with a wrapping `geom` that doesn't specify a `sidesite`
* Attach that model to another using `mjs_attach` and specify a prefix and/or suffix
* Execution finds its way to `mjCTendon::ResolveReferences` where the sidesite is named `prefix + "" + suffix`
* `mjCWrap::ResolveReferences` tries to find the site `prefix + "" + suffix`, fails and throws.
* That exception is caught in `mjCModel::CopyList` and the tendon is skipped due to [this continue statement](https://github.com/google-deepmind/mujoco/blob/c428f675e73e7eb3d21662b16f1b305450731ff1/src/user/user_model.cc#L280)

### The Fix
Don't apply the prefix and suffix when a spatial tendon's `sidesite` is empty. That'll let `mjCTendon::ResolveReferences` know that it need not search for the `site`.

To add some test coverage for this, I also added a `spatial` tendon to the `xml_child` used by `MujocoTest.AttachSame`, `MujocoTest.AttachDifferent` and `MujocoTest.AttachFrame` in `user_api_test.cc`. These tests should all fail without the change added to `user_objects.cc`