### PR TITLE
Prototype Filament package assets and renderer API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ if(EMSCRIPTEN)
   endif()
 endif()
 
+if(MUJOCO_USE_FILAMENT_MJR_COMPAT AND NOT MUJOCO_USE_FILAMENT)
+  message(
+    FATAL_ERROR
+      "MUJOCO_USE_FILAMENT_MJR_COMPAT requires MUJOCO_USE_FILAMENT=ON"
+  )
+endif()
+
 if(APPLE AND (MUJOCO_BUILD_EXAMPLES OR MUJOCO_BUILD_SIMULATE))
   enable_language(OBJC)
   enable_language(OBJCXX)
@@ -202,6 +209,30 @@ target_link_libraries(
           tinyobjloader
           tinyxml2
 )
+
+if(MUJOCO_USE_FILAMENT_MJR_COMPAT)
+  add_dependencies(mujoco mujoco_filament mujoco_filament_mjr_compat)
+  target_sources(mujoco PRIVATE $<TARGET_OBJECTS:mujoco_filament_mjr_compat>)
+  if(APPLE)
+    target_link_libraries(
+      mujoco
+      PRIVATE "-Wl,-force_load,$<TARGET_FILE:mujoco_filament>"
+              mujoco::filament
+    )
+  elseif(MSVC)
+    target_link_libraries(mujoco PRIVATE mujoco::filament)
+    target_link_options(
+      mujoco PRIVATE "/WHOLEARCHIVE:$<TARGET_FILE:mujoco_filament>"
+    )
+  else()
+    target_link_libraries(
+      mujoco
+      PRIVATE "-Wl,--whole-archive"
+              mujoco_filament
+              "-Wl,--no-whole-archive"
+    )
+  endif()
+endif()
 
 set_target_properties(
   mujoco PROPERTIES VERSION "${mujoco_VERSION}" PUBLIC_HEADER "${MUJOCO_HEADERS}"

--- a/cmake/third_party_deps/filament.cmake
+++ b/cmake/third_party_deps/filament.cmake
@@ -41,11 +41,31 @@ if(WIN32)
     set(USE_STATIC_CRT OFF)
 endif()
 
+# MuJoCo fetches Abseil before Filament is configured. Filament's
+# FILAMENT_USE_EXTERNAL_ABSL path calls find_package(absl), which can otherwise
+# discover an unrelated package-manager Abseil config and collide with the
+# targets already created by MuJoCo's fetched Abseil.
+if(DEFINED CMAKE_DISABLE_FIND_PACKAGE_absl)
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED TRUE)
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD "${CMAKE_DISABLE_FIND_PACKAGE_absl}")
+else()
+    set(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED FALSE)
+endif()
+set(CMAKE_DISABLE_FIND_PACKAGE_absl TRUE)
+
 fetchpackage(
     PACKAGE_NAME  filament
     GIT_REPO      https://github.com/google/filament.git
     GIT_TAG       ${MUJOCO_DEP_VERSION_filament}
 )
+
+if(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED)
+    set(CMAKE_DISABLE_FIND_PACKAGE_absl "${MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD}")
+else()
+    unset(CMAKE_DISABLE_FIND_PACKAGE_absl)
+endif()
+unset(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_WAS_DEFINED)
+unset(MUJOCO_CMAKE_DISABLE_FIND_PACKAGE_ABSL_OLD)
 
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_OLD}")

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -850,6 +850,9 @@ MJAPI void mjv_cameraFrustum(float zver[2], float zhor[2], float zclip[2],  cons
 
 //---------------------------------- OpenGL rendering ----------------------------------------------
 
+// Return name of the active renderer implementation backing the mjr API.
+MJAPI const char* mjr_getRenderer(void);
+
 // Set default mjrContext.
 MJAPI void mjr_defaultContext(mjrContext* con);
 

--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -485,6 +485,18 @@ if(APPLE)
 endif()
 
 if(MUJOCO_PYTHON_MAKE_WHEEL)
+  set(WHEEL_FILAMENT_COMMANDS "")
+  if(MUJOCO_USE_FILAMENT AND DEFINED MUJOCO_FILAMENT_ASSETS_DIR)
+    set(FILAMENT_ASSETS_FOR_WHEEL "${CMAKE_CURRENT_BINARY_DIR}/dist/mujoco/assets")
+    list(
+      APPEND
+      WHEEL_FILAMENT_COMMANDS
+      COMMAND "${CMAKE_COMMAND}" -E make_directory "${FILAMENT_ASSETS_FOR_WHEEL}"
+      COMMAND "${CMAKE_COMMAND}" -E copy_directory "${MUJOCO_FILAMENT_ASSETS_DIR}"
+              "${FILAMENT_ASSETS_FOR_WHEEL}"
+    )
+  endif()
+
   add_custom_target(
     wheel ALL
     COMMAND "${CMAKE_COMMAND}" -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/dist"
@@ -494,6 +506,7 @@ if(MUJOCO_PYTHON_MAKE_WHEEL)
             "${CMAKE_CURRENT_BINARY_DIR}/dist/LICENSE"
     COMMAND "${CMAKE_COMMAND}" -E copy ${LIBRARIES_FOR_WHEEL}
             "${CMAKE_CURRENT_BINARY_DIR}/dist/mujoco"
+    ${WHEEL_FILAMENT_COMMANDS}
     COMMAND "${Python3_EXECUTABLE}" -m pip wheel --wheel-dir "${CMAKE_BINARY_DIR}" --no-deps -vvv
             "${CMAKE_CURRENT_BINARY_DIR}/dist"
   )
@@ -512,6 +525,9 @@ if(MUJOCO_PYTHON_MAKE_WHEEL)
     _structs
     mujoco
   )
+  if(TARGET mujoco_filament_assets)
+    add_dependencies(wheel mujoco_filament_assets)
+  endif()
   if(APPLE)
     add_dependencies(wheel mjpython)
   endif()

--- a/python/mujoco/bindings_test.py
+++ b/python/mujoco/bindings_test.py
@@ -160,6 +160,9 @@ class MuJoCoBindingsTest(parameterized.TestCase):
         [[0, 0, 0], [0, 0, 0.1], [0, 0, 0], [0, 0, 0], [42.0, 0, 42.0]],
     )
 
+  def test_renderer_constant(self):
+    self.assertIn(mujoco.mjRENDERER, ('classic', 'filament', 'noop'))
+
   def test_can_set_array(self):
     self.data.qpos = 0.12345
     np.testing.assert_array_equal(

--- a/python/mujoco/constants.cc
+++ b/python/mujoco/constants.cc
@@ -94,6 +94,7 @@ PYBIND11_MODULE(_constants, pymodule) {
   pymodule.attr("mjFRAMESTRING") = MakeTuple(mjFRAMESTRING);
   pymodule.attr("mjVISSTRING") = MakeTuple(mjVISSTRING);
   pymodule.attr("mjRNDSTRING") = MakeTuple(mjRNDSTRING);
+  pymodule.attr("mjRENDERER") = py::str(mjr_getRenderer());
 }
 }  // namespace
 }  // namespace mujoco::python

--- a/python/mujoco/renderer_test.py
+++ b/python/mujoco/renderer_test.py
@@ -16,11 +16,37 @@
 
 import gc
 import sys
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
 import mujoco
+from mujoco.rendering.classic import gl_context
+from mujoco.rendering.classic import renderer as renderer_module
 import numpy as np
+
+
+class MuJoCoRendererNoGLContextTest(absltest.TestCase):
+
+  def test_renderer_allows_missing_gl_context_symbol(self):
+    xml = '<mujoco><worldbody/></mujoco>'
+    model = mujoco.MjModel.from_xml_string(xml)
+    had_gl_context = hasattr(gl_context, 'GLContext')
+    original_gl_context = getattr(gl_context, 'GLContext', None)
+    fake_mjr_context = mock.Mock()
+
+    try:
+      if had_gl_context:
+        delattr(gl_context, 'GLContext')
+      with mock.patch.object(renderer_module, 'GLContext', None):
+        with mock.patch.object(renderer_module.mujoco, 'MjrContext',
+                               return_value=fake_mjr_context):
+          with mock.patch.object(renderer_module.mujoco, 'mjr_setBuffer'):
+            renderer = renderer_module.Renderer(model, 50, 50)
+            self.assertIsNone(renderer._gl_context)  # pylint: disable=protected-access
+    finally:
+      if had_gl_context:
+        gl_context.GLContext = original_gl_context
 
 
 @absltest.skipUnless(

--- a/python/mujoco/rendering/classic/renderer.py
+++ b/python/mujoco/rendering/classic/renderer.py
@@ -84,9 +84,8 @@ the clause:
     self._rect = mujoco.MjrRect(0, 0, self._width, self._height)
 
     # Create render contexts.
-    # TODO(nimrod): Figure out why pytype doesn't like gl_context.GLContext
-    if gl_context.GLContext is not None:
-      self._gl_context = gl_context.GLContext(width, height)  # type: ignore
+    if GLContext is not None:
+      self._gl_context = GLContext(width, height)
     if self._gl_context:
       self._gl_context.make_current()
     self._mjr_context = mujoco.MjrContext(model, font_scale.value)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,6 +54,8 @@ mujoco = [
     "libmujoco.*.dylib",
     "libmujoco*.so.*",
     "mujoco.dll",
+    "assets/*.filamat",
+    "assets/*.ktx",
     "include/mujoco/*.h",
     "testdata/*.xml",
     "testdata/*.msh",

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,7 +79,7 @@ def get_plugin_lib_patterns():
   elif platform.system() == 'Darwin':
     return ['lib*.dylib']
   else:
-    return ['lib*']
+    return ['lib*.so*']
 
 
 def start_and_end(iterable):

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ MUJOCO_CMAKE = 'MUJOCO_CMAKE'
 MUJOCO_CMAKE_ARGS = 'MUJOCO_CMAKE_ARGS'
 MUJOCO_PATH = 'MUJOCO_PATH'
 MUJOCO_PLUGIN_PATH = 'MUJOCO_PLUGIN_PATH'
+MUJOCO_ASSETS_DIR = 'MUJOCO_ASSETS_DIR'
 MUJOCO_FILAMENT_ASSETS_DIR = 'MUJOCO_FILAMENT_ASSETS_DIR'
 FILAMENT_ASSET_PATTERNS = ('*.filamat', '*.ktx')
 FILAMENT_SENTINEL_ASSET = 'pbr.filamat'
@@ -204,14 +205,15 @@ class BuildCMakeExtension(build_ext.build_ext):
           )
 
   def _find_filament_assets_dir(self):
-    explicit_dir = os.environ.get(MUJOCO_FILAMENT_ASSETS_DIR)
-    if explicit_dir:
-      if os.path.isfile(os.path.join(explicit_dir, FILAMENT_SENTINEL_ASSET)):
-        return explicit_dir
-      raise RuntimeError(
-          f'{MUJOCO_FILAMENT_ASSETS_DIR} does not contain '
-          f'{FILAMENT_SENTINEL_ASSET}: {explicit_dir}'
-      )
+    for env_var in (MUJOCO_ASSETS_DIR, MUJOCO_FILAMENT_ASSETS_DIR):
+      explicit_dir = os.environ.get(env_var)
+      if explicit_dir:
+        if os.path.isfile(os.path.join(explicit_dir, FILAMENT_SENTINEL_ASSET)):
+          return explicit_dir
+        raise RuntimeError(
+            f'{env_var} does not contain '
+            f'{FILAMENT_SENTINEL_ASSET}: {explicit_dir}'
+        )
 
     candidate_dirs = []
     mujoco_path = os.environ.get(MUJOCO_PATH)

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@
 import fnmatch
 import logging
 import os
+import pathlib
 import platform
 import random
 import re
@@ -34,6 +35,9 @@ MUJOCO_CMAKE = 'MUJOCO_CMAKE'
 MUJOCO_CMAKE_ARGS = 'MUJOCO_CMAKE_ARGS'
 MUJOCO_PATH = 'MUJOCO_PATH'
 MUJOCO_PLUGIN_PATH = 'MUJOCO_PLUGIN_PATH'
+MUJOCO_FILAMENT_ASSETS_DIR = 'MUJOCO_FILAMENT_ASSETS_DIR'
+FILAMENT_ASSET_PATTERNS = ('*.filamat', '*.ktx')
+FILAMENT_SENTINEL_ASSET = 'pbr.filamat'
 
 EXT_PREFIX = 'mujoco.'
 
@@ -158,6 +162,7 @@ class BuildCMakeExtension(build_ext.build_ext):
       assert '.' not in ext.name[len(EXT_PREFIX) :]
       self.build_extension(ext)
     self._copy_external_libraries()
+    self._copy_filament_assets()
     self._copy_mujoco_headers()
     self._copy_plugin_libraries()
     if self._is_apple:
@@ -197,6 +202,60 @@ class BuildCMakeExtension(build_ext.build_ext):
           shutil.copyfile(
               os.path.join(directory, filename), os.path.join(dst, filename)
           )
+
+  def _find_filament_assets_dir(self):
+    explicit_dir = os.environ.get(MUJOCO_FILAMENT_ASSETS_DIR)
+    if explicit_dir:
+      if os.path.isfile(os.path.join(explicit_dir, FILAMENT_SENTINEL_ASSET)):
+        return explicit_dir
+      raise RuntimeError(
+          f'{MUJOCO_FILAMENT_ASSETS_DIR} does not contain '
+          f'{FILAMENT_SENTINEL_ASSET}: {explicit_dir}'
+      )
+
+    candidate_dirs = []
+    mujoco_path = os.environ.get(MUJOCO_PATH)
+    if mujoco_path:
+      candidate_dirs.extend([
+          os.path.join(mujoco_path, 'lib', 'assets'),
+          os.path.join(mujoco_path, 'bin', 'assets'),
+          os.path.join(mujoco_path, 'assets'),
+      ])
+
+    for directory, _, filenames in os.walk(self.build_temp):
+      if FILAMENT_SENTINEL_ASSET in filenames:
+        candidate_dirs.append(directory)
+
+    seen = set()
+    for directory in candidate_dirs:
+      directory = os.path.normpath(directory)
+      if directory in seen or not os.path.isdir(directory):
+        continue
+      seen.add(directory)
+      if os.path.isfile(os.path.join(directory, FILAMENT_SENTINEL_ASSET)):
+        return directory
+
+    if mujoco_path:
+      for directory, _, filenames in os.walk(mujoco_path):
+        if FILAMENT_SENTINEL_ASSET in filenames:
+          return directory
+
+    return None
+
+  def _copy_filament_assets(self):
+    filament_assets_dir = self._find_filament_assets_dir()
+    if filament_assets_dir is None:
+      return
+
+    dst = os.path.join(
+        os.path.dirname(self.get_ext_fullpath(self.extensions[0].name)),
+        'assets',
+    )
+    os.makedirs(dst, exist_ok=True)
+    for pattern in FILAMENT_ASSET_PATTERNS:
+      for asset in pathlib.Path(filament_assets_dir).glob(pattern):
+        if asset.is_file():
+          shutil.copyfile(asset, os.path.join(dst, asset.name))
 
   def _copy_plugin_libraries(self):
     dst = os.path.join(

--- a/src/experimental/filament/CMakeLists.txt
+++ b/src/experimental/filament/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(${MUJOCO_FILAMENT_TARGET_NAME} STATIC)
 target_compile_definitions(${MUJOCO_FILAMENT_TARGET_NAME} PRIVATE MJ_STATIC)
 
 target_sources(${MUJOCO_FILAMENT_TARGET_NAME}
-    PUBLIC
+    PRIVATE
         render_context_filament.h
         render_context_filament.cc
         render_context_filament_cpp.h
@@ -60,27 +60,38 @@ target_sources(${MUJOCO_FILAMENT_TARGET_NAME}
         compat/scene_geom_util.cc
         compat/scene_geom_util.h
 )
-if(MUJOCO_USE_FILAMENT_MJR_COMPAT)
-    target_sources(${MUJOCO_FILAMENT_TARGET_NAME}
-        PUBLIC
-            mjr_compat.cc
-    )
-endif()
-
 target_include_directories(${MUJOCO_FILAMENT_TARGET_NAME}
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/src
 )
 
+if(MUJOCO_USE_FILAMENT_MJR_COMPAT)
+    add_library(mujoco_filament_mjr_compat OBJECT mjr_compat.cc)
+    target_compile_definitions(mujoco_filament_mjr_compat PRIVATE MUJOCO_DLL_EXPORTS)
+    target_include_directories(mujoco_filament_mjr_compat
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src
+    )
+endif()
+
+# dear_imgui's local CMake creates its SDL2 backend target unconditionally.
+# Studio pulls SDL2 through the platform layer, but the standalone Filament/MJR
+# path needs to define SDL2 here.
+include(third_party_deps/sdl2)
 include(third_party_deps/dear_imgui)
 include(third_party_deps/filament)
 target_link_libraries(${MUJOCO_FILAMENT_TARGET_NAME}
-    dear_imgui
-    filament
-    image       # provided by filament
-    ktxreader   # provided by filament
+    PRIVATE
+        dear_imgui
+        filament
+        image       # provided by filament
+        ktxreader   # provided by filament
 )
+if(CMAKE_DL_LIBS)
+    target_link_libraries(${MUJOCO_FILAMENT_TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS})
+endif()
 
 add_library(mujoco::filament ALIAS ${MUJOCO_FILAMENT_TARGET_NAME})
 
@@ -161,4 +172,15 @@ list(APPEND MUJOCO_FILAMENT_ASSET_FILES "${OUTPUT_ASSETS_DIR}/ibl.ktx")
 add_custom_target(mujoco_filament_assets DEPENDS ${MUJOCO_FILAMENT_ASSET_FILES})
 add_dependencies(${MUJOCO_FILAMENT_TARGET_NAME} mujoco_filament_assets)
 
-set(MUJOCO_FILAMENT_ASSETS_DIR ${OUTPUT_ASSETS_DIR})
+set(MUJOCO_FILAMENT_ASSETS_DIR
+    ${OUTPUT_ASSETS_DIR}
+    CACHE PATH "Directory containing generated MuJoCo Filament runtime assets."
+)
+
+install(
+    DIRECTORY "${OUTPUT_ASSETS_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/assets"
+    FILES_MATCHING
+    PATTERN "*.filamat"
+    PATTERN "*.ktx"
+)

--- a/src/experimental/filament/assets/pbr.mat
+++ b/src/experimental/filament/assets/pbr.mat
@@ -25,7 +25,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
 
     ],
     requires : [
@@ -48,6 +49,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_Metallic, uv).r;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/experimental/filament/assets/pbr_packed.mat
+++ b/src/experimental/filament/assets/pbr_packed.mat
@@ -23,7 +23,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
     ],
     requires : [
         uv0
@@ -45,6 +46,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_ORM, uv).b;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/experimental/filament/assets/phong_2d.mat
+++ b/src/experimental/filament/assets/phong_2d.mat
@@ -45,6 +45,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_2d_fade.mat
+++ b/src/experimental/filament/assets/phong_2d_fade.mat
@@ -46,6 +46,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_2d_reflect.mat
+++ b/src/experimental/filament/assets/phong_2d_reflect.mat
@@ -48,7 +48,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/experimental/filament/assets/phong_2d_uv.mat
+++ b/src/experimental/filament/assets/phong_2d_uv.mat
@@ -37,6 +37,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_2d_uv_fade.mat
+++ b/src/experimental/filament/assets/phong_2d_uv_fade.mat
@@ -38,6 +38,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_2d_uv_reflect.mat
+++ b/src/experimental/filament/assets/phong_2d_uv_reflect.mat
@@ -40,7 +40,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/experimental/filament/assets/phong_color.mat
+++ b/src/experimental/filament/assets/phong_color.mat
@@ -29,6 +29,7 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_color_fade.mat
+++ b/src/experimental/filament/assets/phong_color_fade.mat
@@ -30,6 +30,7 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_color_reflect.mat
+++ b/src/experimental/filament/assets/phong_color_reflect.mat
@@ -33,7 +33,8 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/experimental/filament/assets/phong_cube.mat
+++ b/src/experimental/filament/assets/phong_cube.mat
@@ -44,6 +44,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_cube_fade.mat
+++ b/src/experimental/filament/assets/phong_cube_fade.mat
@@ -45,6 +45,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/experimental/filament/assets/phong_cube_reflect.mat
+++ b/src/experimental/filament/assets/phong_cube_reflect.mat
@@ -47,7 +47,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/experimental/filament/filament/material.cc
+++ b/src/experimental/filament/filament/material.cc
@@ -134,7 +134,11 @@ void UpdateMaterialInstance(filament::MaterialInstance* instance,
                            color);
   }
   if (fmaterial->hasParameter("EmissiveFactor")) {
-    instance->setParameter("EmissiveFactor", material.emissive);
+    const float emissive =
+        material.emissive > 0
+            ? material.emissive
+            : (material.emissive_texture != nullptr ? 1.0f : 0.0f);
+    instance->setParameter("EmissiveFactor", emissive);
   }
   if (fmaterial->hasParameter("SpecularFactor")) {
     instance->setParameter("SpecularFactor", material.specular);

--- a/src/experimental/filament/filament/object_manager.cc
+++ b/src/experimental/filament/filament/object_manager.cc
@@ -38,41 +38,60 @@ std::string ResolveFilamentAssetPath(const std::string& filename) {
   return path;
 }
 
-static filament::Material* LoadMaterial(filament::Engine* engine,
-                                        std::string_view filename) {
-  const std::string path = ResolveFilamentAssetPath(std::string(filename));
-  mjResource* resource = mju_openResource("", path.c_str(), nullptr, nullptr, 0);
-  void* payload = nullptr;
-  int size = mju_readResource(resource, const_cast<const void**>(&payload));
-  filament::Material::Builder material_builder;
-  material_builder.package(payload, size);
-  filament::Material* material = material_builder.build(*engine);
-  mju_closeResource(resource);
-  return material;
-};
+ObjectManager::Asset::Asset(std::string_view filename) {
+  std::string path = ResolveFilamentAssetPath(std::string(filename));
+  resource = mju_openResource("", path.c_str(), nullptr, nullptr, 0);
+  const int read_size =
+      mju_readResource(resource, const_cast<const void**>(&payload));
+  size = read_size > 0 ? read_size : 0;
+}
+
+ObjectManager::Asset::~Asset() {
+  if (resource) {
+    mju_closeResource(resource);
+  }
+}
+
+std::span<const std::byte> ObjectManager::Asset::GetBytes() const {
+  return {reinterpret_cast<const std::byte*>(payload), size};
+}
 
 ObjectManager::ObjectManager(filament::Engine* engine)
     : engine_(engine) {
-  materials_[kPbr] = LoadMaterial(engine, "pbr.filamat");
-  materials_[kPbrPacked] = LoadMaterial(engine, "pbr_packed.filamat");
-  materials_[kPbrTransparent] = LoadMaterial(engine, "pbr_transparent.filamat");
-  materials_[kPbrPackedTransparent] = LoadMaterial(engine, "pbr_packed_transparent.filamat");
-  materials_[kPhong2d] = LoadMaterial(engine, "phong_2d.filamat");
-  materials_[kPhong2dFade] = LoadMaterial(engine, "phong_2d_fade.filamat");
-  materials_[kPhong2dReflect] = LoadMaterial(engine, "phong_2d_reflect.filamat");
-  materials_[kPhong2dUv] = LoadMaterial(engine, "phong_2d_uv.filamat");
-  materials_[kPhong2dUvFade] = LoadMaterial(engine, "phong_2d_uv_fade.filamat");
-  materials_[kPhong2dUvReflect] = LoadMaterial(engine, "phong_2d_uv_reflect.filamat");
-  materials_[kPhongColor] = LoadMaterial(engine, "phong_color.filamat");
-  materials_[kPhongColorFade] = LoadMaterial(engine, "phong_color_fade.filamat");
-  materials_[kPhongColorReflect] = LoadMaterial(engine, "phong_color_reflect.filamat");
-  materials_[kPhongCube] = LoadMaterial(engine, "phong_cube.filamat");
-  materials_[kPhongCubeFade] = LoadMaterial(engine, "phong_cube_fade.filamat");
-  materials_[kPhongCubeReflect] = LoadMaterial(engine, "phong_cube_reflect.filamat");
-  materials_[kUnlitSegmentation] = LoadMaterial(engine, "unlit_segmentation.filamat");
-  materials_[kUnlitDecor] = LoadMaterial(engine, "unlit_decor.filamat");
-  materials_[kUnlitDepth] = LoadMaterial(engine, "unlit_depth.filamat");
-  materials_[kUnlitUi] = LoadMaterial(engine, "unlit_ui.filamat");
+  auto LoadMaterial = [this](std::string_view filename) {
+    Asset asset(filename);
+    if (asset.payload == nullptr || asset.size == 0) {
+      mju_error(
+          "Failed to load Filament material asset '%.*s'. Make sure the "
+          "generated .filamat and .ktx assets were packaged next to MuJoCo.",
+          static_cast<int>(filename.size()), filename.data());
+    }
+    filament::Material::Builder material_builder;
+    material_builder.package(asset.payload, asset.size);
+    return material_builder.build(*this->engine_);
+  };
+
+  materials_[kPbr] = LoadMaterial("pbr.filamat");
+  materials_[kPbrTransparent] = LoadMaterial("pbr_transparent.filamat");
+  materials_[kPbrPacked] = LoadMaterial("pbr_packed.filamat");
+  materials_[kPbrPackedTransparent] =
+      LoadMaterial("pbr_packed_transparent.filamat");
+  materials_[kPhong2d] = LoadMaterial("phong_2d.filamat");
+  materials_[kPhong2dFade] = LoadMaterial("phong_2d_fade.filamat");
+  materials_[kPhong2dReflect] = LoadMaterial("phong_2d_reflect.filamat");
+  materials_[kPhong2dUv] = LoadMaterial("phong_2d_uv.filamat");
+  materials_[kPhong2dUvFade] = LoadMaterial("phong_2d_uv_fade.filamat");
+  materials_[kPhong2dUvReflect] = LoadMaterial("phong_2d_uv_reflect.filamat");
+  materials_[kPhongColor] = LoadMaterial("phong_color.filamat");
+  materials_[kPhongColorFade] = LoadMaterial("phong_color_fade.filamat");
+  materials_[kPhongColorReflect] = LoadMaterial("phong_color_reflect.filamat");
+  materials_[kPhongCube] = LoadMaterial("phong_cube.filamat");
+  materials_[kPhongCubeFade] = LoadMaterial("phong_cube_fade.filamat");
+  materials_[kPhongCubeReflect] = LoadMaterial("phong_cube_reflect.filamat");
+  materials_[kUnlitSegmentation] = LoadMaterial("unlit_segmentation.filamat");
+  materials_[kUnlitDecor] = LoadMaterial("unlit_decor.filamat");
+  materials_[kUnlitDepth] = LoadMaterial("unlit_depth.filamat");
+  materials_[kUnlitUi] = LoadMaterial("unlit_ui.filamat");
 
   static uint8_t black_rgb[3] = {0, 0, 0};
   static uint8_t white_rgb[3] = {255, 255, 255};
@@ -147,5 +166,10 @@ const filament::Texture* ObjectManager::GetFallbackTexture(
     mju_error("Invalid texture role: %d", role);
   }
   return fallback_textures_[role];
+}
+
+std::unique_ptr<ObjectManager::Asset> ObjectManager::LoadAsset(
+    std::string_view filename) {
+  return std::unique_ptr<Asset>(new Asset(filename));
 }
 }  // namespace mujoco

--- a/src/experimental/filament/filament/object_manager.cc
+++ b/src/experimental/filament/filament/object_manager.cc
@@ -123,7 +123,7 @@ ObjectManager::ObjectManager(filament::Engine* engine)
   fallback_textures_[mjTEXROLE_ROUGHNESS] = fallback_white_;
   fallback_textures_[mjTEXROLE_METALLIC] = fallback_black_;
   fallback_textures_[mjTEXROLE_NORMAL] = fallback_normal_;
-  fallback_textures_[mjTEXROLE_EMISSIVE] = fallback_black_;
+  fallback_textures_[mjTEXROLE_EMISSIVE] = fallback_white_;
   fallback_textures_[mjTEXROLE_ORM] = fallback_orm_;
 }
 

--- a/src/experimental/filament/filament/object_manager.h
+++ b/src/experimental/filament/filament/object_manager.h
@@ -35,6 +35,24 @@ namespace mujoco {
 // Creates and owns various filament objects based on the data in a mjrContext.
 class ObjectManager {
  public:
+  class Asset {
+   public:
+    ~Asset();
+
+    std::span<const std::byte> GetBytes() const;
+
+    Asset(const Asset&) = delete;
+    Asset& operator=(const Asset&) = delete;
+
+   private:
+    friend class ObjectManager;
+    explicit Asset(std::string_view filename);
+
+    std::size_t size = 0;
+    void* payload = nullptr;
+    mjResource* resource = nullptr;
+  };
+
   ObjectManager(filament::Engine* engine);
   ~ObjectManager();
 
@@ -60,6 +78,7 @@ class ObjectManager {
     kUnlitSegmentation,
     kUnlitDecor,
     kUnlitDepth,
+    kUnlitLine,
     kUnlitUi,
     kNumMaterials,
   };
@@ -77,6 +96,12 @@ class ObjectManager {
 
   // Returns the filament Engine that owns the assets.
   filament::Engine* GetEngine() const { return engine_; }
+
+  // Loads the given asset from the filament resource directory.
+  std::unique_ptr<Asset> LoadAsset(std::string_view filename);
+
+  // The default environment light to use if no environment light is specified.
+  static constexpr const char* kDefaultEnvironmentLight = "ibl.ktx";
 
   ObjectManager(const ObjectManager&) = delete;
   ObjectManager& operator=(const ObjectManager&) = delete;

--- a/src/experimental/filament/mjr_compat.cc
+++ b/src/experimental/filament/mjr_compat.cc
@@ -170,6 +170,10 @@ extern "C" {
 
 // mjr functions that are supported by the filament renderer.
 
+const char* mjr_getRenderer(void) {
+  return "filament";
+}
+
 void mjr_defaultContext(mjrContext* con) {
   memset(con, 0, sizeof(mjrContext));
 }

--- a/src/experimental/filament/render_context_filament.cc
+++ b/src/experimental/filament/render_context_filament.cc
@@ -15,13 +15,29 @@
 #include "experimental/filament/render_context_filament.h"
 
 #include <array>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 #include <math/mat3.h>
 #include <math/vec3.h>
 #include <mujoco/mjmodel.h>
+#include <mujoco/mjrender.h>
+#include <mujoco/mjvisualize.h>
 #include <mujoco/mujoco.h>
+#include "experimental/filament/compat/mjr_filament_renderer.h"
 #include "experimental/filament/filament/filament_context.h"
 #include "experimental/filament/filament/light.h"
 #include "experimental/filament/filament/mesh.h"
@@ -29,6 +45,141 @@
 #include "experimental/filament/filament/renderable.h"
 #include "experimental/filament/filament/scene_view.h"
 #include "experimental/filament/filament/texture.h"
+
+#if defined(TLS_FILAMENT_CONTEXT)
+static thread_local mujoco::MjrFilamentRenderer* g_filament_context = nullptr;
+#else
+static mujoco::MjrFilamentRenderer* g_filament_context = nullptr;
+#endif
+
+static void CheckFilamentContext() {
+  if (g_filament_context == nullptr) {
+    mju_error("Missing context; did you call mjrf_makeFilamentContext?");
+  }
+}
+
+struct FilamentAssetResource {
+  std::vector<char> data;
+};
+
+static std::once_flag g_filament_provider_once;
+
+static std::string JoinPath(std::string_view dir, std::string_view filename) {
+  if (dir.empty()) {
+    return std::string(filename);
+  }
+  std::string path(dir);
+  const char last = path.back();
+  if (last != '/' && last != '\\') {
+#if defined(_WIN32) || defined(__CYGWIN__)
+    path.push_back('\\');
+#else
+    path.push_back('/');
+#endif
+  }
+  path.append(filename);
+  return path;
+}
+
+static std::string GetLibraryDir() {
+  void* anchor = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(&mj_forward));
+#if defined(_WIN32) || defined(__CYGWIN__)
+  HMODULE module = nullptr;
+  constexpr DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+  if (GetModuleHandleExA(flags, reinterpret_cast<LPCSTR>(anchor), &module)) {
+    char path[MAX_PATH];
+    if (GetModuleFileNameA(module, path, MAX_PATH)) {
+      std::string lib_path(path);
+      const std::size_t last_slash = lib_path.find_last_of("\\/");
+      if (last_slash != std::string::npos) {
+        return lib_path.substr(0, last_slash + 1);
+      }
+    }
+  }
+#else
+  Dl_info info;
+  if (dladdr(anchor, &info) && info.dli_fname) {
+    std::string lib_path(info.dli_fname);
+    const std::size_t last_slash = lib_path.find_last_of('/');
+    if (last_slash != std::string::npos) {
+      return lib_path.substr(0, last_slash + 1);
+    }
+  }
+#endif
+  return "";
+}
+
+static void EnsureDefaultFilamentResourceProvider() {
+  std::call_once(g_filament_provider_once, [] {
+    if (mjp_getResourceProvider("filament:pbr.filamat")) {
+      return;
+    }
+
+    static mjpResourceProvider provider;
+    mjp_defaultResourceProvider(&provider);
+
+    provider.open = [](mjResource* resource) {
+      std::string_view name(resource->name);
+      const std::size_t prefix_end = name.find(':');
+      const std::string_view filename =
+          prefix_end == std::string_view::npos
+              ? name
+              : name.substr(prefix_end + 1);
+
+      std::vector<std::string> asset_dirs;
+      if (const char* env_dir = std::getenv("MUJOCO_FILAMENT_ASSETS_DIR")) {
+        asset_dirs.emplace_back(env_dir);
+      }
+      const std::string library_dir = GetLibraryDir();
+      if (!library_dir.empty()) {
+        asset_dirs.push_back(JoinPath(library_dir, "assets"));
+      }
+      asset_dirs.emplace_back("assets");
+
+      for (const std::string& dir : asset_dirs) {
+        std::ifstream file(JoinPath(dir, filename),
+                           std::ios::binary | std::ios::ate);
+        if (!file.is_open()) {
+          continue;
+        }
+        const std::streamsize size = file.tellg();
+        if (size <= 0) {
+          continue;
+        }
+        auto* asset = new FilamentAssetResource();
+        asset->data.resize(static_cast<std::size_t>(size));
+        file.seekg(0, std::ios::beg);
+        if (!file.read(asset->data.data(), size)) {
+          delete asset;
+          continue;
+        }
+        resource->data = asset;
+        return static_cast<int>(asset->data.size());
+      }
+      return 0;
+    };
+    provider.read = [](mjResource* resource, const void** buffer) {
+      auto* asset = static_cast<FilamentAssetResource*>(resource->data);
+      if (!asset) {
+        return -1;
+      }
+      *buffer = asset->data.data();
+      return static_cast<int>(asset->data.size());
+    };
+    provider.close = [](mjResource* resource) {
+      delete static_cast<FilamentAssetResource*>(resource->data);
+      resource->data = nullptr;
+    };
+    provider.prefix = "filament";
+
+    const int slot = mjp_registerResourceProvider(&provider);
+    if (slot < 0 && !mjp_getResourceProvider("filament:pbr.filamat")) {
+      mju_warning("Failed to register default Filament resource provider.");
+    }
+  });
+}
 
 template <int N>
 static void setf(float (&arr)[N], const std::array<float, N>& values) {
@@ -327,4 +478,90 @@ void mjrf_getFrameStats(mjrfContext* ctx, mjrFrameHandle frame,
                         mjrFrameStats* stats_out) {
   mujoco::FilamentContext::downcast(ctx)->GetFrameStats(frame, stats_out);
 }
+
+// Legacy API, to be deprecated.
+
+void mjrf_makeFilamentContext(const mjModel* m, mjrContext* con,
+                              const mjrFilamentConfig* config) {
+  // TODO: Support multiple contexts and multiple threads. For now, we'll just
+  // assume a single, global context.
+  if (g_filament_context != nullptr) {
+    mju_error("Context already exists!");
+  }
+  EnsureDefaultFilamentResourceProvider();
+  g_filament_context = new mujoco::MjrFilamentRenderer(config);
+  g_filament_context->Init(m);
+}
+
+void mjrf_defaultContext(mjrContext* con) {
+  memset(con, 0, sizeof(mjrContext));
+}
+
+void mjrf_makeContext(const mjModel* m, mjrContext* con, int fontscale) {
+  mjrf_freeContext(con);
+  mjrFilamentConfig cfg;
+  mjrf_defaultFilamentConfig(&cfg);
+  cfg.width = m->vis.global.offwidth;
+  cfg.height = m->vis.global.offheight;
+  mjrf_makeFilamentContext(m, con, &cfg);
+}
+
+void mjrf_freeContext(mjrContext* con) {
+  // mjr_freeContext may be called multiple times.
+  if (g_filament_context) {
+    delete g_filament_context;
+    g_filament_context = nullptr;
+  }
+  mjrf_defaultContext(con);
+}
+
+void mjrf_renderScene(mjrRect viewport, mjvScene* scn, const mjrContext* con) {
+  CheckFilamentContext();
+  g_filament_context->Render(viewport, scn);
+}
+
+void mjrf_uploadMesh(const mjModel* m, const mjrContext* con, int meshid) {
+  CheckFilamentContext();
+  g_filament_context->UploadMesh(m, meshid);
+}
+
+void mjrf_uploadTexture(const mjModel* m, const mjrContext* con, int texid) {
+  CheckFilamentContext();
+  g_filament_context->UploadTexture(m, texid);
+}
+
+void mjrf_uploadHField(const mjModel* m, const mjrContext* con, int hfieldid) {
+  CheckFilamentContext();
+  g_filament_context->UploadHeightField(m, hfieldid);
+}
+
+void mjrf_setBuffer(int framebuffer, mjrContext* con) {
+  CheckFilamentContext();
+  g_filament_context->SetFrameBuffer(framebuffer);
+}
+
+void mjrf_readPixels(unsigned char* rgb, float* depth, mjrRect viewport,
+                          const mjrContext* con) {
+  CheckFilamentContext();
+  g_filament_context->ReadPixels(viewport, rgb, depth);
+}
+
+uintptr_t mjrf_uploadGuiImage(uintptr_t tex_id, const unsigned char* pixels,
+                             int width, int height, int bpp,
+                             const mjrContext* con) {
+  CheckFilamentContext();
+  return g_filament_context->UploadGuiImage(tex_id, pixels, width, height, bpp);
+}
+
+double mjrf_getFrameRate(const mjrContext* con) {
+  CheckFilamentContext();
+  return g_filament_context->GetFrameRate();
+}
+
+void mjrf_updateGui(const mjrContext* con) {
+  if (g_filament_context != nullptr) {
+    g_filament_context->UpdateGui();
+  }
+}
+
 }  // extern "C"

--- a/src/experimental/filament/render_context_filament.cc
+++ b/src/experimental/filament/render_context_filament.cc
@@ -34,10 +34,7 @@
 #include <math/mat3.h>
 #include <math/vec3.h>
 #include <mujoco/mjmodel.h>
-#include <mujoco/mjrender.h>
-#include <mujoco/mjvisualize.h>
 #include <mujoco/mujoco.h>
-#include "experimental/filament/compat/mjr_filament_renderer.h"
 #include "experimental/filament/filament/filament_context.h"
 #include "experimental/filament/filament/light.h"
 #include "experimental/filament/filament/mesh.h"
@@ -45,18 +42,6 @@
 #include "experimental/filament/filament/renderable.h"
 #include "experimental/filament/filament/scene_view.h"
 #include "experimental/filament/filament/texture.h"
-
-#if defined(TLS_FILAMENT_CONTEXT)
-static thread_local mujoco::MjrFilamentRenderer* g_filament_context = nullptr;
-#else
-static mujoco::MjrFilamentRenderer* g_filament_context = nullptr;
-#endif
-
-static void CheckFilamentContext() {
-  if (g_filament_context == nullptr) {
-    mju_error("Missing context; did you call mjrf_makeFilamentContext?");
-  }
-}
 
 struct FilamentAssetResource {
   std::vector<char> data;
@@ -276,6 +261,7 @@ void mjr_defaultFrameStats(mjrFrameStats* stats) {
 }
 
 mjrfContext* mjrf_createContext(const mjrFilamentConfig* config) {
+  EnsureDefaultFilamentResourceProvider();
   return new mujoco::FilamentContext(config);
 }
 
@@ -481,90 +467,4 @@ void mjrf_getFrameStats(mjrfContext* ctx, mjrFrameHandle frame,
                         mjrFrameStats* stats_out) {
   mujoco::FilamentContext::downcast(ctx)->GetFrameStats(frame, stats_out);
 }
-
-// Legacy API, to be deprecated.
-
-void mjrf_makeFilamentContext(const mjModel* m, mjrContext* con,
-                              const mjrFilamentConfig* config) {
-  // TODO: Support multiple contexts and multiple threads. For now, we'll just
-  // assume a single, global context.
-  if (g_filament_context != nullptr) {
-    mju_error("Context already exists!");
-  }
-  EnsureDefaultFilamentResourceProvider();
-  g_filament_context = new mujoco::MjrFilamentRenderer(config);
-  g_filament_context->Init(m);
-}
-
-void mjrf_defaultContext(mjrContext* con) {
-  memset(con, 0, sizeof(mjrContext));
-}
-
-void mjrf_makeContext(const mjModel* m, mjrContext* con, int fontscale) {
-  mjrf_freeContext(con);
-  mjrFilamentConfig cfg;
-  mjrf_defaultFilamentConfig(&cfg);
-  cfg.width = m->vis.global.offwidth;
-  cfg.height = m->vis.global.offheight;
-  mjrf_makeFilamentContext(m, con, &cfg);
-}
-
-void mjrf_freeContext(mjrContext* con) {
-  // mjr_freeContext may be called multiple times.
-  if (g_filament_context) {
-    delete g_filament_context;
-    g_filament_context = nullptr;
-  }
-  mjrf_defaultContext(con);
-}
-
-void mjrf_renderScene(mjrRect viewport, mjvScene* scn, const mjrContext* con) {
-  CheckFilamentContext();
-  g_filament_context->Render(viewport, scn);
-}
-
-void mjrf_uploadMesh(const mjModel* m, const mjrContext* con, int meshid) {
-  CheckFilamentContext();
-  g_filament_context->UploadMesh(m, meshid);
-}
-
-void mjrf_uploadTexture(const mjModel* m, const mjrContext* con, int texid) {
-  CheckFilamentContext();
-  g_filament_context->UploadTexture(m, texid);
-}
-
-void mjrf_uploadHField(const mjModel* m, const mjrContext* con, int hfieldid) {
-  CheckFilamentContext();
-  g_filament_context->UploadHeightField(m, hfieldid);
-}
-
-void mjrf_setBuffer(int framebuffer, mjrContext* con) {
-  CheckFilamentContext();
-  g_filament_context->SetFrameBuffer(framebuffer);
-}
-
-void mjrf_readPixels(unsigned char* rgb, float* depth, mjrRect viewport,
-                          const mjrContext* con) {
-  CheckFilamentContext();
-  g_filament_context->ReadPixels(viewport, rgb, depth);
-}
-
-uintptr_t mjrf_uploadGuiImage(uintptr_t tex_id, const unsigned char* pixels,
-                             int width, int height, int bpp,
-                             const mjrContext* con) {
-  CheckFilamentContext();
-  return g_filament_context->UploadGuiImage(tex_id, pixels, width, height, bpp);
-}
-
-double mjrf_getFrameRate(const mjrContext* con) {
-  CheckFilamentContext();
-  return g_filament_context->GetFrameRate();
-}
-
-void mjrf_updateGui(const mjrContext* con) {
-  if (g_filament_context != nullptr) {
-    g_filament_context->UpdateGui();
-  }
-}
-
 }  // extern "C"

--- a/src/experimental/filament/render_context_filament.cc
+++ b/src/experimental/filament/render_context_filament.cc
@@ -129,6 +129,9 @@ static void EnsureDefaultFilamentResourceProvider() {
               : name.substr(prefix_end + 1);
 
       std::vector<std::string> asset_dirs;
+      if (const char* env_dir = std::getenv("MUJOCO_ASSETS_DIR")) {
+        asset_dirs.emplace_back(env_dir);
+      }
       if (const char* env_dir = std::getenv("MUJOCO_FILAMENT_ASSETS_DIR")) {
         asset_dirs.emplace_back(env_dir);
       }

--- a/src/experimental/studio/README.md
+++ b/src/experimental/studio/README.md
@@ -17,6 +17,47 @@ bash build.sh
 > [!NOTE]
 > For now [`build.sh`](build.sh) script works on windows in a git bash shell.
 
+To keep Studio build artifacts separate from other MuJoCo builds, you can also
+configure an isolated build directory manually:
+
+```
+cmake -B build-studio \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_STATIC_LIBCXX=OFF \
+  -DBUILD_SHARED_LIB=OFF \
+  -DMUJOCO_USE_FILAMENT=ON \
+  -DMUJOCO_BUILD_EXAMPLES=OFF \
+  -DMUJOCO_BUILD_SIMULATE=OFF \
+  -DMUJOCO_BUILD_TESTS=OFF \
+  -DMUJOCO_TEST_PYTHON_UTIL=OFF \
+  -DMUJOCO_WITH_USD=OFF \
+  -DMUJOCO_BUILD_STUDIO=ON \
+  -DFILAMENT_SKIP_SAMPLES=ON \
+  -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations \
+  -DFILAMENT_SHORTEN_MSVC_COMPILATION=OFF
+cmake --build build-studio --config Release --target mujoco_studio --parallel
+```
+
+Run `mujoco_studio` from the build output directory so it can find the copied
+font and Filament assets:
+
+```
+cd build-studio/bin
+./mujoco_studio --gfx=opengl
+```
+
+On macOS, Studio defaults to Filament OpenGL. The OpenGL implementation may be
+provided by Apple's Metal-backed OpenGL layer, so runtime logs can mention both
+OpenGL and Metal/Apple GPU details.
+
+### Troubleshooting
+
+If configure fails while resolving Filament dependencies, check whether CMake is
+finding package-manager CMake configs from environments such as Anaconda. In
+particular, an unrelated `abslConfig.cmake` can conflict with MuJoCo's fetched
+Abseil targets. Remove that prefix from `CMAKE_PREFIX_PATH`, or configure with
+`CMAKE_IGNORE_PREFIX_PATH` pointing at the conflicting environment prefix.
+
 ## Development
 
 The [`build.sh`](build.sh) script is intended to get you up and running quickly.

--- a/src/experimental/studio/README.md
+++ b/src/experimental/studio/README.md
@@ -46,6 +46,10 @@ cd build-studio/bin
 ./mujoco_studio --gfx=opengl
 ```
 
+On Linux, build Filament-backed targets with a single C++ standard library. If
+Filament is built with `libc++`, configure MuJoCo with clang and matching
+`-stdlib=libc++` compiler/linker flags to avoid mixed-stdlib link failures.
+
 On macOS, Studio defaults to Filament OpenGL. The OpenGL implementation may be
 provided by Apple's Metal-backed OpenGL layer, so runtime logs can mention both
 OpenGL and Metal/Apple GPU details.

--- a/src/render/classic/render_context.c
+++ b/src/render/classic/render_context.c
@@ -50,6 +50,10 @@
 
 //----------------------------- custom OpenGL context ----------------------------------------------
 
+const char* mjr_getRenderer(void) {
+  return "classic";
+}
+
 // set default mjrContext
 void mjr_defaultContext(mjrContext* con) {
   memset(con, 0, sizeof(mjrContext));

--- a/src/render/noop/render_noop.c
+++ b/src/render/noop/render_noop.c
@@ -19,6 +19,10 @@
 // library) when you do not intend to use any graphics APIs and want to reduce
 // dependencies, compile times, binary size, etc.
 
+const char* mjr_getRenderer(void) {
+  return "noop";
+}
+
 void mjr_defaultContext(mjrContext* con) {
   mju_error("mjr_defaultContext not implemented.");
 }

--- a/src/user/user_resource.cc
+++ b/src/user/user_resource.cc
@@ -17,12 +17,26 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cctype>
 #include <cstddef>
 #include <cstdio>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <fstream>
+#include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define NOMINMAX
+#include <windows.h>
+#elif !defined(__EMSCRIPTEN__)
+#include <dlfcn.h>
+#endif
+
 #include <mujoco/mujoco.h>
 
 #include <mujoco/mjplugin.h>
@@ -30,8 +44,194 @@
 #include "user/user_util.h"
 #include "user/user_vfs.h"
 
+namespace {
+
+constexpr char kMujocoAssetPrefix[] = "mujoco";
+constexpr char kMujocoAssetScheme[] = "mujoco:";
+constexpr char kMujocoAssetsDirEnv[] = "MUJOCO_ASSETS_DIR";
+constexpr char kMujocoFilamentAssetsDirEnv[] = "MUJOCO_FILAMENT_ASSETS_DIR";
+
+struct MujocoAssetResource {
+  std::vector<char> data;
+};
+
+bool IsMujocoAssetResourceName(const char* name) {
+  if (!name) {
+    return false;
+  }
+
+  for (int i = 0; kMujocoAssetScheme[i]; ++i) {
+    if (std::tolower(static_cast<unsigned char>(name[i])) !=
+        kMujocoAssetScheme[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string JoinPath(std::string_view dir, std::string_view filename) {
+  if (dir.empty()) {
+    return std::string(filename);
+  }
+  std::string path(dir);
+  const char last = path.back();
+  if (last != '/' && last != '\\') {
+#if defined(_WIN32) || defined(__CYGWIN__)
+    path.push_back('\\');
+#else
+    path.push_back('/');
+#endif
+  }
+  path.append(filename);
+  return path;
+}
+
+std::string GetLibraryDir() {
+#if defined(__EMSCRIPTEN__)
+  return "";
+#else
+  void* anchor = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(&mj_forward));
+#if defined(_WIN32) || defined(__CYGWIN__)
+  HMODULE module = nullptr;
+  constexpr DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+  if (GetModuleHandleExA(flags, reinterpret_cast<LPCSTR>(anchor), &module)) {
+    char path[MAX_PATH];
+    if (GetModuleFileNameA(module, path, MAX_PATH)) {
+      std::string lib_path(path);
+      const std::size_t last_slash = lib_path.find_last_of("\\/");
+      if (last_slash != std::string::npos) {
+        return lib_path.substr(0, last_slash + 1);
+      }
+    }
+  }
+#else
+  Dl_info info;
+  if (dladdr(anchor, &info) && info.dli_fname) {
+    std::string lib_path(info.dli_fname);
+    const std::size_t last_slash = lib_path.find_last_of('/');
+    if (last_slash != std::string::npos) {
+      return lib_path.substr(0, last_slash + 1);
+    }
+  }
+#endif
+  return "";
+#endif
+}
+
+std::string_view ResourceFilename(std::string_view name) {
+  const std::size_t prefix_end = name.find(':');
+  return prefix_end == std::string_view::npos ? name
+                                              : name.substr(prefix_end + 1);
+}
+
+bool IsSafeAssetFilename(std::string_view filename) {
+  if (filename.empty() || filename.front() == '/' || filename.front() == '\\') {
+    return false;
+  }
+
+  std::size_t segment_start = 0;
+  while (segment_start <= filename.size()) {
+    std::size_t segment_end = filename.find_first_of("/\\", segment_start);
+    if (segment_end == std::string_view::npos) {
+      segment_end = filename.size();
+    }
+    std::string_view segment =
+        filename.substr(segment_start, segment_end - segment_start);
+    if (segment == "..") {
+      return false;
+    }
+    segment_start = segment_end + 1;
+  }
+  return true;
+}
+
+int OpenMujocoAssetResource(mjResource* resource) {
+  const std::string_view filename = ResourceFilename(resource->name);
+  if (!IsSafeAssetFilename(filename)) {
+    return 0;
+  }
+
+  std::vector<std::string> asset_dirs;
+  if (const char* env_dir = std::getenv(kMujocoAssetsDirEnv)) {
+    asset_dirs.emplace_back(env_dir);
+  }
+  if (const char* env_dir = std::getenv(kMujocoFilamentAssetsDirEnv)) {
+    asset_dirs.emplace_back(env_dir);
+  }
+  const std::string library_dir = GetLibraryDir();
+  if (!library_dir.empty()) {
+    asset_dirs.push_back(JoinPath(library_dir, "assets"));
+  }
+  asset_dirs.emplace_back("assets");
+
+  for (const std::string& dir : asset_dirs) {
+    std::ifstream file(JoinPath(dir, filename),
+                       std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+      continue;
+    }
+    const std::streamsize size = file.tellg();
+    if (size <= 0) {
+      continue;
+    }
+    auto* asset = new MujocoAssetResource();
+    asset->data.resize(static_cast<std::size_t>(size));
+    file.seekg(0, std::ios::beg);
+    if (!file.read(asset->data.data(), size)) {
+      delete asset;
+      continue;
+    }
+    resource->data = asset;
+    return static_cast<int>(asset->data.size());
+  }
+  return 0;
+}
+
+int ReadMujocoAssetResource(mjResource* resource, const void** buffer) {
+  auto* asset = static_cast<MujocoAssetResource*>(resource->data);
+  if (!asset) {
+    return -1;
+  }
+  *buffer = asset->data.data();
+  return static_cast<int>(asset->data.size());
+}
+
+void CloseMujocoAssetResource(mjResource* resource) {
+  delete static_cast<MujocoAssetResource*>(resource->data);
+  resource->data = nullptr;
+}
+
+void EnsureDefaultMujocoAssetProvider() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    if (mjp_getResourceProvider("mujoco:asset")) {
+      return;
+    }
+
+    mjpResourceProvider provider;
+    mjp_defaultResourceProvider(&provider);
+    provider.prefix = kMujocoAssetPrefix;
+    provider.open = OpenMujocoAssetResource;
+    provider.read = ReadMujocoAssetResource;
+    provider.close = CloseMujocoAssetResource;
+
+    const int slot = mjp_registerResourceProvider(&provider);
+    if (slot < 0 && !mjp_getResourceProvider("mujoco:asset")) {
+      mju_warning("Failed to register default MuJoCo asset resource provider.");
+    }
+  });
+}
+
+}  // namespace
+
 mjResource* mju_openResource(const char* dir, const char* name,
                              const mjVFS* vfs, char* error, size_t nerror) {
+  if (IsMujocoAssetResourceName(name)) {
+    EnsureDefaultMujocoAssetProvider();
+  }
+
   // TODO: Update API to use non-const pointer. Unfortunately, while this is
   // ABI stable, it will cause compiler errors in user code that is const
   // correct.

--- a/test/user/user_resource_test.cc
+++ b/test/user/user_resource_test.cc
@@ -15,9 +15,13 @@
 // Tests for user/user_resource.cc
 
 #include <array>
+#include <chrono>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -72,6 +76,46 @@ void close_str(mjResource* resource) {
   mju_free(resource->data);
   resource->data = nullptr;
 }
+
+void SetEnvVar(const char* name, const char* value) {
+#if defined(_WIN32) || defined(__CYGWIN__)
+  _putenv_s(name, value);
+#else
+  setenv(name, value, 1);
+#endif
+}
+
+void UnsetEnvVar(const char* name) {
+#if defined(_WIN32) || defined(__CYGWIN__)
+  _putenv_s(name, "");
+#else
+  unsetenv(name);
+#endif
+}
+
+class ScopedEnvVar {
+ public:
+  ScopedEnvVar(const char* name, const std::string& value) : name_(name) {
+    if (const char* old_value = std::getenv(name)) {
+      had_old_value_ = true;
+      old_value_ = old_value;
+    }
+    SetEnvVar(name, value.c_str());
+  }
+
+  ~ScopedEnvVar() {
+    if (had_old_value_) {
+      SetEnvVar(name_, old_value_.c_str());
+    } else {
+      UnsetEnvVar(name_);
+    }
+  }
+
+ private:
+  const char* name_;
+  bool had_old_value_ = false;
+  std::string old_value_;
+};
 
 TEST_F(ResourceTest, RegisterProviderSuccess) {
   mjpResourceProvider provider = {
@@ -280,6 +324,36 @@ TEST_F(ResourceTest, GeneralTest) {
   EXPECT_THAT(buffer, StrEq("Hello World"));
 
   mju_closeResource(resource);
+}
+
+TEST_F(ResourceTest, BuiltInMujocoAssetProviderUsesAssetsDir) {
+  namespace fs = std::filesystem;
+  const fs::path test_dir =
+      fs::temp_directory_path() /
+      ("mujoco-assets-resource-test-" +
+       std::to_string(
+           std::chrono::steady_clock::now().time_since_epoch().count()));
+  const fs::path assets_dir = test_dir / "assets";
+  fs::create_directories(assets_dir);
+
+  const std::string expected = "packaged asset bytes";
+  const fs::path asset_path = assets_dir / "test_asset.bin";
+  std::ofstream(asset_path, std::ios::binary).write(
+      expected.data(), expected.size());
+
+  ScopedEnvVar assets_dir_env("MUJOCO_ASSETS_DIR", assets_dir.string());
+
+  mjResource* resource = mju_openResource(
+      "", "mujoco:test_asset.bin", nullptr, nullptr, 0);
+  ASSERT_THAT(resource, NotNull());
+
+  const void* buffer = nullptr;
+  const int bytes = mju_readResource(resource, &buffer);
+  EXPECT_EQ(bytes, static_cast<int>(expected.size()));
+  EXPECT_EQ(std::string(static_cast<const char*>(buffer), bytes), expected);
+
+  mju_closeResource(resource);
+  fs::remove_all(test_dir);
 }
 
 TEST_F(ResourceTest, GeneralFailureTest) {


### PR DESCRIPTION
This is a follow-up draft stacked on #3252. It keeps #3252 focused on getting Studio building from source, while this branch prototypes the packaging/runtime pieces requested in the Renderer API discussion.

Until #3252 lands, GitHub may show its source-build commit in this PR. The new review focus here is commits `3427f5ec` and `20899884`.

## What changed

- Installs generated Filament runtime assets (`*.filamat`, `*.ktx`) into `lib/assets`.
- Stages generated Filament assets into the Python wheel/package under `mujoco/assets`.
- Adds a default `filament:` resource provider for non-Studio runtimes. It searches `MUJOCO_FILAMENT_ASSETS_DIR`, library-adjacent `assets`, then cwd `assets`.
- Preserves Studio behavior by only registering the default provider when no `filament:` provider exists.
- Adds a small `mjr_getRenderer()` query returning `classic`, `filament`, or `noop`, and exposes it as `mujoco.mjRENDERER`.
- Wires the Filament MJR compatibility layer into `libmujoco` when `MUJOCO_USE_FILAMENT_MJR_COMPAT=ON` and exports the public `mjr_*` symbols from the shared library.
- Adds basic asset-load error handling so missing Filament material assets fail clearly instead of passing an invalid payload size into Filament.

## Related context

- Source-build precursor PR: https://github.com/google-deepmind/mujoco/pull/3252
- Renderer API issue: https://github.com/google-deepmind/mujoco/issues/2487
- @yuvaltassa noted Studio is nearly ready from `src/experimental/studio/`: https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4341872871
- @BlGene listed the downstream requirements this draft targets: renderer query, Python 3.11 wheels, and pip installability: https://github.com/google-deepmind/mujoco/issues/2487#issuecomment-4354613171
- AllenAI / MolmoSpaces prior art from @BlGene / @wpumacay: https://github.com/allenai/mujoco/tree/molmospaces and https://github.com/allenai/molmospaces
- @julien-blanchon's wheel/asset prior art: https://github.com/julien-blanchon/mujoco/tree/exp-filament-build

## Validation

- `git diff --check`
- Rebased onto current `origin/main` (`d249c882`) and verified the branch is mergeable.
- `python3 -m py_compile python/setup.py python/mujoco/rendering/classic/renderer.py python/mujoco/renderer_test.py`
- `python3 -m pytest -q python/mujoco/renderer_test.py -k 'missing_gl_context_symbol or del_safe'`
- `python3 -m py_compile python/setup.py`
- `cmake --build build-studio-filament-eval --target mujoco_studio --parallel $(sysctl -n hw.logicalcpu)`
- Launched `mujoco_studio` with a local Go2 scene on macOS / Apple M3 Pro. Runtime log reported `FEngine resolved backend: OpenGL`.
- Verified 20 generated Filament assets in the Studio runtime `bin/assets` directory.
- Configured and built a clean `MUJOCO_USE_FILAMENT=ON` + `MUJOCO_USE_FILAMENT_MJR_COMPAT=ON` `mujoco` target using already-fetched dependencies.
- Verified `libmujoco.dylib` exports `mjr_getRenderer`, `mjr_makeContext`, `mjr_render`, and `mjr_freeContext` in the MJR-compat build.
- Verified `mjr_getRenderer()` returns `filament` from the MJR-compat `libmujoco.dylib` via `ctypes`.
- Verified install staging copies 20 generated Filament assets into `lib/assets`.

## Known gaps

- Full wheel artifact verification is still pending. A local wheel attempt was blocked by GitHub DNS while FetchContent tried to fetch Abseil.
- This does not yet make Filament the default Python renderer or define a full runtime renderer-selection API.
- Platform validation is still macOS-focused; Linux/Windows/headless coverage should be separate follow-up work.