### PR TITLE
Add the required OIDC permissions for trusted published

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
-  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
This PR updates the `publish-wasm` workflow to include explicit GitHub Actions permissions. Specifically, it adds `id-token: write` and `contents: read`.

These changes are required to support OpenID Connect (OIDC), allowing the workflow to request a short-lived JWT (JSON Web Token) from GitHub's OIDC provider.

By shifting to OIDC, we reduce the risk associated with long-lived repository secrets.
Note: Even though we currently use `NPM_TOKEN`, many registries are moving toward "Provenance" and "Trusted Publishing," which require these specific permission bits to verify the build's identity.