### PR TITLE
docs: fix undefined variable in mjspec.ipynb

### DIFF
--- a/python/mjspec.ipynb
+++ b/python/mjspec.ipynb
@@ -2000,7 +2000,7 @@
     "\n",
     "# Delete all key frames to avoid name conflicts\n",
     "while humanoid.keys:\n",
-    "  humanoid.delete(keys[-1])\n",
+    "  humanoid.delete(humanoid.keys[-1])\n",
     "\n",
     "# Create a grid of humanoids by attaching humanoid to spec multiple times\n",
     "for i in range(4):\n",


### PR DESCRIPTION
## Fix

`mjspec.ipynb` cell "Humanoid with randomized heads and arm poses" references `keys[-1]` which is undefined in that scope, causing a `NameError`. Changed to `humanoid.keys[-1]` to match the variable used in the `while` condition on the line above.

Before:
```python
while humanoid.keys:
  humanoid.delete(keys[-1])
```

After:
```python
while humanoid.keys:
  humanoid.delete(humanoid.keys[-1])
```

Closes #3232