### PR TITLE
Call ParseMjcPhysicsMeshCollisionAPI() on visual prims that have an inertia attribute

### DIFF
--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -1724,8 +1724,8 @@ void ParseUsdGeomGprim(mjSpec* spec, const pxr::UsdPrim& gprim,
   if (!MaybeParseGeomPrimitive(gprim, geom, caches.xform_cache)) {
     mjsMesh* mesh = ParseUsdMesh(spec, gprim, geom, caches.xform_cache);
     if (mesh != nullptr && gprim.HasAPI<pxr::MjcPhysicsMeshCollisionAPI>()) {
-    ParseMjcPhysicsMeshCollisionAPI(mesh,
-                                    pxr::MjcPhysicsMeshCollisionAPI(gprim));
+      ParseMjcPhysicsMeshCollisionAPI(mesh,
+                                      pxr::MjcPhysicsMeshCollisionAPI(gprim));
     }
   }
 


### PR DESCRIPTION
When converting [hello_robot_stretch](https://github.com/google-deepmind/mujoco_menagerie/tree/main/hello_robot_stretch) to USD, it creates a visual mesh (`base_link_2`) with collision disabled with `mjc:inertia = "shell"`. Because the prim is visual, `ParseMjcPhysicsMeshCollisionAPI()` was not being called on it to decode this inertia property. If it doesn't have a shell inertia, the volume is too low, and it won't load in MuJoCo simulate.

This USD model demonstrates the issue:
[hello_robot_stretch.zip](https://github.com/user-attachments/files/25726511/hello_robot_stretch.zip)
