### PR TITLE
Add python 3.14 support

### DIFF
--- a/mjx/pyproject.toml
+++ b/mjx/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 requires-python = ">=3.10"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [


### PR DESCRIPTION
##overview

This PR adds the Programming Language :: Python :: 3.14 classifier to both mujoco and mujoco-mjx in their respective pyproject.toml files.
The change is limited to package metadata only and does not modify any build, CI, or release logic.

## Details -:

Added "Programming Language :: Python :: 3.14" to:
python/pyproject.toml
mjx/pyproject.toml
Existing supported versions (3.10–3.13) are preserved.

## No changes were made to:

CI workflows
build_steps.sh
CMake files
build_requirements.txt

## Notes -: 
While experimenting with enabling CI testing for Python 3.14, I observed that the current build_requirements.txt pins numpy==2.1.3 with --require-hashes, which does not provide cp314 wheels. Enabling CI validation for 3.14 would therefore require updating pinned build dependencies.

This PR is intentionally scoped to classifier updates only.