### PR TITLE
Set the USD schema multiccd scene flag default to True

### DIFF
--- a/src/experimental/usd/mjcPhysics/generatedSchema.usda
+++ b/src/experimental/usd/mjcPhysics/generatedSchema.usda
@@ -138,7 +138,7 @@ class "MjcSceneAPI" (
         displayName = "Mid-Phase Collision Filtering Toggle"
         doc = "Enables mid-phase collision filtering using a static AABB bounding volume hierarchy (BVH)."
     )
-    uniform bool mjc:flag:multiccd = 0 (
+    uniform bool mjc:flag:multiccd = 1 (
         displayName = "Multiple Contact Collision Detection (CCD) Toggle"
         doc = "Enables multiple-contact collision detection for geom pairs using a general-purpose convex-convex collider."
     )
@@ -727,4 +727,3 @@ class MjcTendon "MjcTendon" (
         doc = "Radius of the cross-section area of the spatial tendon, used for rendering in MuJoCo. Parts of the tendon that wrap around geom obstacles are rendered with reduced width."
     )
 }
-

--- a/src/experimental/usd/mjcPhysics/schema.usda
+++ b/src/experimental/usd/mjcPhysics/schema.usda
@@ -493,7 +493,7 @@ class "MjcSceneAPI"
         doc = """Enables discrete-time inverse dynamics with mj_inverse for integrators other than RK4."""
     )
 
-    uniform bool mjc:flag:multiccd = False (
+    uniform bool mjc:flag:multiccd = True (
         customData = {
             string apiName = "MultiCCDFlag"
         }


### PR DESCRIPTION
`multiccd` was enabled by default for 3.8.0, but the USD schema was not updated. Ideally there should be a test to detect this mismatch.