### PR TITLE
Add config on msvc for mujoco with usd

### DIFF
--- a/cmake/MujocoOptions.cmake
+++ b/cmake/MujocoOptions.cmake
@@ -56,6 +56,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 if(MSVC)
   add_compile_options(/Gy /Gw /Oi)
+  add_compile_options(/utf-8)  # all source file is utf-8 encoded, eliminate warning C4819
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-fdata-sections -ffunction-sections)
 endif()

--- a/plugin/usd_decoder/CMakeLists.txt
+++ b/plugin/usd_decoder/CMakeLists.txt
@@ -34,12 +34,23 @@ target_compile_options(usd_decoder_plugin PRIVATE
   ${MUJOCO_MACOS_COMPILE_OPTIONS}
   ${EXTRA_COMPILE_OPTIONS}
   ${MUJOCO_CXX_FLAGS}
-  -Wno-deprecated # pxr Tf lib uses deprecated header
 )
 target_link_options(usd_decoder_plugin PRIVATE
   ${MUJOCO_MACOS_LINK_OPTIONS}
   ${EXTRA_LINK_OPTIONS}
 )
+if(MSVC)
+  target_compile_options(
+      usd_decoder_plugin
+      PRIVATE /wd4996 # pxr Tf lib uses deprecated header
+  )
+  target_compile_definitions(usd_decoder_plugin PRIVATE NOMINMAX=1)
+else()
+  target_compile_options(
+      usd_decoder_plugin
+      PRIVATE -Wno-deprecated # pxr Tf lib uses deprecated header
+  )
+endif()
 
 # Install to mujoco_plugin directory in bin location so that it is picked up by simulate
 # on startup.

--- a/src/experimental/usd/CMakeLists.txt
+++ b/src/experimental/usd/CMakeLists.txt
@@ -108,10 +108,6 @@ add_library(${MJCF_PLUGIN_TARGET_NAME} SHARED)
 target_sources(${MJCF_PLUGIN_TARGET_NAME} PRIVATE
   plugins/mjcf/mjcf_file_format.cc
   plugins/mjcf/mjcf_file_format.h
-  plugins/mjcf/mujoco_to_usd.cc
-  plugins/mjcf/mujoco_to_usd.h
-  plugins/mjcf/utils.cc
-  plugins/mjcf/utils.h
 )
 set_target_properties(${MJCF_PLUGIN_TARGET_NAME} PROPERTIES
   OUTPUT_NAME ${MJCF_PLUGIN_TARGET_NAME}
@@ -120,6 +116,9 @@ set_target_properties(${MJCF_PLUGIN_TARGET_NAME} PROPERTIES
 target_include_directories(${MJCF_PLUGIN_TARGET_NAME} PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/plugins"
 )
+if(MSVC)
+  target_compile_definitions(${MJCF_PLUGIN_TARGET_NAME} PRIVATE NOMINMAX=1)
+endif()
 
 ## ----- mjcPhysics -----
 
@@ -141,6 +140,9 @@ target_sources(${MJC_PHYSICS_PLUGIN_TARGET_NAME} PRIVATE
   mjcPhysics/tendon.cpp
   mjcPhysics/tokens.cpp
 )
+if(MSVC)
+  target_compile_definitions(${MJC_PHYSICS_PLUGIN_TARGET_NAME} PRIVATE NOMINMAX=1)
+endif()
 set_target_properties(${MJC_PHYSICS_PLUGIN_TARGET_NAME} PROPERTIES
   OUTPUT_NAME ${MJC_PHYSICS_PLUGIN_TARGET_NAME}
   ${DEFAULT_CXX_VISIBILITY_PROPS}
@@ -155,14 +157,27 @@ target_sources(mujoco PRIVATE
   layer_sink.cc
   utils.cc
   writer.cc
+  plugins/mjcf/mujoco_to_usd.cc
+  plugins/mjcf/utils.cc
+)
+target_include_directories(mujoco PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/plugins"
 )
 
 # pxr/usd/tf/hashset.h might include deprecated headers so disable this check
 # when compiling with USD enabled.
-target_compile_options(
-     mujoco
-     PRIVATE -Wno-deprecated
-)
+if(MSVC)
+  target_compile_options(
+      mujoco
+      PRIVATE /wd4996
+  )
+  target_compile_definitions(mujoco PRIVATE NOMINMAX=1)
+else()
+  target_compile_options(
+      mujoco
+      PRIVATE -Wno-deprecated
+  )
+endif()
 
 # Configure RPATH for macOS and UNIX.
 if(APPLE)

--- a/src/experimental/usd/plugins/mjcf/mjcf_file_format.cc
+++ b/src/experimental/usd/plugins/mjcf/mjcf_file_format.cc
@@ -45,6 +45,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(UsdMjcfFileFormatTokens, USD_MJCF_FILE_FORMAT_TOKENS);
 
+#if defined(ARCH_OS_WINDOWS)
+using Arch_ConstructorInit = pxr::Arch_ConstructorInit;
+using Arch_ConstructorEntry = pxr::Arch_ConstructorEntry;
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
 TF_REGISTRY_FUNCTION(TfType) {
   SDF_DEFINE_FILE_FORMAT(UsdMjcfFileFormat, SdfFileFormat);
 }

--- a/src/experimental/usd/plugins/mjcf/mujoco_to_usd.cc
+++ b/src/experimental/usd/plugins/mjcf/mujoco_to_usd.cc
@@ -130,6 +130,9 @@ template <typename T>
 using Arch_PerLibInit = pxr::Arch_PerLibInit<T>;
 #if defined(ARCH_OS_DARWIN)
 using Arch_ConstructorEntry = pxr::Arch_ConstructorEntry;
+#elif defined(ARCH_OS_WINDOWS)
+using Arch_ConstructorInit = pxr::Arch_ConstructorInit;
+using Arch_ConstructorEntry = pxr::Arch_ConstructorEntry;
 #endif
 enum ErrorCodes { UnsupportedActuatorTypeError, UnsupportedGeomTypeError, MujocoCompilationError };
 

--- a/src/experimental/usd/plugins/mjcf/mujoco_to_usd.h
+++ b/src/experimental/usd/plugins/mjcf/mujoco_to_usd.h
@@ -27,7 +27,7 @@ namespace usd {
 //   layer: SdfLayerRefPtr that will be written to.
 //   skip_elems_from_usd: If true, skips over elements in the spec that have a usd_prim_path
 //   custom attribute set.
-bool WriteSpecToData(mjSpec* spec, pxr::SdfLayerRefPtr layer, bool skip_elems_from_usd = false);
+MJAPI bool WriteSpecToData(mjSpec* spec, pxr::SdfLayerRefPtr layer, bool skip_elems_from_usd = false);
 }  // namespace usd
 }  // namespace mujoco
 


### PR DESCRIPTION
This pr add compile configurations to build mujoco with `MUJOCO_WITH_USD=on` on msvc.

- expand cmake configurations
- solve compile error reported by openUSD `TF_REGISTRY_FUNCTION` macros
- explode WriteSpecToData as api of mujoco