### PR TITLE
[Unity plugin] Update to URP for materials

### DIFF
--- a/unity/Editor/Components/MjMouseSpring.cs
+++ b/unity/Editor/Components/MjMouseSpring.cs
@@ -31,13 +31,17 @@ namespace Mujoco {
 
     private Color _translucentRed = new Color(1, 0, 0, 0.1f);
 
+    /*  Since Unity 6 this leads to errors and warning due to acessing GUI functions.
+     TODO: investigate whether hotcontrol is released automatically on disable, and if not,
+     whether we can release appropriately in OnGUI (e.g. simply checking enabled status?)
+
     public void OnDisable() {
       // If we're still the hot control at this stage, we need to release.
       int uniqueID = GUIUtility.GetControlID(FocusType.Passive);
       if (GUIUtility.hotControl == uniqueID) {
         GUIUtility.hotControl = 0;
       }
-    }
+    }*/
 
     private void SetDragOriginAndDragPlane(Vector3 planeOrigin, Vector3 normal) {
       normal[1] = 0;

--- a/unity/Editor/Components/MjMouseSpring.cs
+++ b/unity/Editor/Components/MjMouseSpring.cs
@@ -26,22 +26,18 @@ namespace Mujoco {
   public class MjMouseSpring : Editor {
     private bool _lastShiftKeyState = false;
 
+    private int _controlID = -1;
     private Plane _mouseDragPlane;
     private Vector3 _mouseDragCurrentPoint = Vector3.negativeInfinity;
 
     private Color _translucentRed = new Color(1, 0, 0, 0.1f);
 
-    /*  Since Unity 6 this leads to errors and warning due to acessing GUI functions.
-     TODO: investigate whether hotcontrol is released automatically on disable, and if not,
-     whether we can release appropriately in OnGUI (e.g. simply checking enabled status?)
-
     public void OnDisable() {
       // If we're still the hot control at this stage, we need to release.
-      int uniqueID = GUIUtility.GetControlID(FocusType.Passive);
-      if (GUIUtility.hotControl == uniqueID) {
+      if (GUIUtility.hotControl == _controlID) {
         GUIUtility.hotControl = 0;
       }
-    }*/
+    }
 
     private void SetDragOriginAndDragPlane(Vector3 planeOrigin, Vector3 normal) {
       normal[1] = 0;
@@ -90,6 +86,7 @@ namespace Mujoco {
 
       // Cache the hot control to determine whether we're currently capturing mouse input.
       int uniqueID = GUIUtility.GetControlID(FocusType.Passive);
+      _controlID = uniqueID;
 
       // Mouse spring is active if the control key is held down and the user is dragging the
       // left mouse button, or if we're already in the process of capturing mouse input.

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -153,7 +153,7 @@ public class MjImporterWithAssets : MjcfImporter {
     var assetReferenceName = MjEngineTool.Sanitize(unsanitizedAssetReferenceName);
     var sourceFilePath = Path.Combine(_sourceMeshesDir, fileName);
 
-    if (Path.GetExtension(sourceFilePath) != ".obj" && Path.GetExtension(sourceFilePath) != ".stl") {
+    if (Path.GetExtension(sourceFilePath).ToLower() != ".obj" && Path.GetExtension(sourceFilePath).ToLower() != ".stl") {
       throw new NotImplementedException("Type of mesh file not yet supported. " +
                                         "Please convert to binary STL or OBJ. " +
                                         $"Attempted to load: {sourceFilePath}");
@@ -194,11 +194,11 @@ public class MjImporterWithAssets : MjcfImporter {
   private void CopyMeshAndRescale(
       string sourceFilePath, string targetFilePath, Vector3 scale) {
     var originalMeshBytes = File.ReadAllBytes(sourceFilePath);
-    if (Path.GetExtension(sourceFilePath) == ".stl") {
+    if (Path.GetExtension(sourceFilePath).ToLower() == ".stl") {
       var mesh = StlMeshParser.ParseBinary(originalMeshBytes, scale);
       var rescaledMeshBytes = StlMeshParser.SerializeBinary(mesh);
       File.WriteAllBytes(targetFilePath, rescaledMeshBytes);
-    } else if (Path.GetExtension(sourceFilePath) == ".obj") {
+    } else if (Path.GetExtension(sourceFilePath).ToLower() == ".obj") {
       ObjMeshImportUtility.CopyAndScaleOBJFile(sourceFilePath, targetFilePath, scale);
     } else {
       throw new NotImplementedException($"Extension {Path.GetExtension(sourceFilePath)} " +
@@ -227,7 +227,7 @@ public class MjImporterWithAssets : MjcfImporter {
         AssetDatabase.GUIDToAssetPath(
           AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
     } else {
-      material = new Material(Shader.Find("Standard"));
+      material = new Material(MjcfImporter.GetLitShader());
     }
     material.SetColor("_Color", albedo);
     material.SetFloat("_Metallic", reflectance);
@@ -284,7 +284,7 @@ public class MjImporterWithAssets : MjcfImporter {
               AssetDatabase.GUIDToAssetPath(
                 AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
         } else {
-          material = new Material(Shader.Find("Standard"));
+          material = new Material(MjcfImporter.GetLitShader());
         }
         material.color = new Color(rgba[0], rgba[1], rgba[2], rgba[3]);
         // We use the geom's name, guaranteed to be unique, as the asset name.

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -230,6 +230,7 @@ public class MjImporterWithAssets : MjcfImporter {
       material = new Material(MjcfImporter.GetLitShader());
     }
     material.SetColor("_Color", albedo);
+    material.SetColor("_BaseColor", albedo);
     material.SetFloat("_Metallic", reflectance);
 
     // In order to convert the specular/shininess parameters into glossiness/roughness,
@@ -286,7 +287,7 @@ public class MjImporterWithAssets : MjcfImporter {
         } else {
           material = new Material(MjcfImporter.GetLitShader());
         }
-        material.color = new Color(rgba[0], rgba[1], rgba[2], rgba[3]);
+        material.SetColor("_BaseColor", new Color(rgba[0], rgba[1], rgba[2], rgba[3]));
         // We use the geom's name, guaranteed to be unique, as the asset name.
         // If geom is nameless, use a random number.
         var name =

--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -26,9 +26,6 @@ namespace Mujoco {
 
 // API for importing Mujoco XML files into Unity scenes.
 public class MjImporterWithAssets : MjcfImporter {
-
-  private const string _semiTransparentMaterialName = "mujoco_semitransparent_template";
-
   private string _sourceMeshesDir;
   private string _targetMeshesDir;
   private string _targetAssetDir;
@@ -225,9 +222,9 @@ public class MjImporterWithAssets : MjcfImporter {
     if (rgba[3] < 1f) {
       material = new Material(AssetDatabase.LoadMainAssetAtPath(
         AssetDatabase.GUIDToAssetPath(
-          AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
+          AssetDatabase.FindAssets(SemiTransparentMaterialName)[0])) as Material);
     } else {
-      material = new Material(MjcfImporter.GetLitShader());
+      material = new Material(GetLitShader());
     }
     material.SetColor("_Color", albedo);
     material.SetColor("_BaseColor", albedo);
@@ -283,9 +280,9 @@ public class MjImporterWithAssets : MjcfImporter {
           material = new Material(
             AssetDatabase.LoadMainAssetAtPath(
               AssetDatabase.GUIDToAssetPath(
-                AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
+                AssetDatabase.FindAssets(SemiTransparentMaterialName)[0])) as Material);
         } else {
-          material = new Material(MjcfImporter.GetLitShader());
+          material = new Material(GetLitShader());
         }
         material.SetColor("_BaseColor", new Color(rgba[0], rgba[1], rgba[2], rgba[3]));
         // We use the geom's name, guaranteed to be unique, as the asset name.

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mujoco {
 // API for importing Mujoco XML files into Unity scenes.
@@ -28,7 +29,7 @@ public class MjcfImporter {
   public static Material DefaultMujocoMaterial {
     get {
       if (_DefaultMujocoMaterial == null) {
-        _DefaultMujocoMaterial = new Material(Shader.Find("Standard"));
+        _DefaultMujocoMaterial = new Material(GetLitShader());
       }
 
       return _DefaultMujocoMaterial;
@@ -446,5 +447,24 @@ public class MjcfImporter {
     camera.nearClipPlane = 0.01f;  // MuJoCo default, TODO(etom): get from visual/map/znear
     return gameObject;
   }
+
+  public static Shader GetLitShader() {
+    // Built-in pipeline is deprecated, we'll default to URP
+    string shaderName = "Universal Render Pipeline/Lit";
+
+    if (GraphicsSettings.currentRenderPipeline != null) {
+      string pipelineType = GraphicsSettings.currentRenderPipeline.GetType().ToString();
+
+      if (pipelineType.Contains("Universal")) {
+        shaderName =
+            "Universal Render Pipeline/Lit";
+      } else if (pipelineType.Contains("HighDefinition")) {
+        shaderName = "HDRP/Lit";
+      }
+    }
+    Shader shader = Shader.Find(shaderName);
+    return shader;
+  }
 }
+
 }

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -39,6 +39,22 @@ public class MjcfImporter {
     }
   }
 
+  // There are many configurations that need to be changed in a material to reliably render as
+  // transparent, so we use template materials to ensure all default settings are correct.
+  public static string SemiTransparentMaterialName {
+    get {
+      string defaultName = "mujoco_semitransparent_template";
+      if (GraphicsSettings.currentRenderPipeline != null) {
+        string pipelineType = GraphicsSettings.currentRenderPipeline.GetType().ToString();
+
+        if (pipelineType.Contains("HighDefinition")) {
+          defaultName = "mujoco_semitransparent_template_hd";
+        }
+      }
+      return defaultName;
+    }
+  }
+
   // Modifiers that change the settings of parsed nodes. They're limited to the scope of ParseRoot
   // method.
   protected MjXmlModifiers _modifiers;

--- a/unity/Runtime/Resources/mujoco_semitransparent_template.mat
+++ b/unity/Runtime/Resources/mujoco_semitransparent_template.mat
@@ -2,23 +2,38 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: mujoco_semitransparent_template
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _ALPHAPREMULTIPLY_ON
+  - _SPECULAR_SETUP
+  - _SURFACE_TYPE_TRANSPARENT
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  - DepthOnly
+  - SHADOWCASTER
+  m_LockedProperties:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BumpMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -55,11 +70,40 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BlendOp: 0
     - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
     - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
+    - _EnvironmentReflections: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
@@ -67,11 +111,36 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _SampleGI: 0
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
     - _UVSec: 0
-    - _ZWrite: 1
+    - _WorkflowMode: 0
+    - _XRMotionVectorsPass: 1
+    - _ZWrite: 0
     m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &3406183217315982671
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.RenderPipelines.Universal.Editor::UnityEditor.Rendering.Universal.AssetVersion
+  version: 10

--- a/unity/Runtime/Resources/mujoco_semitransparent_template.mat.meta
+++ b/unity/Runtime/Resources/mujoco_semitransparent_template.mat.meta
@@ -3,6 +3,6 @@ guid: 4daefe8934610e978b13f883bfb904cf
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity/Runtime/Resources/mujoco_semitransparent_template_hd.mat
+++ b/unity/Runtime/Resources/mujoco_semitransparent_template_hd.mat
@@ -1,0 +1,281 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: mujoco_semitransparent_template_hd
+  m_Shader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _DISABLE_SSR_TRANSPARENT
+  - _ENABLE_FOG_ON_TRANSPARENT
+  - _NORMALMAP_TANGENT_SPACE
+  - _SURFACE_TYPE_TRANSPARENT
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - TransparentDepthPrepass
+  - TransparentDepthPostpass
+  - TransparentBackface
+  - RayTracingPrepass
+  - MOTIONVECTORS
+  m_LockedProperties:
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AnisotropyMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CoatMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissiveColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _HeightMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmissionMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmittanceColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AORemapMax: 1
+    - _AORemapMin: 0
+    - _ATDistance: 1
+    - _AddPrecomputedVelocity: 0
+    - _AlbedoAffectEmissive: 0
+    - _AlphaCutoff: 0.5
+    - _AlphaCutoffEnable: 0
+    - _AlphaCutoffPostpass: 0.5
+    - _AlphaCutoffPrepass: 0.5
+    - _AlphaCutoffShadow: 0.5
+    - _AlphaDstBlend: 10
+    - _AlphaRemapMax: 1
+    - _AlphaRemapMin: 0
+    - _AlphaSrcBlend: 1
+    - _Anisotropy: 0
+    - _BlendMode: 0
+    - _CoatMask: 0
+    - _CullMode: 2
+    - _CullModeForward: 2
+    - _Cutoff: 0.5
+    - _DepthOffsetEnable: 0
+    - _DetailAlbedoScale: 1
+    - _DetailNormalScale: 1
+    - _DetailSmoothnessScale: 1
+    - _DiffusionProfile: 0
+    - _DiffusionProfileHash: 0
+    - _DisplacementLockObjectScale: 1
+    - _DisplacementLockTilingScale: 1
+    - _DisplacementMode: 0
+    - _DoubleSidedEnable: 0
+    - _DoubleSidedGIMode: 0
+    - _DoubleSidedNormalMode: 1
+    - _DstBlend: 10
+    - _DstBlend2: 10
+    - _EmissiveColorMode: 1
+    - _EmissiveExposureWeight: 1
+    - _EmissiveIntensity: 1
+    - _EmissiveIntensityUnit: 0
+    - _EnableBlendModePreserveSpecularLighting: 1
+    - _EnableFogOnTransparent: 1
+    - _EnableGeometricSpecularAA: 0
+    - _EnergyConservingSpecularColor: 1
+    - _HeightAmplitude: 0.02
+    - _HeightCenter: 0.5
+    - _HeightMapParametrization: 0
+    - _HeightMax: 1
+    - _HeightMin: -1
+    - _HeightOffset: 0
+    - _HeightPoMAmplitude: 2
+    - _HeightTessAmplitude: 2
+    - _HeightTessCenter: 0.5
+    - _InvTilingScale: 1
+    - _Ior: 1.5
+    - _IridescenceMask: 1
+    - _IridescenceThickness: 1
+    - _LinkDetailsWithBase: 1
+    - _MaterialID: 1
+    - _Metallic: 0
+    - _MetallicRemapMax: 1
+    - _MetallicRemapMin: 0
+    - _NormalMapSpace: 0
+    - _NormalScale: 1
+    - _ObjectSpaceUVMapping: 0
+    - _ObjectSpaceUVMappingEmissive: 0
+    - _OpaqueCullMode: 2
+    - _PPDLodThreshold: 5
+    - _PPDMaxSamples: 15
+    - _PPDMinSamples: 5
+    - _PPDPrimitiveLength: 1
+    - _PPDPrimitiveWidth: 1
+    - _PerPixelSorting: 0
+    - _RayTracing: 0
+    - _ReceivesSSR: 1
+    - _ReceivesSSRTransparent: 0
+    - _RefractionModel: 0
+    - _Smoothness: 0.5
+    - _SmoothnessRemapMax: 1
+    - _SmoothnessRemapMin: 0
+    - _SpecularAAScreenSpaceVariance: 0.1
+    - _SpecularAAThreshold: 0.2
+    - _SpecularOcclusionMode: 1
+    - _SrcBlend: 1
+    - _StencilRef: 0
+    - _StencilRefDepth: 0
+    - _StencilRefGBuffer: 2
+    - _StencilRefMV: 32
+    - _StencilWriteMask: 6
+    - _StencilWriteMaskDepth: 9
+    - _StencilWriteMaskGBuffer: 15
+    - _StencilWriteMaskMV: 41
+    - _SubsurfaceMask: 1
+    - _SupportDecals: 1
+    - _SurfaceType: 1
+    - _TexWorldScale: 1
+    - _TexWorldScaleEmissive: 1
+    - _Thickness: 1
+    - _TransmissionEnable: 1
+    - _TransmissionMask: 1
+    - _TransparentBackfaceEnable: 0
+    - _TransparentCullMode: 2
+    - _TransparentDepthPostpassEnable: 0
+    - _TransparentDepthPrepassEnable: 0
+    - _TransparentSortPriority: 0
+    - _TransparentWritingMotionVec: 0
+    - _TransparentZWrite: 0
+    - _UVBase: 0
+    - _UVDetail: 0
+    - _UVEmissive: 0
+    - _UseEmissiveIntensity: 0
+    - _UseShadowThreshold: 0
+    - _ZTestDepthEqualForOpaque: 4
+    - _ZTestGBuffer: 4
+    - _ZTestTransparent: 4
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
+    - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissiveColorLDR: {r: 0, g: 0, b: 0, a: 1}
+    - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
+    - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
+    - _ThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _TransmittanceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _UVDetailsMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &7741880585315700800
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da692e001514ec24dbc4cca1949ff7e8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.RenderPipelines.HighDefinition.Editor::UnityEditor.Rendering.HighDefinition.AssetVersion
+  version: 13
+  hdPluginSubTargetMaterialVersions:
+    m_Keys: []
+    m_Values:

--- a/unity/Runtime/Resources/mujoco_semitransparent_template_hd.mat.meta
+++ b/unity/Runtime/Resources/mujoco_semitransparent_template_hd.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c386fab6148520d4c9b95339df73f344
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
The built-in pipeline is beginning to be deprecated, projects will use URP by default. This PR swaps the materials to use the URP lit materials, so users don't have to manually update/reassign each material to their imported MJCFs.

A couple other housekeeping updates are also included:
- STL/OBJ file name parsing is now no longer case sensitive (many menagerie repos use uppercase extensions)
- The mouse spring utility was throwing errors due to GUI functionality becoming more restricted to specific contexts. We now store the result of the ID call while we are in the appropriate context. 