### PR TITLE
Fix `mj_sensorAcc` returning zero after `mj_step1`

### DIFF
--- a/src/engine/engine_forward.c
+++ b/src/engine/engine_forward.c
@@ -1530,6 +1530,7 @@ void mj_step2(const mjModel* m, mjData* d) {
   mj_fwdActuation(m, d);
   mj_fwdAcceleration(m, d);
   mj_fwdConstraint(m, d);
+  d->flg_rnepost = 0;  // clear flag for lazy evaluation
   mj_sensorAcc(m, d);
   mj_checkAcc(m, d);
 


### PR DESCRIPTION
`mj_step2` was not clearing `flg_rnepost` before calling `mj_sensorAcc`. This meant the flag stayed set from the previous timestep, so `mj_rnePostConstraint` was skipped and acceleration sensors read zero.

`mj_forwardSkip` already clears the flag correctly. This patch does the same in `mj_step2`.

Added a regression test that settles a box with a split step loop, then checks that the accelerometer reads gravity after `mj_step1` + `mj_sensorAcc`.

Fixes #3133.