### PR TITLE
Fix runtime site pose updates after default initialization

### DIFF
--- a/src/engine/engine_core_smooth.c
+++ b/src/engine/engine_core_smooth.c
@@ -187,6 +187,81 @@ void mj_kinematics1(const mjModel* m, mjData* d) {
 }
 
 
+static int sameframe_pos(const mjtNum pos1[3], const mjtNum pos2[3]) {
+  static const mjtNum eps = 1e-6;
+  return mju_abs(pos1[0] - pos2[0]) < eps &&
+         mju_abs(pos1[1] - pos2[1]) < eps &&
+         mju_abs(pos1[2] - pos2[2]) < eps;
+}
+
+
+static int sameframe_quat(const mjtNum quat1[4], const mjtNum quat2[4]) {
+  static const mjtNum eps = 1e-6;
+  int same_quat_minus =
+      mju_abs(quat1[0] - quat2[0]) < eps &&
+      mju_abs(quat1[1] - quat2[1]) < eps &&
+      mju_abs(quat1[2] - quat2[2]) < eps &&
+      mju_abs(quat1[3] - quat2[3]) < eps;
+  int same_quat_plus =
+      mju_abs(quat1[0] + quat2[0]) < eps &&
+      mju_abs(quat1[1] + quat2[1]) < eps &&
+      mju_abs(quat1[2] + quat2[2]) < eps &&
+      mju_abs(quat1[3] + quat2[3]) < eps;
+
+  return same_quat_minus || same_quat_plus;
+}
+
+
+static mjtByte site_sameframe(const mjModel* m, int site) {
+  static const mjtNum zero[3] = {0, 0, 0};
+  static const mjtNum identity[4] = {1, 0, 0, 0};
+
+  mjtSameFrame sameframe = m->site_sameframe[site];
+  const mjtNum* pos = m->site_pos + 3*site;
+  const mjtNum* quat = m->site_quat + 4*site;
+
+  switch (sameframe) {
+  case mjSAMEFRAME_BODY:
+    if (sameframe_pos(pos, zero) && sameframe_quat(quat, identity)) {
+      return mjSAMEFRAME_BODY;
+    }
+    if (sameframe_quat(quat, identity)) {
+      return mjSAMEFRAME_BODYROT;
+    }
+    return mjSAMEFRAME_NONE;
+
+  case mjSAMEFRAME_BODYROT:
+    return sameframe_quat(quat, identity) ? mjSAMEFRAME_BODYROT : mjSAMEFRAME_NONE;
+
+  case mjSAMEFRAME_INERTIA:
+    {
+      int body = m->site_bodyid[site];
+      const mjtNum* ipos = m->body_ipos + 3*body;
+      const mjtNum* iquat = m->body_iquat + 4*body;
+      if (sameframe_pos(pos, ipos) && sameframe_quat(quat, iquat)) {
+        return mjSAMEFRAME_INERTIA;
+      }
+      if (sameframe_quat(quat, iquat)) {
+        return mjSAMEFRAME_INERTIAROT;
+      }
+      return mjSAMEFRAME_NONE;
+    }
+
+  case mjSAMEFRAME_INERTIAROT:
+    {
+      int body = m->site_bodyid[site];
+      return sameframe_quat(quat, m->body_iquat + 4*body) ?
+             mjSAMEFRAME_INERTIAROT : mjSAMEFRAME_NONE;
+    }
+
+  case mjSAMEFRAME_NONE:
+    return mjSAMEFRAME_NONE;
+  }
+
+  return sameframe;
+}
+
+
 // forward kinematics part 2: body inertias, geoms and sites
 void mj_kinematics2(const mjModel* m, mjData* d) {
   int sleep_filter = mjENABLED(mjENBL_SLEEP) && d->nbody_awake < m->nbody;
@@ -227,7 +302,7 @@ void mj_kinematics2(const mjModel* m, mjData* d) {
 
     mj_local2Global(d, d->site_xpos+3*i, d->site_xmat+9*i,
                     m->site_pos+3*i, m->site_quat+4*i,
-                    bodyid, m->site_sameframe[i]);
+                    bodyid, site_sameframe(m, i));
   }
 }
 

--- a/test/engine/engine_core_smooth_test.cc
+++ b/test/engine/engine_core_smooth_test.cc
@@ -113,6 +113,90 @@ TEST_F(CoreSmoothTest, MjKinematicsWorldXipos) {
   mj_deleteModel(model);
 }
 
+TEST_F(CoreSmoothTest, SitePositionMutationUpdatesDefaultSiteXpos) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <site name="default_pos" size=".01" pos="0 0 0"/>
+      <site name="nondefault_pos" size=".01" pos=".01 0 0"/>
+    </worldbody>
+  </mujoco>)";
+  mjModel* model = LoadModelFromString(xml);
+  ASSERT_THAT(model, NotNull());
+  mjData* data = mj_makeData(model);
+  ASSERT_THAT(data, NotNull());
+
+  const int default_site = mj_name2id(model, mjOBJ_SITE, "default_pos");
+  const int nondefault_site = mj_name2id(model, mjOBJ_SITE, "nondefault_pos");
+  ASSERT_NE(default_site, -1);
+  ASSERT_NE(nondefault_site, -1);
+  EXPECT_EQ(model->site_sameframe[default_site], mjSAMEFRAME_BODY);
+  EXPECT_EQ(model->site_sameframe[nondefault_site], mjSAMEFRAME_BODYROT);
+
+  const mjtNum default_pos[3] = {.2, -.3, .4};
+  const mjtNum nondefault_pos[3] = {-.4, .5, -.6};
+  mju_copy3(model->site_pos + 3*default_site, default_pos);
+  mju_copy3(model->site_pos + 3*nondefault_site, nondefault_pos);
+
+  mj_forward(model, data);
+
+  EXPECT_THAT(AsVector(data->site_xpos + 3*default_site, 3),
+              Pointwise(MjNear(1e-12, 1e-12), AsVector(default_pos, 3)));
+  EXPECT_THAT(AsVector(data->site_xpos + 3*nondefault_site, 3),
+              Pointwise(MjNear(1e-12, 1e-12), AsVector(nondefault_pos, 3)));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+TEST_F(CoreSmoothTest, SiteQuatMutationUpdatesDefaultSiteXmat) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <site name="default_quat" size=".01" pos=".01 0 0" quat="1 0 0 0"/>
+      <site name="nondefault_quat" size=".01" pos=".01 0 0"
+            quat=".7071067811865476 0 .7071067811865476 0"/>
+    </worldbody>
+  </mujoco>)";
+  mjModel* model = LoadModelFromString(xml);
+  ASSERT_THAT(model, NotNull());
+  mjData* data = mj_makeData(model);
+  ASSERT_THAT(data, NotNull());
+
+  const int default_site = mj_name2id(model, mjOBJ_SITE, "default_quat");
+  const int nondefault_site = mj_name2id(model, mjOBJ_SITE, "nondefault_quat");
+  ASSERT_NE(default_site, -1);
+  ASSERT_NE(nondefault_site, -1);
+  EXPECT_EQ(model->site_sameframe[default_site], mjSAMEFRAME_BODYROT);
+  EXPECT_EQ(model->site_sameframe[nondefault_site], mjSAMEFRAME_NONE);
+
+  const mjtNum default_quat[4] = {
+    .9238795325112867, .3826834323650898, 0, 0
+  };
+  const mjtNum nondefault_quat[4] = {
+    .8660254037844386, 0, 0, .5
+  };
+  mju_copy4(model->site_quat + 4*default_site, default_quat);
+  mju_copy4(model->site_quat + 4*nondefault_site, nondefault_quat);
+
+  mj_forward(model, data);
+
+  mjtNum expected_default_xmat[9];
+  mjtNum expected_nondefault_xmat[9];
+  mju_quat2Mat(expected_default_xmat, default_quat);
+  mju_quat2Mat(expected_nondefault_xmat, nondefault_quat);
+
+  EXPECT_THAT(AsVector(data->site_xmat + 9*default_site, 9),
+              Pointwise(MjNear(1e-12, 1e-12),
+                        AsVector(expected_default_xmat, 9)));
+  EXPECT_THAT(AsVector(data->site_xmat + 9*nondefault_site, 9),
+              Pointwise(MjNear(1e-12, 1e-12),
+                        AsVector(expected_nondefault_xmat, 9)));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
 // ----------------------------- mj_tendon -------------------------------------
 
 TEST_F(CoreSmoothTest, FixedTendonSortedIndices) {


### PR DESCRIPTION
Fixes #3029.

## Summary

Fixes runtime site pose updates when a site was initialized with a default position and/or identity quaternion.

## Problem

Sites initialized with default pose values can be compiled with `site_sameframe` shortcuts such as `mjSAMEFRAME_BODY` or `mjSAMEFRAME_BODYROT`.

After users mutate `model->site_pos` or `model->site_quat` at runtime and call `mj_forward`, those compiled shortcuts can remain active. As a result, `mj_local2Global` may skip the current local site position or quaternion, causing `data->site_xpos` / `data->site_xmat` not to reflect the mutated model fields.

This made behavior depend on the site's initial XML pose: non-default-initialized sites updated as expected, while default-initialized sites could appear static.

## Fix

`mj_kinematics2` now revalidates site same-frame shortcuts against the current site pose before calling `mj_local2Global`.

The change is limited to site transform computation and preserves valid shortcuts where possible, including downgrading shortcuts when only part of the shortcut remains valid.

## Tests

Added C++ regression coverage:

- `CoreSmoothTest.SitePositionMutationUpdatesDefaultSiteXpos`
- `CoreSmoothTest.SiteQuatMutationUpdatesDefaultSiteXmat`

These tests failed before the fix and pass after it.

`ctest --test-dir build-gcc15 -R '^CoreSmoothTest\.' --output-on-failure`