### PR TITLE
Fix segfault from <attach> mjCwrap

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -6441,8 +6441,9 @@ void mjCTendon::CopyFromSpec() {
   material_ = spec_material_;
   userdata_ = spec_userdata_;
 
-  // clear precompiled
+  // propagate model pointer to wraps and clear precompiled
   for (int i=0; i < path.size(); i++) {
+    path[i]->model = model;
     if (path[i]->Type() == mjWRAP_CYLINDER) {
       path[i]->spec.type = mjWRAP_SPHERE;
     }


### PR DESCRIPTION
## Summary
Fixes #3152: Accessing MjsTendonPath.MjsWrap Python bindings causes a segfault with a body/attach model

It honestly took me sorta a long time to trace/figure this out but the bug originates in `mjCTendon::CopyFromSpec()` in `src/user/user_objects.cc`. 

When the model is loaded using the <attach> block, MuJoCo runs CopyList() for each of the tendons:
`candidate->model = this;`
`candidate->CopyFromSpec();`
`candidate->ResolveReferences(this);`

This shows you how the model gets updated, but `CopyFromSpec()` never propagated that to the `mjCWrap` objects in `path[]`. This means that each wrap had like a null or old pointer from the child.

This solution also wasn't exactly new since the `mjCTendon::SetMode()` function already does this; I'm not sure why `CopyFromSpec` wasn't doing the same thing.

I lowkey decided on omitting the test-cases for this since it is such a small fix if that's ok. 