### PR TITLE
Always compute site kinematics from site_pos/site_quat, ignoring sameframe optimization

### DIFF
--- a/src/engine/engine_core_smooth.c
+++ b/src/engine/engine_core_smooth.c
@@ -227,7 +227,7 @@ void mj_kinematics2(const mjModel* m, mjData* d) {
 
     mj_local2Global(d, d->site_xpos+3*i, d->site_xmat+9*i,
                     m->site_pos+3*i, m->site_quat+4*i,
-                    bodyid, m->site_sameframe[i]);
+                    bodyid, mjSAMEFRAME_NONE);
   }
 }
 


### PR DESCRIPTION
`mj_kinematics2` in `engine_core_smooth.c` used the `site_sameframe` flag to skip full transform computation for sites initialized at zero position or identity quaternion. This optimization is a compile-time decision: if a site has a null pose at compile time, `site_sameframe` is set to `mjSAMEFRAME_BODY`, causing `mj_local2Global` to copy the body frame directly without reading `site_pos`/`site_quat`. When users modify `model.site_pos` or `model.site_quat` at runtime and then call `mj_forward`, those changes are silently ignored for such sites, leaving `data.site_xpos` and `data.site_xmat` stale.

The fix passes `mjSAMEFRAME_NONE` unconditionally for all sites in `mj_kinematics2`, ensuring `mj_local2Global` always reads the current `site_pos` and `site_quat` values and computes the full transform. Sites are typically few in number and the overhead of an extra matrix-vector multiply per site per step is negligible compared to the correctness guarantee this provides.

Fixes #3029
