### PR TITLE
Add USD parsing for contact excludes

### DIFF
--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -2250,12 +2250,8 @@ void ParseMjcPhysicsKeyframe(mjSpec* spec,
 }
 
 void ParseUsdFilteredPairsAPI(mjSpec* spec, const pxr::UsdPrim& prim) {
-  if (!prim.HasAPI<pxr::UsdPhysicsFilteredPairsAPI>()) {
-    return;
-  }
-  auto filtered_pairs_api = pxr::UsdPhysicsFilteredPairsAPI(prim);
   pxr::SdfPathVector filtered_bodies;
-  filtered_pairs_api.GetFilteredPairsRel().GetTargets(&filtered_bodies);
+  pxr::UsdPhysicsFilteredPairsAPI(prim).GetFilteredPairsRel().GetTargets(&filtered_bodies);
   for (const auto& filtered_body : filtered_bodies) {
     mjsExclude* exclude = mjs_addExclude(spec);
     mjs_setString(exclude->bodyname1, prim.GetPath().GetAsString().c_str());
@@ -2283,7 +2279,9 @@ mjsBody* ParseUsdPhysicsRigidbody(
       body->element, kUsdPrimPathKey, usd_primpath,
       [](const void* data) { delete static_cast<const pxr::SdfPath*>(data); });
 
-  ParseUsdFilteredPairsAPI(spec, prim);
+  if (prim.HasAPI<pxr::UsdPhysicsFilteredPairsAPI>()) {
+    ParseUsdFilteredPairsAPI(spec, prim);
+  }
 
   return body;
 }


### PR DESCRIPTION
Contact excludes use the `UsdPhysicsFilteredPairsAPI` schema. Body1 is the body with the schema, body2 is contained in the list of filtered targets within the schema.

This zip contains a test USD model that demonstrates the feature:
[collision_excludes.zip](https://github.com/user-attachments/files/25494140/collision_excludes.zip)

