### PR TITLE
Handle rollout MuJoCo errors as warnings

### DIFF
--- a/doc/python.rst
+++ b/doc/python.rst
@@ -901,7 +901,9 @@ The basic usage form is
   ``control_spec`` bitflag.
 
 If a rollout diverges, the current state and sensor values are used to fill the remainder of the trajectory.
-Therefore, non-increasing time values can be used to detect diverged rollouts.
+Therefore, non-increasing time values can be used to detect diverged rollouts. By default, MuJoCo errors still raise
+exceptions, but passing ``raise_on_error=False`` handles them like diverged rollouts and fills the remainder of the
+failed trajectory.
 
 The ``rollout`` function is designed to be computationally stateless, so all inputs of the stepping pipeline are set and
 any values already present in the given ``MjData`` instance will have no effect on the output.

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -14,10 +14,8 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <exception>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <sstream>
 #include <vector>
@@ -135,6 +133,7 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
     }
 
     // roll out trajectory
+    bool nerror = false;
     for (size_t t = 0; t < nstep; t++) {
       // check for warnings
       bool nwarning = false;
@@ -143,37 +142,6 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
           nwarning = true;
           break;
         }
-      }
-
-      bool nerror = false;
-
-      size_t step = r*static_cast<size_t>(nstep) + t;
-
-      // controls
-      if (control && !nwarning) {
-        mj_setState(m[r], d, control + step*ncontrol, control_spec);
-      }
-
-      // step
-      if (!nwarning) {
-        try {
-          InterceptMjErrors(mj_step)(m[r], d);
-        } catch (const FatalError&) {
-          if (raise_on_error) {
-            throw;
-          }
-          nerror = true;
-        }
-      }
-
-      // copy out new state
-      if (state && !nwarning && !nerror) {
-        mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
-      }
-
-      // copy out sensor values
-      if (sensordata && !nwarning && !nerror) {
-        mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
       }
 
       // if any warnings or handled errors, fill remaining outputs with current outputs, break
@@ -188,6 +156,41 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
           }
         }
         break;
+      }
+
+      size_t step = r*static_cast<size_t>(nstep) + t;
+
+      // controls
+      if (control) {
+        mj_setState(m[r], d, control + step*ncontrol, control_spec);
+      }
+
+      // step
+      try {
+        InterceptMjErrors(mj_step)(m[r], d);
+      } catch (const FatalError&) {
+        if (raise_on_error) {
+          throw;
+        }
+        // Write this step before continuing to the fill path.
+        if (state) {
+          mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
+        }
+        if (sensordata) {
+          mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+        }
+        nerror = true;
+        continue;
+      }
+
+      // copy out new state
+      if (state) {
+        mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
+      }
+
+      // copy out sensor values
+      if (sensordata) {
+        mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
       }
     }
   }
@@ -204,53 +207,34 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
   int nfulljobs = nbatch / chunk_size;
   int chunk_remainder = nbatch % chunk_size;
   int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;
-  std::exception_ptr rollout_error;
-  std::mutex rollout_error_mutex;
 
   // Reset the pool counter
   pool->ResetCount();
 
   // schedule all jobs of full (chunk) size
   for (int j = 0; j < nfulljobs; j++) {
-    auto task = [=, &m, &d, &rollout_error, &rollout_error_mutex](void) {
+    auto task = [=, &m, &d](void) {
       int id = pool->WorkerId();
-      try {
-        _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
-          nstep, control_spec, state0, warmstart0, control, state, sensordata,
-          raise_on_error);
-      } catch (...) {
-        std::lock_guard<std::mutex> lock(rollout_error_mutex);
-        if (!rollout_error) {
-          rollout_error = std::current_exception();
-        }
-      }
+      _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
+        nstep, control_spec, state0, warmstart0, control, state, sensordata,
+        raise_on_error);
     };
     pool->Schedule(task);
   }
 
   // schedule any remaining jobs of size < chunk_size
   if (chunk_remainder > 0) {
-    auto task = [=, &m, &d, &rollout_error, &rollout_error_mutex](void) {
-      try {
-        _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
-          nfulljobs*chunk_size+chunk_remainder,
-          nstep, control_spec, state0, warmstart0, control, state, sensordata,
-          raise_on_error);
-      } catch (...) {
-        std::lock_guard<std::mutex> lock(rollout_error_mutex);
-        if (!rollout_error) {
-          rollout_error = std::current_exception();
-        }
-      }
+    auto task = [=, &m, &d](void) {
+      _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
+        nfulljobs*chunk_size+chunk_remainder,
+        nstep, control_spec, state0, warmstart0, control, state, sensordata,
+        raise_on_error);
     };
     pool->Schedule(task);
   }
 
   // wait for counter to increment up to number of jobs submitted by this thread
   pool->WaitCount(njobs);
-  if (rollout_error) {
-    std::rethrow_exception(rollout_error);
-  }
 }
 
 // NOLINTEND(whitespace/line_length)
@@ -351,12 +335,12 @@ class Rollout {
         } else {
           chunk_size_final = *chunk_size;
         }
-        _unsafe_rollout_threaded(
+        InterceptMjErrors(_unsafe_rollout_threaded)(
             model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
             warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
             this->pool_.get(), chunk_size_final, raise_on_error);
       } else {
-        _unsafe_rollout(
+        InterceptMjErrors(_unsafe_rollout)(
             model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
             state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
             sensordata_ptr, raise_on_error);

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -172,15 +172,7 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
         if (raise_on_error) {
           throw;
         }
-        // Write this step before continuing to the fill path.
-        if (state) {
-          mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
-        }
-        if (sensordata) {
-          mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
-        }
         nerror = true;
-        continue;
       }
 
       // copy out new state

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <mujoco/mujoco.h>
@@ -66,7 +67,33 @@ Roll out batch of trajectories from initial states, get resulting states and sen
     sensordata         (nbatch x nstep x nsendordata) nbatch trajectories of nstep sensordata arrays
     chunk_size         integer, determines threadpool chunk size. If unspecified, the default is
                            chunk_size = max(1, nbatch / (nthread * 10))
+    raise_on_error     boolean, whether to raise MuJoCo errors. If false, errors fill the
+                           remaining trajectory outputs like warnings.
 )";
+
+void FillRemainingOutputs(const mjModel* m, const mjData* d, size_t r, size_t t,
+                          int nstep, size_t nstate, size_t nsensordata,
+                          mjtNum* state, mjtNum* sensordata) {
+  for (; t < nstep; t++) {
+    size_t step = r*static_cast<size_t>(nstep) + t;
+    if (state) {
+      mj_getState(m, d, state + step*nstate, mjSTATE_FULLPHYSICS);
+    }
+    if (sensordata) {
+      mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+    }
+  }
+}
+
+template <typename Callable>
+bool TryMjCall(Callable&& callable) {
+  try {
+    InterceptMjErrors(std::forward<Callable>(callable))();
+  } catch (const FatalError&) {
+    return false;
+  }
+  return true;
+}
 
 // C-style rollout function, assumes all arguments are valid
 // all input fields of d are initialised, contents at call time do not matter
@@ -74,7 +101,8 @@ Roll out batch of trajectories from initial states, get resulting states and sen
 void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
                      int end_roll, int nstep, unsigned int control_spec,
                      const mjtNum* state0, const mjtNum* warmstart0,
-                     const mjtNum* control, mjtNum* state, mjtNum* sensordata) {
+                     const mjtNum* control, mjtNum* state, mjtNum* sensordata,
+                     bool handle_mj_errors) {
   // sizes
   size_t nstate = static_cast<size_t>(mj_stateSize(m[0], mjSTATE_FULLPHYSICS));
   size_t ncontrol = static_cast<size_t>(mj_stateSize(m[0], control_spec));
@@ -115,7 +143,17 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
     }
 
     // set initial state
-    mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
+    if (handle_mj_errors) {
+      if (!TryMjCall([&]() {
+        mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
+      })) {
+        FillRemainingOutputs(
+            m[r], d, r, 0, nstep, nstate, nsensordata, state, sensordata);
+        continue;
+      }
+    } else {
+      mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
+    }
 
     // set warmstart accelerations
     if (warmstart0) {
@@ -142,15 +180,8 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
 
       // if any warnings, fill remaining outputs with current outputs, break
       if (nwarning) {
-        for (; t < nstep; t++) {
-          size_t step = r*static_cast<size_t>(nstep) + t;
-          if (state) {
-            mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
-          }
-          if (sensordata) {
-            mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
-          }
-        }
+        FillRemainingOutputs(
+            m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
         break;
       }
 
@@ -158,11 +189,29 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
 
       // controls
       if (control) {
-        mj_setState(m[r], d, control + step*ncontrol, control_spec);
+        if (handle_mj_errors) {
+          if (!TryMjCall([&]() {
+            mj_setState(m[r], d, control + step*ncontrol, control_spec);
+          })) {
+            FillRemainingOutputs(
+                m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
+            break;
+          }
+        } else {
+          mj_setState(m[r], d, control + step*ncontrol, control_spec);
+        }
       }
 
       // step
-      mj_step(m[r], d);
+      if (handle_mj_errors) {
+        if (!TryMjCall([&]() { mj_step(m[r], d); })) {
+          FillRemainingOutputs(
+              m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
+          break;
+        }
+      } else {
+        mj_step(m[r], d);
+      }
 
       // copy out new state
       if (state) {
@@ -183,7 +232,8 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
                               unsigned int control_spec, const mjtNum* state0,
                               const mjtNum* warmstart0, const mjtNum* control,
                               mjtNum* state, mjtNum* sensordata,
-                              ThreadPool* pool, int chunk_size) {
+                              ThreadPool* pool, int chunk_size,
+                              bool handle_mj_errors) {
   int nfulljobs = nbatch / chunk_size;
   int chunk_remainder = nbatch % chunk_size;
   int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;
@@ -196,7 +246,8 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
     auto task = [=, &m, &d](void) {
       int id = pool->WorkerId();
       _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata);
+        nstep, control_spec, state0, warmstart0, control, state, sensordata,
+        handle_mj_errors);
     };
     pool->Schedule(task);
   }
@@ -206,7 +257,8 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
     auto task = [=, &m, &d](void) {
       _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
         nfulljobs*chunk_size+chunk_remainder,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata);
+        nstep, control_spec, state0, warmstart0, control, state, sensordata,
+        handle_mj_errors);
     };
     pool->Schedule(task);
   }
@@ -252,7 +304,7 @@ class Rollout {
                std::optional<const PyCArray> control,
                std::optional<const PyCArray> state,
                std::optional<const PyCArray> sensordata,
-               std::optional<int> chunk_size) {
+               std::optional<int> chunk_size, bool raise_on_error) {
     // get raw pointers
     int nbatch = state0.shape(0);
     std::vector<const raw::MjModel*> model_ptrs(nbatch);
@@ -313,14 +365,29 @@ class Rollout {
         } else {
           chunk_size_final = *chunk_size;
         }
-        InterceptMjErrors(_unsafe_rollout_threaded)(
-            model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
-            warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
-            this->pool_.get(), chunk_size_final);
+        if (raise_on_error) {
+          InterceptMjErrors(_unsafe_rollout_threaded)(
+              model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
+              warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
+              this->pool_.get(), chunk_size_final, false);
+        } else {
+          _unsafe_rollout_threaded(
+              model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
+              warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
+              this->pool_.get(), chunk_size_final, true);
+        }
       } else {
-        InterceptMjErrors(_unsafe_rollout)(
-            model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
-            state0_ptr, warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr);
+        if (raise_on_error) {
+          InterceptMjErrors(_unsafe_rollout)(
+              model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
+              state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
+              sensordata_ptr, false);
+        } else {
+          _unsafe_rollout(
+              model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
+              state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
+              sensordata_ptr, true);
+        }
       }
     }
   }
@@ -354,10 +421,10 @@ PYBIND11_MODULE(_rollout, pymodule, pybind11::mod_gil_not_used()) {
         py::arg("state")      = py::none(),
         py::arg("sensordata") = py::none(),
         py::arg("chunk_size") = py::none(),
+        py::arg("raise_on_error") = true,
         py::doc(rollout_doc));
 }
 
 }  // namespace
 
 }  // namespace mujoco::python
-

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -14,11 +14,12 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
-#include <utility>
 #include <vector>
 
 #include <mujoco/mujoco.h>
@@ -71,30 +72,6 @@ Roll out batch of trajectories from initial states, get resulting states and sen
                            remaining trajectory outputs like warnings.
 )";
 
-void FillRemainingOutputs(const mjModel* m, const mjData* d, size_t r, size_t t,
-                          int nstep, size_t nstate, size_t nsensordata,
-                          mjtNum* state, mjtNum* sensordata) {
-  for (; t < nstep; t++) {
-    size_t step = r*static_cast<size_t>(nstep) + t;
-    if (state) {
-      mj_getState(m, d, state + step*nstate, mjSTATE_FULLPHYSICS);
-    }
-    if (sensordata) {
-      mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
-    }
-  }
-}
-
-template <typename Callable>
-bool TryMjCall(Callable&& callable) {
-  try {
-    InterceptMjErrors(std::forward<Callable>(callable))();
-  } catch (const FatalError&) {
-    return false;
-  }
-  return true;
-}
-
 // C-style rollout function, assumes all arguments are valid
 // all input fields of d are initialised, contents at call time do not matter
 // after returning, d will contain the last step of the last rollout
@@ -102,7 +79,7 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
                      int end_roll, int nstep, unsigned int control_spec,
                      const mjtNum* state0, const mjtNum* warmstart0,
                      const mjtNum* control, mjtNum* state, mjtNum* sensordata,
-                     bool handle_mj_errors) {
+                     bool raise_on_error) {
   // sizes
   size_t nstate = static_cast<size_t>(mj_stateSize(m[0], mjSTATE_FULLPHYSICS));
   size_t ncontrol = static_cast<size_t>(mj_stateSize(m[0], control_spec));
@@ -143,17 +120,7 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
     }
 
     // set initial state
-    if (handle_mj_errors) {
-      if (!TryMjCall([&]() {
-        mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
-      })) {
-        FillRemainingOutputs(
-            m[r], d, r, 0, nstep, nstate, nsensordata, state, sensordata);
-        continue;
-      }
-    } else {
-      mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
-    }
+    mj_setState(m[r], d, state0 + r*nstate, mjSTATE_FULLPHYSICS);
 
     // set warmstart accelerations
     if (warmstart0) {
@@ -178,49 +145,49 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
         }
       }
 
-      // if any warnings, fill remaining outputs with current outputs, break
-      if (nwarning) {
-        FillRemainingOutputs(
-            m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
-        break;
-      }
+      bool nerror = false;
 
       size_t step = r*static_cast<size_t>(nstep) + t;
 
       // controls
-      if (control) {
-        if (handle_mj_errors) {
-          if (!TryMjCall([&]() {
-            mj_setState(m[r], d, control + step*ncontrol, control_spec);
-          })) {
-            FillRemainingOutputs(
-                m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
-            break;
-          }
-        } else {
-          mj_setState(m[r], d, control + step*ncontrol, control_spec);
-        }
+      if (control && !nwarning) {
+        mj_setState(m[r], d, control + step*ncontrol, control_spec);
       }
 
       // step
-      if (handle_mj_errors) {
-        if (!TryMjCall([&]() { mj_step(m[r], d); })) {
-          FillRemainingOutputs(
-              m[r], d, r, t, nstep, nstate, nsensordata, state, sensordata);
-          break;
+      if (!nwarning) {
+        try {
+          InterceptMjErrors(mj_step)(m[r], d);
+        } catch (const FatalError&) {
+          if (raise_on_error) {
+            throw;
+          }
+          nerror = true;
         }
-      } else {
-        mj_step(m[r], d);
       }
 
       // copy out new state
-      if (state) {
+      if (state && !nwarning && !nerror) {
         mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
       }
 
       // copy out sensor values
-      if (sensordata) {
+      if (sensordata && !nwarning && !nerror) {
         mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+      }
+
+      // if any warnings or handled errors, fill remaining outputs with current outputs, break
+      if (nwarning || nerror) {
+        for (; t < nstep; t++) {
+          size_t step = r*static_cast<size_t>(nstep) + t;
+          if (state) {
+            mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
+          }
+          if (sensordata) {
+            mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+          }
+        }
+        break;
       }
     }
   }
@@ -233,38 +200,57 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
                               const mjtNum* warmstart0, const mjtNum* control,
                               mjtNum* state, mjtNum* sensordata,
                               ThreadPool* pool, int chunk_size,
-                              bool handle_mj_errors) {
+                              bool raise_on_error) {
   int nfulljobs = nbatch / chunk_size;
   int chunk_remainder = nbatch % chunk_size;
   int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;
+  std::exception_ptr rollout_error;
+  std::mutex rollout_error_mutex;
 
   // Reset the pool counter
   pool->ResetCount();
 
   // schedule all jobs of full (chunk) size
   for (int j = 0; j < nfulljobs; j++) {
-    auto task = [=, &m, &d](void) {
+    auto task = [=, &m, &d, &rollout_error, &rollout_error_mutex](void) {
       int id = pool->WorkerId();
-      _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata,
-        handle_mj_errors);
+      try {
+        _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
+          nstep, control_spec, state0, warmstart0, control, state, sensordata,
+          raise_on_error);
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(rollout_error_mutex);
+        if (!rollout_error) {
+          rollout_error = std::current_exception();
+        }
+      }
     };
     pool->Schedule(task);
   }
 
   // schedule any remaining jobs of size < chunk_size
   if (chunk_remainder > 0) {
-    auto task = [=, &m, &d](void) {
-      _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
-        nfulljobs*chunk_size+chunk_remainder,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata,
-        handle_mj_errors);
+    auto task = [=, &m, &d, &rollout_error, &rollout_error_mutex](void) {
+      try {
+        _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
+          nfulljobs*chunk_size+chunk_remainder,
+          nstep, control_spec, state0, warmstart0, control, state, sensordata,
+          raise_on_error);
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(rollout_error_mutex);
+        if (!rollout_error) {
+          rollout_error = std::current_exception();
+        }
+      }
     };
     pool->Schedule(task);
   }
 
   // wait for counter to increment up to number of jobs submitted by this thread
   pool->WaitCount(njobs);
+  if (rollout_error) {
+    std::rethrow_exception(rollout_error);
+  }
 }
 
 // NOLINTEND(whitespace/line_length)
@@ -365,29 +351,15 @@ class Rollout {
         } else {
           chunk_size_final = *chunk_size;
         }
-        if (raise_on_error) {
-          InterceptMjErrors(_unsafe_rollout_threaded)(
-              model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
-              warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
-              this->pool_.get(), chunk_size_final, false);
-        } else {
-          _unsafe_rollout_threaded(
-              model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
-              warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
-              this->pool_.get(), chunk_size_final, true);
-        }
+        _unsafe_rollout_threaded(
+            model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
+            warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
+            this->pool_.get(), chunk_size_final, raise_on_error);
       } else {
-        if (raise_on_error) {
-          InterceptMjErrors(_unsafe_rollout)(
-              model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
-              state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
-              sensordata_ptr, false);
-        } else {
-          _unsafe_rollout(
-              model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
-              state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
-              sensordata_ptr, true);
-        }
+        _unsafe_rollout(
+            model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
+            state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
+            sensordata_ptr, raise_on_error);
       }
     }
   }

--- a/python/mujoco/rollout.cc
+++ b/python/mujoco/rollout.cc
@@ -14,8 +14,10 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <vector>
@@ -132,57 +134,77 @@ void _unsafe_rollout(std::vector<const mjModel*>& m, mjData* d, int start_roll,
       d->warning[i].number = 0;
     }
 
-    // roll out trajectory
+    // Roll out the trajectory under a single error interceptor. The progress
+    // counter must be volatile because a MuJoCo error returns here via longjmp.
+    volatile int t = 0;
     bool nerror = false;
-    for (size_t t = 0; t < nstep; t++) {
-      // check for warnings
-      bool nwarning = false;
-      for (int i = 0; i < mjNWARNING; i++) {
-        if (d->warning[i].number) {
-          nwarning = true;
-          break;
-        }
-      }
-
-      // if any warnings or handled errors, fill remaining outputs with current outputs, break
-      if (nwarning || nerror) {
+    try {
+      InterceptMjErrors([&]() {
         for (; t < nstep; t++) {
+          // check for warnings
+          bool nwarning = false;
+          for (int i = 0; i < mjNWARNING; i++) {
+            if (d->warning[i].number) {
+              nwarning = true;
+              break;
+            }
+          }
+
+          // if any warnings, fill remaining outputs with current outputs, break
+          if (nwarning) {
+            for (; t < nstep; t++) {
+              size_t step = r*static_cast<size_t>(nstep) + t;
+              if (state) {
+                mj_getState(m[r], d, state + step*nstate,
+                            mjSTATE_FULLPHYSICS);
+              }
+              if (sensordata) {
+                mju_copy(sensordata + step*nsensordata, d->sensordata,
+                         nsensordata);
+              }
+            }
+            break;
+          }
+
           size_t step = r*static_cast<size_t>(nstep) + t;
+
+          // controls
+          if (control) {
+            mj_setState(m[r], d, control + step*ncontrol, control_spec);
+          }
+
+          // step
+          mj_step(m[r], d);
+
+          // copy out new state
           if (state) {
             mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
           }
+
+          // copy out sensor values
           if (sensordata) {
-            mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+            mju_copy(sensordata + step*nsensordata, d->sensordata,
+                     nsensordata);
           }
         }
-        break;
+      })();
+    } catch (const FatalError&) {
+      if (raise_on_error) {
+        throw;
       }
+      nerror = true;
+    }
 
-      size_t step = r*static_cast<size_t>(nstep) + t;
-
-      // controls
-      if (control) {
-        mj_setState(m[r], d, control + step*ncontrol, control_spec);
-      }
-
-      // step
-      try {
-        InterceptMjErrors(mj_step)(m[r], d);
-      } catch (const FatalError&) {
-        if (raise_on_error) {
-          throw;
+    // A handled error fills the failed step and the rest of the trajectory.
+    if (nerror) {
+      for (; t < nstep; t++) {
+        size_t step = r*static_cast<size_t>(nstep) + t;
+        if (state) {
+          mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
         }
-        nerror = true;
-      }
-
-      // copy out new state
-      if (state) {
-        mj_getState(m[r], d, state + step*nstate, mjSTATE_FULLPHYSICS);
-      }
-
-      // copy out sensor values
-      if (sensordata) {
-        mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+        if (sensordata) {
+          mju_copy(sensordata + step*nsensordata, d->sensordata, nsensordata);
+        }
       }
     }
   }
@@ -199,34 +221,54 @@ void _unsafe_rollout_threaded(std::vector<const mjModel*>& m,
   int nfulljobs = nbatch / chunk_size;
   int chunk_remainder = nbatch % chunk_size;
   int njobs = (chunk_remainder > 0) ? nfulljobs + 1 : nfulljobs;
+  std::mutex exception_mutex;
+  std::exception_ptr task_exception;
+
+  auto run_task = [&](auto&& task) {
+    try {
+      task();
+    } catch (...) {
+      std::lock_guard<std::mutex> lock(exception_mutex);
+      if (!task_exception) {
+        task_exception = std::current_exception();
+      }
+    }
+  };
 
   // Reset the pool counter
   pool->ResetCount();
 
   // schedule all jobs of full (chunk) size
   for (int j = 0; j < nfulljobs; j++) {
-    auto task = [=, &m, &d](void) {
-      int id = pool->WorkerId();
-      _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata,
-        raise_on_error);
+    auto task = [=, &m, &d, &run_task](void) {
+      run_task([&]() {
+        int id = pool->WorkerId();
+        _unsafe_rollout(m, d[id], j*chunk_size, (j+1)*chunk_size,
+          nstep, control_spec, state0, warmstart0, control, state, sensordata,
+          raise_on_error);
+      });
     };
     pool->Schedule(task);
   }
 
   // schedule any remaining jobs of size < chunk_size
   if (chunk_remainder > 0) {
-    auto task = [=, &m, &d](void) {
-      _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
-        nfulljobs*chunk_size+chunk_remainder,
-        nstep, control_spec, state0, warmstart0, control, state, sensordata,
-        raise_on_error);
+    auto task = [=, &m, &d, &run_task](void) {
+      run_task([&]() {
+        _unsafe_rollout(m, d[pool->WorkerId()], nfulljobs*chunk_size,
+          nfulljobs*chunk_size+chunk_remainder,
+          nstep, control_spec, state0, warmstart0, control, state, sensordata,
+          raise_on_error);
+      });
     };
     pool->Schedule(task);
   }
 
   // wait for counter to increment up to number of jobs submitted by this thread
   pool->WaitCount(njobs);
+  if (task_exception) {
+    std::rethrow_exception(task_exception);
+  }
 }
 
 // NOLINTEND(whitespace/line_length)
@@ -320,6 +362,9 @@ class Rollout {
       py::gil_scoped_release no_gil;
 
       // call unsafe rollout function, multi or single threaded
+      // _unsafe_rollout installs one error interceptor per trajectory. Do not
+      // nest another interceptor here: nested TLS handlers would forward
+      // warnings back into the same handler.
       if (this->nthread_ > 0 && nbatch > 1) {
         int chunk_size_final = 1;
         if (!chunk_size.has_value()) {
@@ -327,12 +372,12 @@ class Rollout {
         } else {
           chunk_size_final = *chunk_size;
         }
-        InterceptMjErrors(_unsafe_rollout_threaded)(
+        _unsafe_rollout_threaded(
             model_ptrs, data_ptrs, nbatch, nstep, control_spec, state0_ptr,
             warmstart0_ptr, control_ptr, state_ptr, sensordata_ptr,
             this->pool_.get(), chunk_size_final, raise_on_error);
       } else {
-        InterceptMjErrors(_unsafe_rollout)(
+        _unsafe_rollout(
             model_ptrs, data_ptrs[0], 0, nbatch, nstep, control_spec,
             state0_ptr, warmstart0_ptr, control_ptr, state_ptr,
             sensordata_ptr, raise_on_error);

--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -61,6 +61,7 @@ class Rollout:
       state: Optional[npt.ArrayLike] = None,
       sensordata: Optional[npt.ArrayLike] = None,
       chunk_size: Optional[int] = None,
+      raise_on_error: bool = True,
   ):
     """Rolls out open-loop trajectories from initial states, get subsequent state and sensor values.
 
@@ -87,6 +88,8 @@ class Rollout:
         (nbatch x nstep x nsensordata)
       chunk_size: Determines threadpool chunk size. If unspecified,
                   chunk_size = max(1, nbatch / (nthread * 10))
+      raise_on_error: Whether MuJoCo errors abort rollout. If false, the
+        remainder of the failed trajectory is filled like a diverged rollout.
 
     Returns:
       state:
@@ -119,6 +122,7 @@ class Rollout:
           state,
           sensordata,
           chunk_size,
+          raise_on_error,
       )
       return state, sensordata
 
@@ -235,6 +239,7 @@ class Rollout:
         state,
         sensordata,
         chunk_size,
+        raise_on_error,
     )
 
     # return outputs
@@ -272,6 +277,7 @@ def rollout(
     sensordata: Optional[npt.ArrayLike] = None,
     chunk_size: Optional[int] = None,
     persistent_pool: bool = False,
+    raise_on_error: bool = True,
 ):
   """Rolls out open-loop trajectories from initial states, get subsequent states and sensor values.
 
@@ -299,6 +305,8 @@ def rollout(
     chunk_size: Determines threadpool chunk size. If unspecified,
                 chunk_size = max(1, nbatch / (nthread * 10))
     persistent_pool: Determines if a persistent thread pool is created or reused.
+    raise_on_error: Whether MuJoCo errors abort rollout. If false, the
+      remainder of the failed trajectory is filled like a diverged rollout.
 
   Returns:
     state:
@@ -340,6 +348,7 @@ def rollout(
         state=state,
         sensordata=sensordata,
         chunk_size=chunk_size,
+        raise_on_error=raise_on_error,
     )
   finally:
     if not persistent_pool:

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -727,6 +727,43 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     ):
       rollout.rollout(model, data, initial_state, ctrl)
 
+  @parameterized.parameters(0, 2)
+  def test_mj_errors_can_fill_remaining_trajectory(self, nthread):
+    model = mujoco.MjModel.from_xml_string(TEST_XML)
+    bad_model = copy.copy(model)
+    bad_model.opt.solver = 10  # invalid solver type
+    nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
+
+    nbatch = 2
+    nstep = 3
+    initial_state = np.zeros((nbatch, nstate))
+    ctrl = np.zeros((nbatch, nstep, model.nu))
+    data = (
+        [mujoco.MjData(model) for _ in range(nthread)]
+        if nthread
+        else mujoco.MjData(model)
+    )
+
+    state, sensordata = rollout.rollout(
+        [bad_model, model],
+        data,
+        initial_state,
+        ctrl,
+        raise_on_error=False,
+    )
+
+    expected_state, expected_sensordata = rollout.rollout(
+        model, mujoco.MjData(model), initial_state[1], ctrl[1]
+    )
+    np.testing.assert_array_equal(
+        state[0], np.tile(state[0, 0], (nstep, 1))
+    )
+    np.testing.assert_array_equal(
+        sensordata[0], np.tile(sensordata[0, 0], (nstep, 1))
+    )
+    np.testing.assert_array_equal(state[1:], expected_state)
+    np.testing.assert_array_equal(sensordata[1:], expected_sensordata)
+
   def test_invalid(self):
     model = mujoco.MjModel.from_xml_string(TEST_XML)
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -779,6 +779,32 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     np.testing.assert_array_equal(state[1:], expected_state)
     np.testing.assert_array_equal(sensordata[1:], expected_sensordata)
 
+  def test_python_callback_exception_does_not_stop_worker_thread(self):
+    model = mujoco.MjModel.from_xml_string(TEST_XML)
+    nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
+    models = [model, model]
+    data = [mujoco.MjData(model)]
+    initial_state = np.zeros((2, nstate))
+    ctrl = np.zeros((2, 1, model.nu))
+
+    def raise_from_control_callback(m, d):
+      del m, d
+      raise RuntimeError('control callback failed')
+
+    with rollout.Rollout(nthread=1) as rollout_:
+      mujoco.set_mjcb_control(raise_from_control_callback)
+      try:
+        with self.assertRaisesRegex(
+            mujoco.FatalError, 'Python exception raised'
+        ):
+          rollout_.rollout(models, data, initial_state, ctrl)
+      finally:
+        mujoco.set_mjcb_control(None)
+
+      # The pool remains usable after forwarding the worker exception.
+      state, _ = rollout_.rollout(models, data, initial_state, ctrl)
+      self.assertEqual(state.shape, (2, 1, nstate))
+
   def test_invalid(self):
     model = mujoco.MjModel.from_xml_string(TEST_XML)
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -728,14 +728,17 @@ class MuJoCoRolloutTest(parameterized.TestCase):
       rollout.rollout(model, data, initial_state, ctrl)
 
   @parameterized.parameters(0, 2)
-  def test_mj_errors_can_fill_remaining_trajectory(self, nthread):
+  def test_mj_errors_can_fill_remaining_trajectory_from_mid_rollout(
+      self, nthread
+  ):
     model = mujoco.MjModel.from_xml_string(TEST_XML)
     bad_model = copy.copy(model)
-    bad_model.opt.solver = 10  # invalid solver type
+    bad_model.opt.timestep *= 2
+    bad_timestep = bad_model.opt.timestep
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
 
     nbatch = 2
-    nstep = 3
+    nstep = 5
     initial_state = np.zeros((nbatch, nstate))
     ctrl = np.zeros((nbatch, nstep, model.nu))
     data = (
@@ -744,22 +747,34 @@ class MuJoCoRolloutTest(parameterized.TestCase):
         else mujoco.MjData(model)
     )
 
-    state, sensordata = rollout.rollout(
-        [bad_model, model],
-        data,
-        initial_state,
-        ctrl,
-        raise_on_error=False,
-    )
+    def invalidate_solver_mid_rollout(m, d):
+      if (
+          abs(m.opt.timestep - bad_timestep) < 1e-12
+          and d.time >= 2 * bad_timestep
+      ):
+        m.opt.solver = 10  # invalid solver type
+
+    mujoco.set_mjcb_control(invalidate_solver_mid_rollout)
+    try:
+      state, sensordata = rollout.rollout(
+          [bad_model, model],
+          data,
+          initial_state,
+          ctrl,
+          raise_on_error=False,
+      )
+    finally:
+      mujoco.set_mjcb_control(None)
 
     expected_state, expected_sensordata = rollout.rollout(
         model, mujoco.MjData(model), initial_state[1], ctrl[1]
     )
+    self.assertGreater(state[0, 1, 0], state[0, 0, 0])
     np.testing.assert_array_equal(
-        state[0], np.tile(state[0, 0], (nstep, 1))
+        state[0, 2:], np.tile(state[0, 1], (nstep - 2, 1))
     )
     np.testing.assert_array_equal(
-        sensordata[0], np.tile(sensordata[0, 0], (nstep, 1))
+        sensordata[0, 2:], np.tile(sensordata[0, 1], (nstep - 2, 1))
     )
     np.testing.assert_array_equal(state[1:], expected_state)
     np.testing.assert_array_equal(sensordata[1:], expected_sensordata)


### PR DESCRIPTION
## Summary
- add `raise_on_error` to rollout so existing strict error behavior remains the default
- when `raise_on_error=False`, intercept MuJoCo fatal errors during a rollout, fill the failed trajectory remainder from the current state and sensor data, and continue other batches
- document the new tolerant path and cover both single-threaded and threaded rollout behavior

Fixes #2704

## Validation
- `python3 -m py_compile python/mujoco/rollout.py python/mujoco/rollout_test.py`
- built local MuJoCo, generated the Python sdist, built and installed a wheel from this checkout
- `MUJOCO_GL=disable /tmp/mujoco-rollout-venv/bin/python -m pytest -q --pyargs mujoco.rollout_test` (`67 passed, 1 skipped`)
