### PR TITLE
[codex] Fix EGL CUDA device selection

### DIFF
--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -32,19 +32,117 @@ from mujoco.egl import egl_ext as EGL
 from OpenGL import error
 
 
+def _get_egl_device_cuda_id(device):
+  """Returns the CUDA device id for an EGL device, if the driver exposes it."""
+  try:
+    return EGL.eglQueryDeviceAttribEXT(device, EGL.EGL_CUDA_DEVICE_NV)
+  except (AttributeError, ImportError, TypeError, error.GLError):
+    return None
+
+
+def _get_egl_device_cuda_map(devices):
+  """Returns a CUDA id to EGL device map, or None if it is unavailable."""
+  cuda_map = {}
+  for device in devices:
+    cuda_id = _get_egl_device_cuda_id(device)
+    if cuda_id is None or cuda_id in cuda_map:
+      return None
+    cuda_map[cuda_id] = device
+  return cuda_map
+
+
+def _parse_cuda_visible_devices():
+  """Returns integer CUDA_VISIBLE_DEVICES entries, if they are parseable."""
+  value = os.environ.get('CUDA_VISIBLE_DEVICES')
+  if not value:
+    return None
+
+  device_ids = []
+  for raw_device_id in value.split(','):
+    raw_device_id = raw_device_id.strip()
+    if not raw_device_id:
+      continue
+    try:
+      device_id = int(raw_device_id)
+    except ValueError:
+      return None
+    if device_id < 0:
+      return None
+    device_ids.append(device_id)
+
+  return device_ids or None
+
+
+def _visible_cuda_candidates(cuda_map):
+  """Returns EGL devices ordered by CUDA_VISIBLE_DEVICES, if possible."""
+  visible_cuda_devices = _parse_cuda_visible_devices()
+  if not visible_cuda_devices:
+    return None
+
+  candidates = []
+  for logical_id, physical_id in enumerate(visible_cuda_devices):
+    if physical_id in cuda_map:
+      candidates.append(cuda_map[physical_id])
+    elif logical_id in cuda_map:
+      candidates.append(cuda_map[logical_id])
+    else:
+      return None
+
+  return candidates
+
+
+def _ordered_egl_devices(devices):
+  """Returns EGL devices in CUDA order when possible."""
+  cuda_map = _get_egl_device_cuda_map(devices)
+  if cuda_map is None:
+    return devices, None
+
+  candidates = _visible_cuda_candidates(cuda_map)
+  if candidates:
+    return candidates, cuda_map
+
+  return [cuda_map[cuda_id] for cuda_id in sorted(cuda_map)], cuda_map
+
+
+def _select_egl_device(devices, cuda_map, device_id):
+  """Selects an EGL device by CUDA id when possible, otherwise by index."""
+  visible_cuda_devices = _parse_cuda_visible_devices()
+  if cuda_map is not None and visible_cuda_devices:
+    if 0 <= device_id < len(visible_cuda_devices):
+      physical_id = visible_cuda_devices[device_id]
+      if physical_id in cuda_map:
+        return cuda_map[physical_id]
+      if device_id in cuda_map:
+        return cuda_map[device_id]
+
+    if device_id in visible_cuda_devices:
+      logical_id = visible_cuda_devices.index(device_id)
+      if device_id in cuda_map:
+        return cuda_map[device_id]
+      if logical_id in cuda_map:
+        return cuda_map[logical_id]
+
+  if cuda_map is not None and device_id in cuda_map:
+    return cuda_map[device_id]
+
+  if not 0 <= device_id < len(devices):
+    raise RuntimeError(
+        f'The MUJOCO_EGL_DEVICE_ID environment variable must be an integer '
+        f'between 0 and {len(devices)-1} (inclusive), got {device_id}.')
+
+  return devices[device_id]
+
+
 def create_initialized_egl_device_display():
   """Creates an initialized EGL display directly on a device."""
   all_devices = EGL.eglQueryDevicesEXT()
+  ordered_devices, cuda_map = _ordered_egl_devices(all_devices)
   selected_device = os.environ.get('MUJOCO_EGL_DEVICE_ID', None)
   if selected_device is None:
-    candidates = all_devices
+    candidates = ordered_devices
   else:
     device_idx = int(selected_device)
-    if not 0 <= device_idx < len(all_devices):
-      raise RuntimeError(
-          f'The MUJOCO_EGL_DEVICE_ID environment variable must be an integer '
-          f'between 0 and {len(all_devices)-1} (inclusive), got {device_idx}.')
-    candidates = all_devices[device_idx:device_idx + 1]
+    candidates = [_select_egl_device(ordered_devices, cuda_map, device_idx)]
   for device in candidates:
     display = EGL.eglGetPlatformDisplayEXT(
         EGL.EGL_PLATFORM_DEVICE_EXT, device, None)

--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -40,18 +40,18 @@ def _get_egl_device_cuda_id(device):
     return None
 
 
-def _get_egl_device_cuda_map(devices):
+def _get_cuda_to_egl_device_map(devices):
   """Returns a CUDA id to EGL device map, or None if it is unavailable."""
-  cuda_map = {}
+  cuda_to_egl_device = {}
   for device in devices:
     cuda_id = _get_egl_device_cuda_id(device)
-    if cuda_id is None or cuda_id in cuda_map:
+    if cuda_id is None or cuda_id in cuda_to_egl_device:
       return None
-    cuda_map[cuda_id] = device
-  return cuda_map
+    cuda_to_egl_device[cuda_id] = device
+  return cuda_to_egl_device
 
 
-def _parse_cuda_visible_devices():
+def _parse_cuda_device_ids():
   """Returns integer CUDA_VISIBLE_DEVICES entries, if they are parseable."""
   value = os.environ.get('CUDA_VISIBLE_DEVICES')
   if not value:
@@ -73,57 +73,61 @@ def _parse_cuda_visible_devices():
   return device_ids or None
 
 
-def _visible_cuda_candidates(cuda_map):
+def _egl_device_from_cuda_ids(cuda_to_egl_device, cuda_ids):
+  """Returns the first EGL device matching one of the CUDA ids."""
+  if cuda_to_egl_device is None:
+    return None
+
+  for cuda_id in cuda_ids:
+    if cuda_id in cuda_to_egl_device:
+      return cuda_to_egl_device[cuda_id]
+  return None
+
+
+def _cuda_id_candidates(device_id, cuda_devices):
+  """Returns CUDA ids matching a logical or physical device selection."""
+  if cuda_devices:
+    if 0 <= device_id < len(cuda_devices):
+      yield cuda_devices[device_id]
+    if device_id in cuda_devices:
+      yield cuda_devices.index(device_id)
+  yield device_id
+
+
+def _cuda_device_order(cuda_to_egl_device, cuda_devices):
   """Returns EGL devices ordered by CUDA_VISIBLE_DEVICES, if possible."""
-  visible_cuda_devices = _parse_cuda_visible_devices()
-  if not visible_cuda_devices:
+  if not cuda_devices:
     return None
 
   candidates = []
-  for logical_id, physical_id in enumerate(visible_cuda_devices):
-    if physical_id in cuda_map:
-      candidates.append(cuda_map[physical_id])
-    elif logical_id in cuda_map:
-      candidates.append(cuda_map[logical_id])
-    else:
+  for logical_id, physical_id in enumerate(cuda_devices):
+    device = _egl_device_from_cuda_ids(
+        cuda_to_egl_device, (physical_id, logical_id))
+    if device is None:
       return None
+    candidates.append(device)
 
   return candidates
 
 
-def _ordered_egl_devices(devices):
+def _ordered_egl_devices(devices, cuda_to_egl_device, cuda_devices):
   """Returns EGL devices in CUDA order when possible."""
-  cuda_map = _get_egl_device_cuda_map(devices)
-  if cuda_map is None:
-    return devices, None
+  if cuda_to_egl_device is None:
+    return devices
 
-  candidates = _visible_cuda_candidates(cuda_map)
+  candidates = _cuda_device_order(cuda_to_egl_device, cuda_devices)
   if candidates:
-    return candidates, cuda_map
+    return candidates
 
-  return [cuda_map[cuda_id] for cuda_id in sorted(cuda_map)], cuda_map
+  return [cuda_to_egl_device[cuda_id] for cuda_id in sorted(cuda_to_egl_device)]
 
 
-def _select_egl_device(devices, cuda_map, device_id):
+def _select_egl_device(devices, cuda_to_egl_device, cuda_devices, device_id):
   """Selects an EGL device by CUDA id when possible, otherwise by index."""
-  visible_cuda_devices = _parse_cuda_visible_devices()
-  if cuda_map is not None and visible_cuda_devices:
-    if 0 <= device_id < len(visible_cuda_devices):
-      physical_id = visible_cuda_devices[device_id]
-      if physical_id in cuda_map:
-        return cuda_map[physical_id]
-      if device_id in cuda_map:
-        return cuda_map[device_id]
-
-    if device_id in visible_cuda_devices:
-      logical_id = visible_cuda_devices.index(device_id)
-      if device_id in cuda_map:
-        return cuda_map[device_id]
-      if logical_id in cuda_map:
-        return cuda_map[logical_id]
-
-  if cuda_map is not None and device_id in cuda_map:
-    return cuda_map[device_id]
+  device = _egl_device_from_cuda_ids(
+      cuda_to_egl_device, _cuda_id_candidates(device_id, cuda_devices))
+  if device is not None:
+    return device
 
   if not 0 <= device_id < len(devices):
     raise RuntimeError(
@@ -136,13 +140,17 @@ def _select_egl_device(devices, cuda_map, device_id):
 def create_initialized_egl_device_display():
   """Creates an initialized EGL display directly on a device."""
   all_devices = EGL.eglQueryDevicesEXT()
-  ordered_devices, cuda_map = _ordered_egl_devices(all_devices)
+  cuda_to_egl_device = _get_cuda_to_egl_device_map(all_devices)
+  cuda_devices = _parse_cuda_device_ids()
+  ordered_devices = _ordered_egl_devices(
+      all_devices, cuda_to_egl_device, cuda_devices)
   selected_device = os.environ.get('MUJOCO_EGL_DEVICE_ID', None)
   if selected_device is None:
     candidates = ordered_devices
   else:
     device_idx = int(selected_device)
-    candidates = [_select_egl_device(ordered_devices, cuda_map, device_idx)]
+    candidates = [_select_egl_device(
+        ordered_devices, cuda_to_egl_device, cuda_devices, device_idx)]
   for device in candidates:
     display = EGL.eglGetPlatformDisplayEXT(
         EGL.EGL_PLATFORM_DEVICE_EXT, device, None)

--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -51,9 +51,8 @@ def _get_cuda_to_egl_device_map(devices):
   return cuda_to_egl_device
 
 
-def _parse_cuda_device_ids():
+def _parse_cuda_device_ids(value):
   """Returns integer CUDA_VISIBLE_DEVICES entries, if they are parseable."""
-  value = os.environ.get('CUDA_VISIBLE_DEVICES')
   if not value:
     return None
 
@@ -141,7 +140,7 @@ def create_initialized_egl_device_display():
   """Creates an initialized EGL display directly on a device."""
   all_devices = EGL.eglQueryDevicesEXT()
   cuda_to_egl_device = _get_cuda_to_egl_device_map(all_devices)
-  cuda_devices = _parse_cuda_device_ids()
+  cuda_devices = _parse_cuda_device_ids(os.environ.get('CUDA_VISIBLE_DEVICES'))
   ordered_devices = _ordered_egl_devices(
       all_devices, cuda_to_egl_device, cuda_devices)
   selected_device = os.environ.get('MUJOCO_EGL_DEVICE_ID', None)

--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -139,6 +139,11 @@ def _select_egl_device(devices, cuda_to_egl_device, cuda_devices, device_id):
 def create_initialized_egl_device_display():
   """Creates an initialized EGL display directly on a device."""
   all_devices = EGL.eglQueryDevicesEXT()
+  # Some drivers expose which CUDA device backs each EGL device. When that
+  # mapping is available, use CUDA_VISIBLE_DEVICES to put EGL devices in the
+  # same order CUDA users expect, and let MUJOCO_EGL_DEVICE_ID refer to either a
+  # visible-device index or a CUDA id. If the mapping is missing or ambiguous,
+  # fall back to EGL's native device order.
   cuda_to_egl_device = _get_cuda_to_egl_device_map(all_devices)
   cuda_devices = _parse_cuda_device_ids(os.environ.get('CUDA_VISIBLE_DEVICES'))
   ordered_devices = _ordered_egl_devices(

--- a/python/mujoco/egl/egl_ext.py
+++ b/python/mujoco/egl/egl_ext.py
@@ -27,6 +27,9 @@ except OSError:
 from OpenGL import EGL
 from OpenGL import error
 
+# From the EGL_NV_device_cuda extension.
+EGL_CUDA_DEVICE_NV = 0x323A
+
 # From the EGL_EXT_device_enumeration extension.
 PFNEGLQUERYDEVICESEXTPROC = ctypes.CFUNCTYPE(
     EGL.EGLBoolean,
@@ -52,6 +55,21 @@ except TypeError as e:
   raise ImportError('eglGetPlatformDisplayEXT is not available.') from e
 
 
+# From the EGL_EXT_device_query extension.
+EGLAttrib = getattr(EGL, 'EGLAttrib', ctypes.c_ssize_t)
+PFNEGLQUERYDEVICEATTRIBEXTPROC = ctypes.CFUNCTYPE(
+    EGL.EGLBoolean,
+    EGL.EGLDeviceEXT,
+    EGL.EGLint,
+    ctypes.POINTER(EGLAttrib),
+)
+try:
+  _eglQueryDeviceAttribEXT = PFNEGLQUERYDEVICEATTRIBEXTPROC(  # pylint: disable=invalid-name
+      EGL.eglGetProcAddress('eglQueryDeviceAttribEXT'))
+except TypeError:
+  _eglQueryDeviceAttribEXT = None
+
+
 # Wrap raw _eglQueryDevicesEXT function into something more Pythonic.
 def eglQueryDevicesEXT(max_devices=10):  # pylint: disable=invalid-name
   devices = (EGL.EGLDeviceEXT * max_devices)()
@@ -65,7 +83,25 @@ def eglQueryDevicesEXT(max_devices=10):  # pylint: disable=invalid-name
                         result=success)
 
 
+def eglQueryDeviceAttribEXT(device, attribute):  # pylint: disable=invalid-name
+  if _eglQueryDeviceAttribEXT is None:
+    raise ImportError('eglQueryDeviceAttribEXT is not available.')
+
+  value = EGLAttrib()
+  success = _eglQueryDeviceAttribEXT(device, attribute, ctypes.byref(value))
+  if success == EGL.EGL_TRUE:
+    return value.value
+  else:
+    raise error.GLError(err=EGL.eglGetError(),
+                        baseOperation=eglQueryDeviceAttribEXT,
+                        result=success)
+
+
 # Expose everything from upstream so that
 # we can use this as a drop-in replacement for OpenGL.EGL.
 # pylint: disable=wildcard-import,g-bad-import-order
+_eglQueryDevicesEXTWrapper = eglQueryDevicesEXT  # pylint: disable=invalid-name
+_eglQueryDeviceAttribEXTWrapper = eglQueryDeviceAttribEXT  # pylint: disable=invalid-name
 from OpenGL.EGL import *
+eglQueryDevicesEXT = _eglQueryDevicesEXTWrapper  # pylint: disable=invalid-name
+eglQueryDeviceAttribEXT = _eglQueryDeviceAttribEXTWrapper  # pylint: disable=invalid-name

--- a/python/mujoco/egl/egl_ext.py
+++ b/python/mujoco/egl/egl_ext.py
@@ -27,6 +27,12 @@ except OSError:
 from OpenGL import EGL
 from OpenGL import error
 
+# Expose everything from upstream so that this can be used as a drop-in
+# replacement for OpenGL.EGL. Extension wrappers below use eglGetProcAddress
+# because PyOpenGL may not expose these entry points directly.
+# pylint: disable=wildcard-import,g-bad-import-order
+from OpenGL.EGL import *
+
 # From the EGL_NV_device_cuda extension.
 EGL_CUDA_DEVICE_NV = 0x323A
 
@@ -95,13 +101,3 @@ def eglQueryDeviceAttribEXT(device, attribute):  # pylint: disable=invalid-name
     raise error.GLError(err=EGL.eglGetError(),
                         baseOperation=eglQueryDeviceAttribEXT,
                         result=success)
-
-
-# Expose everything from upstream so that
-# we can use this as a drop-in replacement for OpenGL.EGL.
-# pylint: disable=wildcard-import,g-bad-import-order
-_eglQueryDevicesEXTWrapper = eglQueryDevicesEXT  # pylint: disable=invalid-name
-_eglQueryDeviceAttribEXTWrapper = eglQueryDeviceAttribEXT  # pylint: disable=invalid-name
-from OpenGL.EGL import *
-eglQueryDevicesEXT = _eglQueryDevicesEXTWrapper  # pylint: disable=invalid-name
-eglQueryDeviceAttribEXT = _eglQueryDeviceAttribEXTWrapper  # pylint: disable=invalid-name

--- a/python/mujoco/egl_test.py
+++ b/python/mujoco/egl_test.py
@@ -1,0 +1,197 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for EGL device selection."""
+
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+from unittest import mock
+
+from absl.testing import absltest
+
+
+class _FakeGLError(Exception):
+  pass
+
+
+class _FakeEGL:
+
+  EGL_TRUE = 1
+  EGL_SUCCESS = 0x3000
+  EGL_NO_DISPLAY = None
+  EGL_PLATFORM_DEVICE_EXT = 0x313F
+  EGL_CUDA_DEVICE_NV = 0x323A
+
+  EGL_RED_SIZE = 0
+  EGL_GREEN_SIZE = 1
+  EGL_BLUE_SIZE = 2
+  EGL_ALPHA_SIZE = 3
+  EGL_DEPTH_SIZE = 4
+  EGL_STENCIL_SIZE = 5
+  EGL_COLOR_BUFFER_TYPE = 6
+  EGL_RGB_BUFFER = 7
+  EGL_SURFACE_TYPE = 8
+  EGL_PBUFFER_BIT = 9
+  EGL_RENDERABLE_TYPE = 10
+  EGL_OPENGL_BIT = 11
+  EGL_NONE = 12
+
+  def __init__(self, devices, cuda_ids=None):
+    self._devices = devices
+    self._cuda_ids = cuda_ids
+
+  def eglQueryDevicesEXT(self):
+    return self._devices
+
+  def eglQueryDeviceAttribEXT(self, device, attribute):
+    if self._cuda_ids is None:
+      raise ImportError('eglQueryDeviceAttribEXT is not available.')
+    if attribute != self.EGL_CUDA_DEVICE_NV:
+      raise _FakeGLError()
+    return self._cuda_ids[device]
+
+  def eglGetPlatformDisplayEXT(self, platform, device, attributes):
+    del platform, attributes
+    return f'display:{device}'
+
+  def eglGetError(self):
+    return self.EGL_SUCCESS
+
+  def eglInitialize(self, display, major, minor):
+    del display, major, minor
+    return self.EGL_TRUE
+
+
+def _load_egl_module(fake_egl, env):
+  fake_mujoco = types.ModuleType('mujoco')
+  fake_mujoco.__path__ = []
+  fake_mujoco_egl = types.ModuleType('mujoco.egl')
+  fake_mujoco_egl.__path__ = []
+  fake_mujoco_egl.egl_ext = fake_egl
+  fake_opengl = types.ModuleType('OpenGL')
+  fake_opengl.error = types.SimpleNamespace(GLError=_FakeGLError)
+
+  module_name = '_mujoco_egl_under_test'
+  module_path = pathlib.Path(__file__).with_name('egl') / '__init__.py'
+  spec = importlib.util.spec_from_file_location(module_name, module_path)
+  module = importlib.util.module_from_spec(spec)
+
+  modules = {
+      'mujoco': fake_mujoco,
+      'mujoco.egl': fake_mujoco_egl,
+      'mujoco.egl.egl_ext': fake_egl,
+      'OpenGL': fake_opengl,
+      'OpenGL.error': fake_opengl.error,
+  }
+  test_env = {'PYOPENGL_PLATFORM': 'egl'}
+  test_env.update(env)
+
+  with mock.patch.dict(sys.modules, modules), mock.patch.dict(
+      os.environ, test_env, clear=True):
+    spec.loader.exec_module(module)
+  return module
+
+
+def _create_initialized_egl_device_display(module, env):
+  test_env = {'PYOPENGL_PLATFORM': 'egl'}
+  test_env.update(env)
+  with mock.patch.dict(os.environ, test_env, clear=True):
+    return module.create_initialized_egl_device_display()
+
+
+class EGLDeviceSelectionTest(absltest.TestCase):
+
+  def test_selected_device_uses_cuda_device_id(self):
+    devices = ['egl-for-cuda-2', 'egl-for-cuda-1', 'egl-for-cuda-0']
+    fake_egl = _FakeEGL(
+        devices,
+        {
+            'egl-for-cuda-0': 0,
+            'egl-for-cuda-1': 1,
+            'egl-for-cuda-2': 2,
+        })
+    module = _load_egl_module(fake_egl, {'MUJOCO_EGL_DEVICE_ID': '2'})
+
+    display = _create_initialized_egl_device_display(
+        module, {'MUJOCO_EGL_DEVICE_ID': '2'})
+
+    self.assertEqual(display, 'display:egl-for-cuda-2')
+
+  def test_selected_device_uses_cuda_visible_logical_id(self):
+    devices = ['egl-for-cuda-2', 'egl-for-cuda-0']
+    fake_egl = _FakeEGL(
+        devices,
+        {
+            'egl-for-cuda-0': 0,
+            'egl-for-cuda-2': 2,
+        })
+    module = _load_egl_module(fake_egl, {
+        'CUDA_VISIBLE_DEVICES': '2',
+        'MUJOCO_EGL_DEVICE_ID': '0',
+    })
+
+    display = _create_initialized_egl_device_display(module, {
+        'CUDA_VISIBLE_DEVICES': '2',
+        'MUJOCO_EGL_DEVICE_ID': '0',
+    })
+
+    self.assertEqual(display, 'display:egl-for-cuda-2')
+
+  def test_selected_device_uses_cuda_visible_physical_id(self):
+    devices = ['egl-visible']
+    fake_egl = _FakeEGL(devices, {'egl-visible': 0})
+    module = _load_egl_module(fake_egl, {
+        'CUDA_VISIBLE_DEVICES': '2',
+        'MUJOCO_EGL_DEVICE_ID': '2',
+    })
+
+    display = _create_initialized_egl_device_display(module, {
+        'CUDA_VISIBLE_DEVICES': '2',
+        'MUJOCO_EGL_DEVICE_ID': '2',
+    })
+
+    self.assertEqual(display, 'display:egl-visible')
+
+  def test_falls_back_to_egl_order_without_cuda_query(self):
+    devices = ['egl-0', 'egl-1', 'egl-2']
+    fake_egl = _FakeEGL(devices)
+    module = _load_egl_module(fake_egl, {'MUJOCO_EGL_DEVICE_ID': '1'})
+
+    display = _create_initialized_egl_device_display(
+        module, {'MUJOCO_EGL_DEVICE_ID': '1'})
+
+    self.assertEqual(display, 'display:egl-1')
+
+  def test_unselected_devices_use_cuda_visible_order(self):
+    devices = ['egl-for-cuda-4', 'egl-for-cuda-2', 'egl-for-cuda-0']
+    fake_egl = _FakeEGL(
+        devices,
+        {
+            'egl-for-cuda-0': 0,
+            'egl-for-cuda-2': 2,
+            'egl-for-cuda-4': 4,
+        })
+    module = _load_egl_module(fake_egl, {'CUDA_VISIBLE_DEVICES': '2,4'})
+
+    display = _create_initialized_egl_device_display(
+        module, {'CUDA_VISIBLE_DEVICES': '2,4'})
+
+    self.assertEqual(display, 'display:egl-for-cuda-2')
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary
- map EGL devices to CUDA device IDs when the NVIDIA EGL CUDA device extension is available
- respect simple integer CUDA_VISIBLE_DEVICES mappings when selecting MUJOCO_EGL_DEVICE_ID
- add mocked EGL selection tests for raw EGL order, CUDA order, and CUDA_VISIBLE_DEVICES cases

Fixes #3245

## Testing
- python -m pytest -q python/mujoco/egl_test.py
- python -m compileall -q python/mujoco/egl python/mujoco/egl_test.py
- git diff --check

## Notes
I do not have access to a multi-GPU NVIDIA/EGL host in this environment, so the hardware-specific behavior is covered by mocked EGL tests rather than an end-to-end nvidia-smi validation.
