### PR TITLE
Fix sleeping island link in changelog

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -271,7 +271,7 @@ Version 3.4.0 (December 5, 2025)
 General
 ^^^^^^^
 
-.. youtube:: aKa3ZlEF9_Y
+.. youtube:: vct493lGQ8Q
    :aspect: 2:1
    :align: right
    :width: 35%


### PR DESCRIPTION
It seems like the sleeping island video got accidentally changed to the nonlinear stiffness video in https://github.com/google-deepmind/mujoco/commit/efae9157a771957d08e9a4caa9523df4447268c1#diff-cd05d972a76959467eae3b3513b758279bad7f44b589c882a83b1c93214e7477L198-R223.