### PR TITLE
fix: release the gil when calling compile in spec.recompile

### DIFF
--- a/python/mujoco/structs.cc
+++ b/python/mujoco/structs.cc
@@ -77,7 +77,18 @@ py::tuple RecompileSpec(raw::MjSpec* spec, const MjModelWrapper& old_m,
   raw::MjModel* m = static_cast<raw::MjModel*>(mju_malloc(sizeof(mjModel)));
   m->buffer = nullptr;
   raw::MjData* d = mj_copyData(nullptr, old_m.get(), old_d.get());
-  if (mj_recompile(spec, nullptr, m, d)) {
+
+  bool compile_failed = false;
+
+  {
+    // Release GIL before calling mj_recompile which may spawn threads
+    py::gil_scoped_release no_gil;
+    if (mj_recompile(spec, nullptr, m, d)) {
+      compile_failed = true;
+    }
+  }
+
+  if (compile_failed) {
     throw py::value_error(mjs_getError(spec));
   }
 

--- a/python/mujoco/structs_wrappers.cc
+++ b/python/mujoco/structs_wrappers.cc
@@ -400,7 +400,18 @@ py::tuple RecompileSpec(raw::MjSpec* spec, const MjModelWrapper& old_m,
   raw::MjModel* m = static_cast<raw::MjModel*>(mju_malloc(sizeof(mjModel)));
   m->buffer = nullptr;
   raw::MjData* d = mj_copyData(nullptr, old_m.get(), old_d.get());
-  if (mj_recompile(spec, nullptr, m, d)) {
+
+  bool compile_failed = false;
+
+  {
+    // Release GIL before calling mj_recompile which may spawn threads
+    py::gil_scoped_release no_gil;
+    if (mj_recompile(spec, nullptr, m, d)) {
+      compile_failed = true;
+    }
+  }
+
+  if (compile_failed) {
     throw py::value_error(mjs_getError(spec));
   }
 


### PR DESCRIPTION
The pybind for recompile was not releasing the GIL when it called mj_recompile, this can caused deadlocks with the asset loading threads. For example if a resource provider was trying to call Python.

To resolve this the GIL is release just for the mj_recompile.

Additionally the newly allocation data and model are being freed before the ValueError is raised.

Addresses: https://github.com/google-deepmind/mujoco/issues/3118

---

I was not able to find a _nice_ way to test that the GIL we released, but I was able to validate this locally with the Python resource providers we have.