### PR TITLE
full change in implementing windows malloc support

### DIFF
--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -40,12 +40,18 @@
 
 static LONG CALLBACK mju_commitHandler(EXCEPTION_POINTERS* ep) {
   if (ep->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+    ULONG_PTR access_type = ep->ExceptionRecord->ExceptionInformation[0];
     void* fault_addr = (void*)ep->ExceptionRecord->ExceptionInformation[1];
     MEMORY_BASIC_INFORMATION mbi;
-    if (VirtualQuery(fault_addr, &mbi, sizeof(mbi)) != 0 &&
-        mbi.State == MEM_RESERVE) {
+    if (VirtualQuery(fault_addr, &mbi, sizeof(mbi)) != 0) {
       // commit just the faulting page
-      if (VirtualAlloc(fault_addr, 1, MEM_COMMIT, PAGE_READWRITE)) {
+      if (mbi.State == MEM_RESERVE) {
+        if (VirtualAlloc(fault_addr, 1, MEM_COMMIT, PAGE_READWRITE)) {
+          return EXCEPTION_CONTINUE_EXECUTION;
+        }
+      }
+
+      if (mbi.State == MEM_COMMIT && (mbi.Protect & PAGE_READWRITE) && access_type != 8) {
         return EXCEPTION_CONTINUE_EXECUTION;
       }
     }

--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -24,13 +24,58 @@
 #include <unistd.h>
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "engine/engine_array_safety.h"
 #include "engine/engine_macro.h"
 
 //------------------------- cross-platform aligned malloc/free -------------------------------------
 
+#ifdef _WIN32
+
+// virtualalloc has 64KB min alloc granularity
+#define MJU_LARGE_ALLOC_THRESHOLD (1 << 16)
+
+static LONG CALLBACK mju_commitHandler(EXCEPTION_POINTERS* ep) {
+  if (ep->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+    void* fault_addr = (void*)ep->ExceptionRecord->ExceptionInformation[1];
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(fault_addr, &mbi, sizeof(mbi)) != 0 &&
+        mbi.State == MEM_RESERVE) {
+      // commit just the faulting page
+      if (VirtualAlloc(fault_addr, 1, MEM_COMMIT, PAGE_READWRITE)) {
+        return EXCEPTION_CONTINUE_EXECUTION;
+      }
+    }
+  }
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+
+// register handler once, thread-safe bc of InitOnce
+static INIT_ONCE mju_veh_init_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK mju_initVEH(INIT_ONCE* initOnce, void* param, void** ctx) {
+  AddVectoredExceptionHandler(1, mju_commitHandler);
+  return TRUE;
+}
+
+static void mju_ensureVEH(void) {
+  InitOnceExecuteOnce(&mju_veh_init_once, mju_initVEH, NULL, NULL);
+}
+
+#endif  // _WIN32
+
+
 static inline void* mju_alignedMalloc(size_t size, size_t align) {
 #ifdef _WIN32
+  if (size >= MJU_LARGE_ALLOC_THRESHOLD) {
+    // install lazy-commit handler
+    mju_ensureVEH();
+    // MEM_RESERVE only: reserves virtual address space without commit charge
+    return VirtualAlloc(NULL, size, MEM_RESERVE, PAGE_READWRITE);
+  }
   return _aligned_malloc(size, align);
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   return aligned_alloc(align, size);
@@ -39,7 +84,13 @@ static inline void* mju_alignedMalloc(size_t size, size_t align) {
 
 static inline void mju_alignedFree(void* ptr) {
 #ifdef _WIN32
-  _aligned_free(ptr);
+  // determine which allocator owns this pointer
+  MEMORY_BASIC_INFORMATION mbi;
+  if (VirtualQuery(ptr, &mbi, sizeof(mbi)) != 0 && mbi.AllocationBase == ptr) {
+    VirtualFree(ptr, 0, MEM_RELEASE);
+  } else {
+    _aligned_free(ptr);
+  }
 #else
   free(ptr);
 #endif


### PR DESCRIPTION
## Summary - 
Fixes #2337: Windows memory allocation failure when creating many MjData instances.

Not sure if there is much interest in still resolving this issue by @okmatija or @yuvaltassa but I did a simple edit on the original MRE to print the memory allocation and discovered that the origin of the issue. In `engine_io.c` three `mju_malloc` calls are made for each `MjData` using aligned malloc so its overloading the VMS. 

Before:
<img width="378" height="118" alt="image" src="https://github.com/user-attachments/assets/d1cc7643-4628-4361-a62b-250a38b5c7be" />

After:
<img width="391" height="80" alt="image" src="https://github.com/user-attachments/assets/5905459c-160b-40db-9f88-c5a6d9f3539f" />

## Fix
For allocations >= 64KB on windows, I just replaced `_aligned_malloc` with `VirtualAlloc(MEM_RESERVE)` and a vectored exception handler that commits pages on first access. This basically just mimics the linux overcommit behavior. 

I am pretty confident that this implementation is safe but a review or some help with the code implementation if needed would be nice.