### PR TITLE
Fix linker selection: avoid LLD when using GCC with LTO

### DIFF
--- a/cmake/MujocoLinkOptions.cmake
+++ b/cmake/MujocoLinkOptions.cmake
@@ -1,4 +1,3 @@
-
 # Copyright 2021 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/MujocoLinkOptions.cmake
+++ b/cmake/MujocoLinkOptions.cmake
@@ -1,3 +1,4 @@
+
 # Copyright 2021 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +15,7 @@
 
 include(CheckCSourceCompiles)
 
-# Gets the appropriate linker options for building MuJoCo, based on features available on the
-# linker.
+# Gets the appropriate linker options for building MuJoCo, based on features available on the linker, use lld-link only with clang
 function(get_mujoco_extra_link_options OUTPUT_VAR)
   if(MSVC)
     set(EXTRA_LINK_OPTIONS /OPT:REF /OPT:ICF=5 /STACK:16777216)
@@ -23,16 +23,24 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
     set(EXTRA_LINK_OPTIONS)
 
     if(WIN32)
-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
+        check_c_source_compiles("int main() {}" SUPPORTS_LLD_LINK)
+      else()
+        set(SUPPORTS_LLD_LINK FALSE)
+      endif()
       if(SUPPORTS_LLD_LINK)
         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld-link -Wl,/STACK:16777216 -Wl,/OPT:REF -Wl,/OPT:ICF)
       else()
         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--stack,16777216)
       endif()
     else()
-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
-      check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+      if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
+        check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+      else()
+        set(SUPPORTS_LLD FALSE)
+      endif()
       if(SUPPORTS_LLD)
         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld)
       else()

--- a/src/engine/engine_print.c
+++ b/src/engine/engine_print.c
@@ -480,7 +480,7 @@ static bool validateFloatFormat(const char* float_format) {
   // flag characters. allow at most one of each flag
   const char flag_characters[] = "-+ #0";
   int flag_character_counts[sizeof(flag_characters)] = { 0 };
-  char* c;
+  const char* c;
   while (c = strchr(flag_characters, float_format[cur_idx]), c != NULL) {
     int flag_idx = (c - flag_characters)/sizeof(char);
     flag_character_counts[flag_idx]++;


### PR DESCRIPTION
# Fix linker selection: avoid LLD when using GCC with LTO
## Summary

MuJoCo's CMake configuration currently prioritizes linkers in the following order: `LLD` → `gold` → `bfd`. 
This causes build failures when using **GCC with LTO enabled**, because LLD is selected even though it is incompatible with GCC's LTO object format.

This PR updates the linker selection logic to:
* Prefer **LLD only when using Clang**.
* Fall back to **gold/bfd when using GCC**.

+ change  'char* c' to 'const char* c' as strchr() returns a const and is an error in GCC 15
---

## Problem

`MujocoLinkOptions.cmake` detects linker support using:

```cmake
check_c_source_compiles("int main() {}" SUPPORTS_LLD)
```

This test passes for LLD because:
1. It does not use LTO.
2. It only checks basic compilation and linking.

As a result, LLD is selected and `-fuse-ld=lld` is added to `EXTRA_LINK_OPTIONS`. 

Later in the build process, `MujocoOptions.cmake` enables LTO:
```cmake
CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
```
This causes GCC to compile with `-flto`. LLD does not support GCC's GIMPLE IR or `liblto_plugin.so`. Therefore, when LLD encounters these object files, it only sees an empty `.text` section. Symbols such as `main` appear undefined, and linking fails.

---

## Fix

Restrict usage of LLD to Clang builds only.

**Key changes:**
* Only probe and enable `lld` (Linux/macOS) and `lld-link` (Windows) when `CMAKE_C_COMPILER_ID MATCHES "Clang"`.
* For GCC, skip LLD entirely and fall back to `gold` or `bfd`.

This ensures compatibility with GCC LTO while preserving LLD usage for Clang.

---

## Changes

**Updated `MujocoLinkOptions.cmake`:**
* Added compiler checks before enabling LLD.
* Prevented LLD selection when using GCC.
* Maintained existing fallback behavior (`gold` → `bfd`).

---

## Testing

Tested under the following configurations:

* **GCC + LTO (before fix):**  Linking fails with undefined symbols when LLD is selected.
* **GCC + LTO (after fix):**  Successfully links using `gold`/`bfd`.
* **Clang + LLD:** Works as expected (no regression).
* **Python bindings:**  Import succeeds after build (`python -c "import mujoco"`).

---

## Environment

* **OS:** Linux 6.19.11-arch1-1
* **Compiler:** GCC 15
* **Linker:** LLD 22.1