### PR TITLE
Fix test build failure on Linux

### DIFF
--- a/test/engine/engine_solver_test.cc
+++ b/test/engine/engine_solver_test.cc
@@ -87,7 +87,7 @@ TEST_F(SolverTest, IslandsEquivalent) {
       mjtNum worst_scale = 1.0;
       mjtNum worst_expected = 0;
       mjtNum worst_actual = 0;
-      std::string worst_time = "";
+      mjtNum worst_time = 0;
       int worst_dof = -1;
 
       while (data_noisland->time < .1) {
@@ -112,7 +112,7 @@ TEST_F(SolverTest, IslandsEquivalent) {
             worst_scale = scale;
             worst_expected = data_island->qacc[j];
             worst_actual = data_noisland->qacc[j];
-            worst_time = std::to_string(data_noisland->time);
+            worst_time = data_noisland->time;
             worst_dof = j;
           }
         }


### PR DESCRIPTION
While trying to package MuJoCo for Alpine Linux, I encountered the following build failure when building the tests:

```
ninja: job failed with status 1: : && /usr/bin/c++ -fPIC -Os -fstack-clash-protection -Wformat -Werror=format-security -D_GLIBCXX_ASSERTIONS=1 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1 -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -flto=auto -fno-fat-lto-objects  -shared -Wl,--as-needed,-O1,--sort-common -Wl,-z,pack-relative-relocs -Wl,--gc-sections -Wl,-soname,libmujoco.so.3.10.0 -o lib/libmujoco.so.3.10.0 CMakeFiles/mujoco.dir/plugin/obj_decoder/obj_decoder.cc.o CMakeFiles/mujoco.dir/plugin/stl_decoder/stl_decoder.cc.o CMakeFiles/mujoco.dir/src/engine/engine_callback.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_box.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_convex.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_driver.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_gjk.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_primitive.c.o CMakeFiles/mujoco.dir/src/engine/engine_collision_sdf.c.o CMakeFiles/mujoco.dir/src/engine/engine_core_constraint.c.o CMakeFiles/mujoco.dir/src/engine/engine_core_util.c.o CMakeFiles/mujoco.dir/src/engine/engine_core_smooth.c.o CMakeFiles/mujoco.dir/src/engine/engine_crossplatform.cc.o CMakeFiles/mujoco.dir/src/engine/engine_derivative.c.o CMakeFiles/mujoco.dir/src/engine/engine_derivative_fd.c.o CMakeFiles/mujoco.dir/src/engine/engine_forward.c.o CMakeFiles/mujoco.dir/src/engine/engine_inverse.c.o CMakeFiles/mujoco.dir/src/engine/engine_init.c.o CMakeFiles/mujoco.dir/src/engine/engine_island.c.o CMakeFiles/mujoco.dir/src/engine/engine_io.c.o CMakeFiles/mujoco.dir/src/engine/engine_memory.c.o CMakeFiles/mujoco.dir/src/engine/engine_name.c.o CMakeFiles/mujoco.dir/src/engine/engine_passive.c.o CMakeFiles/mujoco.dir/src/engine/engine_plugin.cc.o CMakeFiles/mujoco.dir/src/engine/engine_print.c.o CMakeFiles/mujoco.dir/src/engine/engine_ray.c.o CMakeFiles/mujoco.dir/src/engine/engine_sensor.c.o CMakeFiles/mujoco.dir/src/engine/engine_setconst.c.o CMakeFiles/mujoco.dir/src/engine/engine_sleep.c.o CMakeFiles/mujoco.dir/src/engine/engine_solver.c.o CMakeFiles/mujoco.dir/src/engine/engine_support.c.o CMakeFiles/mujoco.dir/src/engine/engine_thread.cc.o CMakeFiles/mujoco.dir/src/engine/engine_util_blas.c.o CMakeFiles/mujoco.dir/src/engine/engine_util_errmem.c.o CMakeFiles/mujoco.dir/src/engine/engine_util_misc.c.o CMakeFiles/mujoco.dir/src/engine/engine_util_solve.c.o CMakeFiles/mujoco.dir/src/engine/engine_util_sparse.c.o CMakeFiles/mujoco.dir/src/engine/engine_util_spatial.c.o CMakeFiles/mujoco.dir/src/engine/engine_vis_init.c.o CMakeFiles/mujoco.dir/src/engine/engine_vis_interact.c.o CMakeFiles/mujoco.dir/src/engine/engine_vis_visualize.c.o CMakeFiles/mujoco.dir/src/user/user_api.cc.o CMakeFiles/mujoco.dir/src/user/user_cache.cc.o CMakeFiles/mujoco.dir/src/user/user_composite.cc.o CMakeFiles/mujoco.dir/src/user/user_flexcomp.cc.o CMakeFiles/mujoco.dir/src/user/user_init.c.o CMakeFiles/mujoco.dir/src/user/user_mesh.cc.o CMakeFiles/mujoco.dir/src/user/user_model.cc.o CMakeFiles/mujoco.dir/src/user/user_objects.cc.o CMakeFiles/mujoco.dir/src/user/user_resolver.cc.o CMakeFiles/mujoco.dir/src/user/user_resource.cc.o CMakeFiles/mujoco.dir/src/user/user_threadpool.cc.o CMakeFiles/mujoco.dir/src/user/user_util.cc.o CMakeFiles/mujoco.dir/src/user/user_vfs.cc.o CMakeFiles/mujoco.dir/src/xml/xml_api.cc.o CMakeFiles/mujoco.dir/src/xml/xml_base.cc.o CMakeFiles/mujoco.dir/src/xml/xml_global.cc.o CMakeFiles/mujoco.dir/src/xml/xml.cc.o CMakeFiles/mujoco.dir/src/xml/xml_native_reader.cc.o CMakeFiles/mujoco.dir/src/xml/xml_numeric_format.cc.o CMakeFiles/mujoco.dir/src/xml/xml_native_writer.cc.o CMakeFiles/mujoco.dir/src/xml/xml_urdf.cc.o CMakeFiles/mujoco.dir/src/xml/xml_util.cc.o CMakeFiles/mujoco.dir/src/xml/mjz/mjz_decoder.cc.o CMakeFiles/mujoco.dir/src/xml/mjz/mjz_encoder.cc.o CMakeFiles/mujoco.dir/src/render/classic/glad/glad.c.o CMakeFiles/mujoco.dir/src/render/classic/glad/loader.cc.o CMakeFiles/mujoco.dir/src/render/classic/render_context.c.o CMakeFiles/mujoco.dir/src/render/classic/render_gl2.c.o CMakeFiles/mujoco.dir/src/render/classic/render_gl3.c.o CMakeFiles/mujoco.dir/src/render/classic/render_util.c.o CMakeFiles/mujoco.dir/src/ui/ui_main.c.o  -ltinyobjloader  -lminiz  -ldl  /usr/lib/libccd.so.2.0  /usr/lib/libqhull_r.so.8.0.2  /usr/lib/libtinyobjloader.so.2.0.0-rc13  /usr/lib/libm.a  -llodepng  -lm  /usr/lib/libtinyxml2.so && :
/usr/include/fortify/stdio.h: In function '__to_xstring.constprop':
/usr/include/fortify/stdio.h:82:28: error: inlining failed in call to 'always_inline' 'vsnprintf': function body can be overwritten at link time
   82 | _FORTIFY_FN(vsnprintf) int vsnprintf(char * _FORTIFY_POS0 __s, size_t __n,
      |                            ^
/usr/include/c++/15.2.0/ext/string_conversions.h:115:32: note: called from here
  115 |       const int __len = __convf(__s, __n, __fmt, __args);
      |                                ^
```

I was able to trace the error down to the `std::to_string` call, so I moved the string generation out of the loop, eliminating the direct call to `to_string`.