### PR TITLE
Fix resource leaks in to_zip/from_zip and incorrect dirname argument in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ EXT_PREFIX = 'mujoco.'
 
 def get_long_description():
   """Creates a long description for the package from bundled markdown files."""
-  current_dir = os.path.dirname('__file__')
+  current_dir = os.path.dirname(__file__)
   with open(os.path.join(current_dir, 'README.md')) as f:
     description = f.read()
   try:


### PR DESCRIPTION
# Summary

Fixes three bugs in the Python bindings:

## Resource leaks in `to_zip` and `from_zip`

When a string filepath is passed to `to_zip` or `from_zip`, the file is opened but never explicitly closed. In `from_zip`, if `zipfile.is_zipfile()` returns `False`, the `ValueError` is raised before the `ZipFile` context manager gets a chance to close the handle.

Both functions now track whether they opened the file and use `try/finally` to ensure cleanup.

## Incorrect `os.path.dirname` argument in `setup.py`

`get_long_description()` passes the string literal `'__file__'` to `os.path.dirname()` instead of the variable `__file__`. This causes `current_dir` to resolve to an empty string rather than the directory containing `setup.py`, so the function only works when the working directory happens to be the same as the `setup.py` directory.