### PR TITLE
docs: add clarifying comments to the tutorial notebook

### DIFF
--- a/python/tutorial.ipynb
+++ b/python/tutorial.ipynb
@@ -45,6 +45,8 @@
    },
    "outputs": [],
    "source": [
+    "# Import the MuJoCo library and verify the installation\n",
+    "\n",
     "!pip install mujoco\n",
     "\n",
     "# Set up GPU rendering.\n",


### PR DESCRIPTION
Added clarifying comments to the first cell of the main tutorial notebook (`python/tutorial.ipynb`).

This change is intended to improve the onboarding experience for new users by explicitly explaining the library import and verification steps.