### PR TITLE
Add manual workflow trigger for WASM publishing

### DIFF
--- a/.github/workflows/build_steps.sh
+++ b/.github/workflows/build_steps.sh
@@ -222,7 +222,7 @@ package_wasm() {
     cp wasm/package.npm.json wasm/dist/package.json
     cp wasm/README.md wasm/dist/README.md
 
-    VERSION=${GITHUB_REF#refs/tags/}
+    VERSION="${VERSION:-${GITHUB_REF#refs/tags/}}"
     npm --prefix wasm/dist version "${VERSION}" --no-git-tag-version
 
     echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -5,10 +5,21 @@ on:
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
 
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'Release tag version to deploy'
+        required: true
+        default: '0.0.0'
+
 jobs:
   publish:
     name: Publish MuJoCo WASM package
     runs-on: ubuntu-24.04
+
+    env:
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_version || github.ref_name }}
+
     steps:
     - uses: actions/checkout@v3
 
@@ -32,5 +43,5 @@ jobs:
     - name: Package WASM bindings
       env:
         NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-        GITHUB_REF: ${{ github.ref }}
+        VERSION: ${{ env.VERSION }}
       run: bash ./.github/workflows/build_steps.sh package_wasm


### PR DESCRIPTION
This PR adds support for manually triggering the `publish-wasm` workflow via `workflow_dispatch`.

### Changes

* Added a `workflow_dispatch` trigger with a required `tag_version` input.
* Introduced a `VERSION` environment variable in the workflow that resolves to:
  * the provided `tag_version` when triggered manually, or
  * `github.ref_name` when triggered by a tag push.
* Updated `package_wasm` in `build_steps.sh` to use the `VERSION` environment variable instead of deriving the version directly from `GITHUB_REF`.
* Kept a fallback to `${GITHUB_REF#refs/tags/}` for backward compatibility if `VERSION` is not set.

### Motivation

Previously the workflow could only run when a tag was pushed. Adding `workflow_dispatch` allows maintainers to:

* manually publish a release when needed,
* retry publishing without creating a new tag,
* test the release pipeline more easily.

Using a dedicated `VERSION` variable also avoids overriding GitHub-provided environment variables such as `GITHUB_REF`, which keeps the workflow behavior clearer and more predictable.

### Behavior

| Trigger            | Version source      |
| ------------------ | ------------------- |
| Tag push (`1.2.3`) | `github.ref_name`   |
| Manual dispatch    | `tag_version` input |

No changes to the resulting npm package contents or publish process.
