### PR TITLE
Install pkg-config file for library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,10 @@ if(NOT (APPLE AND MUJOCO_BUILD_MACOS_FRAMEWORKS))
           DESTINATION ${CONFIG_PACKAGE_LOCATION}
   )
 
+  # Configure and install the pkg-config file
+  configure_file(mujoco.pc.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc" @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
   # Install also models into share folder.
   install(
     DIRECTORY model

--- a/mujoco.pc.in
+++ b/mujoco.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version : @CMAKE_PROJECT_VERSION@
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
This adds a pkg-config file for the shared library which is useful when linking against MuJoCo from a build system that is not CMake.