### PR TITLE
Fix GCC 15 compatibility warnings

### DIFF
--- a/src/engine/engine_plugin.cc
+++ b/src/engine/engine_plugin.cc
@@ -194,7 +194,7 @@ bool GlobalTable<mjpPlugin>::CopyObject(mjpPlugin& dst, const mjpPlugin& src, Er
 
   // check and copy plugin attributes
   std::unique_ptr<std::unique_ptr<char[]>[]> attributes_list;
-  if (src.nattribute) {
+  if (src.nattribute && src.nattribute <= kMaxAttributes) {
     attributes_list.reset(new(std::nothrow) std::unique_ptr<char[]>[src.nattribute]);
     if (!attributes_list) {
       std::snprintf(err, sizeof(err), "failed to allocate memory for plugin attribute list");


### PR DESCRIPTION
- engine_print.c: change 'char* c' to 'const char* c' since strchr() returns const char*; fixes -Werror=discarded-qualifiers
- engine_plugin.cc: add bounds check for nattribute to prevent alloc-size overflow; fixes -Walloc-size-larger-than