### PR TITLE
Enable COOP/COEP headers for wasm Vite dev servers

### DIFF
--- a/wasm/demo_app/vite.demo.config.ts
+++ b/wasm/demo_app/vite.demo.config.ts
@@ -23,5 +23,9 @@ export default defineConfig({
   },
   server: {
     open: true,
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
   },
 })

--- a/wasm/tests/sandbox/vite.sandbox.config.ts
+++ b/wasm/tests/sandbox/vite.sandbox.config.ts
@@ -23,5 +23,9 @@ export default defineConfig({
   },
   server: {
     open: true,
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
   },
 })


### PR DESCRIPTION
# Summary

Fixes: https://github.com/google-deepmind/mujoco/issues/3078

Enable cross-origin isolation for the wasm dev servers so the browser can use `SharedArrayBuffer` with worker transfers (required by Emscripten `pthreads`).

## What changed

- Added the following headers to the Vite dev server configs:
   - `Cross-Origin-Opener-Policy: same-origin`
   - `Cross-Origin-Embedder-Policy: require-corp`

## Why

Browsers require COOP+COEP (cross-origin isolation) for `SharedArrayBuffer` transfers. Without these headers the app raised: `DataCloneError: SharedArrayBuffer transfer requires self.crossOriginIsolated.` which prevented pthread-backed wasm workers from initializing.

## Testing / verification

- Start dev server: `npm run dev:demo --prefix ./wasm` or `npm run dev:sandbox --prefix ./wasm`
- Verify headers: `curl -I http://localhost:5173/` (or the port Vite reports) — response should include the two COOP/COEP headers.
- In the browser console:
   - Verify `crossOriginIsolated` is `true`. Reload and confirm the previous DataCloneError no longer appears.
   - If issues persist, clear service workers/site data and ensure cache is disabled.