### PR TITLE
Fix float comparision in tests for non-x86 CPUs

### DIFF
--- a/test/engine/engine_core_smooth_test.cc
+++ b/test/engine/engine_core_smooth_test.cc
@@ -722,7 +722,7 @@ TEST_F(CoreSmoothTest, SolveLDs) {
 
   // expect vectors to match up to floating point precision
   for (int i = 0; i < nv; i++) {
-    EXPECT_NEAR(vec[i], vec2[i], MjTol(1e-14, 5e-6));
+    EXPECT_NEAR(vec[i], vec2[i], MjTol(1e-13, 5e-6));
   }
 
   mj_deleteData(d);


### PR DESCRIPTION
On non-x86 CPUs (64-bit ARM, 64-bit RISC-V, ...), this assertion fails (tested with Alpine Linux). Increasing the tolerance in this case helps for the tests to pass on those platforms as well.