### PR TITLE
Add Python 3.14 classifier to mujoco and mujoco-mjx

### DIFF
--- a/mjx/pyproject.toml
+++ b/mjx/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 requires-python = ">=3.10"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [


### PR DESCRIPTION
Adds the Programming Language :: Python :: 3.14 classifier to both mujoco and mujoco-mjx in their respective pyproject.toml files.
->This change is limited to package metadata only and does not modify any build, CI, or release logic.

## Changes
Added "Programming Language :: Python :: 3.14" to:
python/pyproject.toml
mjx/pyproject.toml
Preserves existing supported versions (3.10–3.13).

## Not Modified (by design)
.github/workflows/build.yml
build_steps.sh
setup.py / CMake files
build_requirements.txt

## Notes -> 

While experimenting with enabling CI validation for Python 3.14, I observed that the current build_requirements.txt pins numpy==2.1.3 with --require-hashes, which does not provide cp314 wheels. Enabling CI testing for 3.14 will require updating the pinned build dependencies.