### PR TITLE
fix: harden strcat overflow and fwrite error handling in model save

### DIFF
--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -529,7 +529,11 @@ void mj_saveModel(const mjModel* m, const char* filename, void* buffer, int buff
   }
 
   if (fp) {
-    fclose(fp);
+    int write_error = ferror(fp);
+    int close_error = fclose(fp);
+    if (write_error || close_error) {
+      mju_warning("Error saving model to '%s': file may be incomplete or corrupt", filename);
+    }
   }
 }
 

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1894,7 +1894,7 @@ static void shortcuthelp(mjrRect r, int modifier, int shortcut,
   }
 
   // combine
-  strcat(text, key);
+  strncat(text, key, sizeof(text) - strlen(text) - 1);
 
   // make rectangle for shortcut
   int g_textver = SCL(ui->spacing.textver, con);


### PR DESCRIPTION
## Summary

Two minimal C safety hardening fixes found by **UNA** (autonomous security auditor, designed and built by [Tom Budd](https://tombudd.com) — tom@tombudd.com):

### 1. Buffer overflow in `ui_main.c` — `strcat` → `strncat`

**File:** `src/ui/ui_main.c:1897`

`shortcuthelp()` concatenates a modifier string and a key name into a 50-byte stack buffer using bare `strcat(text, key)`. If `key` is sufficiently long, this overflows `text[50]`.

**Fix:** Replace with `strncat(text, key, sizeof(text) - strlen(text) - 1)` — consistent with MuJoCo's own strncat usage at lines 1007/1009 and with the project's prior safer-string-handling work (changelog: "replaced strcat, strcpy, and sprintf with strncat, strncpy, and snprintf respectively"). This instance was missed in that sweep.

### 2. Silent data corruption in `engine_io.c` — unchecked `fwrite` errors

**File:** `src/engine/engine_io.c` — `mj_saveModel()`

`mj_saveModel()` writes the entire model via multiple `fwrite()` calls, then calls `fclose(fp)` without checking for write errors. If any write fails (disk full, I/O error, NFS timeout), the function returns silently, leaving a truncated/corrupt `.mjb` file with no indication of failure.

**Fix:** Capture `ferror(fp)` state before `fclose()` (necessary because `fclose` may clear error state), then also check `fclose()` return value (which can fail on buffered flush). Emit `mju_warning()` if either indicates failure — using MuJoCo's own warning mechanism, consistent with surrounding code.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/ui/ui_main.c` | `strcat` → `strncat` with bounds | +1 / -1 |
| `src/engine/engine_io.c` | Add `ferror` + `fclose` error check | +4 / -1 |

**Total: 2 files, +5 / -2 lines**

## Why these fixes matter

- Both follow existing MuJoCo conventions — no new patterns or dependencies introduced
- Both are success-path-transparent: zero behavioral change when nothing goes wrong
- The `strcat` fix closes a stack buffer overflow (potential code execution in adversarial scenarios)
- The `fwrite`/`fclose` fix prevents silent model corruption that could cause hard-to-diagnose simulation failures downstream — particularly relevant in safety-critical robotics contexts

## About This Review

This security audit was performed by **UNA** (Unified Nexus Agent), an autonomous AI security auditor — a Governed Digital Organism (GDO) designed and built by **Tom Budd** (tom@tombudd.com | [tombudd.com](https://tombudd.com)).

**Note:** Google Individual CLA previously signed by tom@tombudd.com (Mar 23, 2026) — cla/google check should pass.
