### PR TITLE
ui: fix SELECT dropdown to use click-to-open model

### DIFF
--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -2523,6 +2523,23 @@ mjuiItem* mjui_event(mjUI* ui, mjuiState* state, const mjrContext* con) {
       mjui_update(sect_edit-1, item_edit, ui, state, con);
     }
 
+    // if a SELECT dropdown was open, handle click-to-select before resetting focus
+    if (sect_rec > 0 && it_rec && it_rec->type == mjITEM_SELECT) {
+      int sel = findselect(it_rec, ui, state, con);
+      if (sel >= 0) {
+        // cursor is over an option: select it, close dropdown
+        *(int*)it_rec->pdata = sel;
+        ui->mousesect = 0;
+        mjui_update(-1, -1, ui, state, con);
+        return it_rec;
+      } else if (sect_cur == sect_rec && item_cur == item_rec) {
+        // cursor is on the same dropdown header: toggle closed
+        ui->mousesect = 0;
+        mjui_update(-1, -1, ui, state, con);
+        return ui->editchanged;
+      }
+    }
+
     // free mouse focus, just in case
     ui->mousesect = 0;
 
@@ -2695,17 +2712,15 @@ mjuiItem* mjui_event(mjUI* ui, mjuiState* state, const mjrContext* con) {
       // find and set value
       i = findselect(it_rec, ui, state, con);
       if (i >= 0) {
+        // option selected: set value, close dropdown
         *(int*)it_rec->pdata = i;
-      }
-
-      // free mouse and redraw ALL (selection box spills over)
-      ui->mousesect = 0;
-      mjui_update(-1, -1, ui, state, con);
-
-      // return if value set change
-      if (i >= 0) {
+        ui->mousesect = 0;
+        mjui_update(-1, -1, ui, state, con);
         return it_rec;
       }
+
+      // no option under cursor (quick click): keep dropdown open for next click
+      return NULL;
     }
 
     // button release


### PR DESCRIPTION
## Problem

The `mjITEM_SELECT` widget uses a press-and-hold drag-to-select model: the dropdown is visible only while the mouse button is held, and the release event selects whichever option is under the cursor at that moment.

On platforms where GLFW fires `PRESS` and `RELEASE` in rapid succession — most notably **WSL/WSLg** on Windows — the dropdown opens and closes in the same frame, making it impossible to select any option. The widget appears to do nothing when clicked.

## Fix

Changes `mjITEM_SELECT` to a **click-to-open / click-to-select** model while preserving full backward compatibility with the drag-to-select workflow:

**In the `PRESS` handler** (before the global `mousesect = 0` reset):
- If a SELECT dropdown is already open and the cursor is over one of its options → select that option and close (enables click-on-option selection)
- If the cursor is back on the same header → toggle closed

**In the `RELEASE` handler**:
- If an option is under the cursor → select and close (unchanged)
- If no option is under the cursor (quick click on header) → **keep the dropdown open** rather than closing it

The original drag behaviour is fully preserved: pressing, dragging the cursor onto an option, and releasing still selects that option immediately via the `RELEASE` path.

## Testing

Verified on WSL2 (Ubuntu 24.04 / WSLg) running MuJoCo via [mujoco_mpc](https://github.com/google-deepmind/mujoco_mpc). All SELECT dropdowns (task, planner, integrator, solver, etc.) now respond correctly to single clicks.