### PR TITLE
Improve Filament Studio source builds

### DIFF
--- a/cmake/third_party_deps/dear_imgui/CMakeLists.txt
+++ b/cmake/third_party_deps/dear_imgui/CMakeLists.txt
@@ -13,61 +13,65 @@
 # limitations under the License.
 
 add_library(dear_imgui STATIC)
+set(MUJOCO_DEAR_IMGUI_SOURCE_DIR "${dear_imgui_SOURCE_DIR}" CACHE INTERNAL "")
 target_include_directories(dear_imgui
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}
 )
 target_sources(dear_imgui
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}/imgui.h
-    ${dear_imgui_SOURCE_DIR}/imgui.cpp
-    ${dear_imgui_SOURCE_DIR}/imgui_internal.h
-    ${dear_imgui_SOURCE_DIR}/imgui_draw.cpp
-    ${dear_imgui_SOURCE_DIR}/imgui_tables.cpp
-    ${dear_imgui_SOURCE_DIR}/imgui_widgets.cpp
-    ${dear_imgui_SOURCE_DIR}/imgui_demo.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui.h
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui_internal.h
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui_draw.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui_tables.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui_widgets.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/imgui_demo.cpp
 )
 
-# SDL2 backend
-# TODO: I don't know how to correctly check for dependencies in cmake. This
-# assumes that SDL2 is pulled in _before_ dear_imgui, but that seems fragile.
-# For now, we'll just assume SDL2 is available as dear_imgui is only being used
-# in contexts which depend on SDL2.
-#if(TARGET SDL2)
+function(mujoco_add_dear_imgui_sdl2_backend)
+  if(TARGET dear_imgui_SDL2 OR NOT TARGET SDL2::SDL2-static)
+    return()
+  endif()
+
   add_library(dear_imgui_SDL2 STATIC)
   target_include_directories(dear_imgui_SDL2
     PUBLIC
-      ${dear_imgui_SOURCE_DIR}
+      ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}
   )
   target_sources(dear_imgui_SDL2
     PUBLIC
-      ${dear_imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+      ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
   )
   target_link_libraries(dear_imgui_SDL2
     SDL2::SDL2-static
   )
-#endif()
+endfunction()
+
+# SDL2 backend. Filament uses base dear_imgui without SDL2; platform calls this
+# helper again after SDL2 is pulled in.
+mujoco_add_dear_imgui_sdl2_backend()
 
 # OpenGL3 backend
 add_library(dear_imgui_OpenGL3 STATIC)
 target_include_directories(dear_imgui_OpenGL3
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}
 )
 target_sources(dear_imgui_OpenGL3
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.h
-    ${dear_imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/backends/imgui_impl_opengl3.h
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
 )
 
 # stdlib
 add_library(dear_imgui_stdlib STATIC)
 target_include_directories(dear_imgui_stdlib
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}
 )
 target_sources(dear_imgui_stdlib
   PUBLIC
-    ${dear_imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.h
-    ${dear_imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/misc/cpp/imgui_stdlib.h
+    ${MUJOCO_DEAR_IMGUI_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
 )

--- a/cmake/third_party_deps/filament.cmake
+++ b/cmake/third_party_deps/filament.cmake
@@ -51,12 +51,32 @@ set(FILAMENT_PATCH_COMMAND
   git apply --reject --whitespace=fix ${mujoco_SOURCE_DIR}/cmake/filament-allow-clang-windows.patch
 )
 
+# MuJoCo fetches Abseil before Filament is configured. Filament's
+# FILAMENT_USE_EXTERNAL_ABSL path calls find_package(absl), which can otherwise
+# discover an unrelated package-manager Abseil config and collide with the
+# targets already created by MuJoCo's fetched Abseil.
+if(DEFINED CMAKE_DISABLE_FIND_PACKAGE_absl)
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED TRUE)
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD "${CMAKE_DISABLE_FIND_PACKAGE_absl}")
+else()
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED FALSE)
+endif()
+set(CMAKE_DISABLE_FIND_PACKAGE_absl TRUE)
+
 fetchpackage(
     PACKAGE_NAME  filament
     GIT_REPO      https://github.com/google/filament.git
     GIT_TAG       ${MUJOCO_DEP_VERSION_filament}
     PATCH_COMMAND ${FILAMENT_PATCH_COMMAND}
 )
+
+if(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED)
+    set(CMAKE_DISABLE_FIND_PACKAGE_absl "${MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD}")
+else()
+    unset(CMAKE_DISABLE_FIND_PACKAGE_absl)
+endif()
+unset(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED)
+unset(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD)
 
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_OLD}")

--- a/src/experimental/platform/CMakeLists.txt
+++ b/src/experimental/platform/CMakeLists.txt
@@ -94,9 +94,10 @@ target_include_directories(${MUJOCO_PLATFORM_TARGET_NAME}
         ${PROJECT_SOURCE_DIR}/src
 )
 
-include(third_party_deps/dear_imgui)
-include(third_party_deps/implot)
 include(third_party_deps/sdl2)
+include(third_party_deps/dear_imgui)
+mujoco_add_dear_imgui_sdl2_backend()
+include(third_party_deps/implot)
 include(third_party_deps/libwebp)
 
 target_link_libraries(${MUJOCO_PLATFORM_TARGET_NAME}

--- a/src/experimental/studio/README.md
+++ b/src/experimental/studio/README.md
@@ -17,6 +17,47 @@ bash build.sh
 > [!NOTE]
 > For now [`build.sh`](build.sh) script works on windows in a git bash shell.
 
+To keep Studio build artifacts separate from other MuJoCo builds, you can also
+configure an isolated build directory manually:
+
+```
+cmake -B build-studio \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_STATIC_LIBCXX=OFF \
+  -DBUILD_SHARED_LIB=OFF \
+  -DMUJOCO_USE_FILAMENT=ON \
+  -DMUJOCO_BUILD_EXAMPLES=OFF \
+  -DMUJOCO_BUILD_SIMULATE=OFF \
+  -DMUJOCO_BUILD_TESTS=OFF \
+  -DMUJOCO_TEST_PYTHON_UTIL=OFF \
+  -DMUJOCO_WITH_USD=OFF \
+  -DMUJOCO_BUILD_STUDIO=ON \
+  -DFILAMENT_SKIP_SAMPLES=ON \
+  -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations \
+  -DFILAMENT_SHORTEN_MSVC_COMPILATION=OFF
+cmake --build build-studio --config Release --target mujoco_studio --parallel
+```
+
+Run `mujoco_studio` from the build output directory so it can find the copied
+font and Filament assets:
+
+```
+cd build-studio/bin
+./mujoco_studio --gfx=opengl
+```
+
+On macOS, Studio defaults to Filament OpenGL. The OpenGL implementation may be
+provided by Apple's Metal-backed OpenGL layer, so runtime logs can mention both
+OpenGL and Metal/Apple GPU details.
+
+### Troubleshooting
+
+If configure fails while resolving Filament dependencies, check whether CMake is
+finding package-manager CMake configs from environments such as Anaconda. In
+particular, an unrelated `abslConfig.cmake` can conflict with MuJoCo's fetched
+Abseil targets. Remove that prefix from `CMAKE_PREFIX_PATH`, or configure with
+`CMAKE_IGNORE_PREFIX_PATH` pointing at the conflicting environment prefix.
+
 ## Development
 
 The [`build.sh`](build.sh) script is intended to get you up and running quickly.


### PR DESCRIPTION
## Summary

This draft improves the experimental Studio + Filament source-build path in two ways:

- prevents Filament's Abseil lookup from discovering unrelated package-manager CMake configs after MuJoCo has already fetched Abseil
- documents a minimal isolated Studio build/run flow, including macOS runtime expectations and troubleshooting for conflicting CMake package prefixes

## Motivation

While validating `mujoco_studio` with `MUJOCO_USE_FILAMENT=ON`, configure can fail on machines with ambient package-manager CMake configs, for example an Anaconda-provided `abslConfig.cmake`. Filament's `FILAMENT_USE_EXTERNAL_ABSL` path calls `find_package(absl)`, which can collide with the Abseil targets already created by MuJoCo's fetched dependency.

This keeps the Filament fetch isolated from unrelated Abseil package configs, while preserving any pre-existing `CMAKE_DISABLE_FIND_PACKAGE_absl` value after Filament is configured.

## Validation

- `git diff --check`
- fresh CMake configure of Studio + Filament without manually passing `-DCMAKE_DISABLE_FIND_PACKAGE_absl=TRUE`
- `cmake --build build-studio-filament-eval --target mujoco_studio --parallel $(sysctl -n hw.logicalcpu)`
- local runtime smoke test:
  - `./mujoco_studio --gfx=opengl --model_file=/tmp/mujoco_go2_demo/unitree_go2/scene_filament_open_assets_showcase.xml`
  - runtime log: `FEngine resolved backend: OpenGL`
  - platform log: Apple M3 Pro, OpenGL reported through Apple's Metal-backed OpenGL layer

Screenshot from the local smoke test:

![MuJoCo Studio Filament Go2 smoke test](https://gist.githubusercontent.com/devshahofficial/fdf87a447094ddcabe3f4ace72d08927/raw/ca9e18c78f25a18adee4c738fda1676fad7af9c4/mujoco-studio-go2-filament-open-assets.svg)

## Related context

Tagging a few people from the surrounding Filament/Studio discussion for visibility:

- @yuvaltassa noted in issue #2487 that Studio is close to ready from `src/experimental/studio/`: https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4341872871. This PR is a small source-build/doc cleanup around that path.
- @BlGene and @wpumacay have related downstream wheel/runtime requirements from the AllenAI/MolmoSpaces work: https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4302133553, https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4354613171, and https://github.com/allenai/mujoco/tree/molmospaces.
- @julien-blanchon has related prior work around Filament builds, wheel asset staging, and runtime asset lookup: https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4304461344 and https://github.com/julien-blanchon/mujoco/tree/exp-filament-build.

## Notes

The Go2 / Filament sample-asset scene used for the runtime smoke test is local-only and not included in this PR.
