### PR TITLE
Chore: normalize package.json metadata

### DIFF
--- a/wasm/package.npm.json
+++ b/wasm/package.npm.json
@@ -4,7 +4,7 @@
   "description": "MuJoCo WASM bindings",
   "repository": {
     "type": "git",
-    "url": "https://github.com/google-deepmind/mujoco.git",
+    "url": "git+https://github.com/google-deepmind/mujoco.git",
     "directory": "wasm"
   },
   "homepage": "https://github.com/google-deepmind/mujoco/tree/main/wasm",


### PR DESCRIPTION
This PR addresses the npm warn publish warning encountered during the last release. 

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/google-deepmind/mujoco.git"
```

Updated repository.url from a standard HTTPS link to the preferred git+https format.