### PR TITLE
Fix model.bind shape for single-element spec slices

### DIFF
--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -165,10 +165,7 @@ class _MjBindModel:
     object.__setattr__(self, 'elements', elements)
 
   def __getattr__(self, key: str):
-    items = []
-    for e in self.elements:
-      items.extend(getattr(e, key))
-    return items
+    return _bind_attribute(self.elements, key)
 
   def __setattr__(self, key: str, value: Any):
     raise AttributeError(f'Cannot set {key} on MjModel.')
@@ -181,15 +178,72 @@ class _MjBindData:
     object.__setattr__(self, 'elements', elements)
 
   def __getattr__(self, key: str):
-    items = []
-    for e in self.elements:
-      items.extend(getattr(e, key))
-    return items
+    return _bind_attribute(self.elements, key)
 
   def __setattr__(self, key: str, value: Any):
     value_it = iter(value)
     for element in self.elements:
       setattr(element, key, next(value_it))
+
+
+_JOINT_VECTOR_FIELDS = frozenset({
+    'qpos0',
+    'qpos_spring',
+    'bodyid',
+    'jntid',
+    'parentid',
+    'Madr',
+    'simplenum',
+    'frictionloss',
+    'armature',
+    'damping',
+    'dampingpoly',
+    'invweight0',
+    'M0',
+    'qpos',
+    'qvel',
+    'qacc_warmstart',
+    'qfrc_applied',
+    'qacc',
+    'cdof',
+    'qLDiagInv',
+    'cdof_dot',
+    'qfrc_bias',
+    'qfrc_passive',
+    'qfrc_actuator',
+    'qfrc_smooth',
+    'qacc_smooth',
+    'qfrc_constraint',
+    'qfrc_inverse',
+})
+
+
+_RAGGED_BIND_FIELDS_BY_GROUP = {
+    'MjModelHfieldViews': frozenset({'data'}),
+    'MjModelJointViews': _JOINT_VECTOR_FIELDS,
+    'MjModelNumericViews': frozenset({'data'}),
+    'MjModelTextureViews': frozenset({'data'}),
+    'MjModelTupleViews': frozenset({'objtype', 'objid', 'objprm'}),
+    'MjDataJointViews': _JOINT_VECTOR_FIELDS,
+    'MjDataSensorViews': frozenset({'data'}),
+}
+
+
+def _bind_attribute(elements: Sequence[Any], key: str):
+  """Returns the bound attribute for a sequence of grouped view objects."""
+  items = []
+  for element in elements:
+    value = getattr(element, key)
+    group = type(element).__name__
+    shape = getattr(value, 'shape', ())
+    if (
+        key in _RAGGED_BIND_FIELDS_BY_GROUP.get(group, ())
+        or tuple(shape) == (1,)
+    ):
+      items.extend(value)
+    else:
+      items.append(value)
+  return items
 
 
 def _bind_model(

--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -1465,14 +1465,33 @@ class SpecsTest(absltest.TestCase):
     joint_box = spec.joint('box')
     joint_sphere = spec.joint('sphere')
     joints = [joint_box, joint_sphere]
+    geoms = spec.geoms[1:3]
     mj_model = spec.compile()
     mj_data = mujoco.MjData(mj_model)
+    mujoco.mj_forward(mj_model, mj_data)
     np.testing.assert_array_equal(mj_data.bind(joint_box).qpos, 0)
     np.testing.assert_array_equal(mj_model.bind(joint_box).qposadr, 7)
     np.testing.assert_array_equal(mj_data.bind(joints).qpos, [0, 0])
     np.testing.assert_array_equal(mj_model.bind(joints).qposadr, [7, 8])
     np.testing.assert_array_equal(mj_data.bind([]).qpos, [])
     np.testing.assert_array_equal(mj_model.bind([]).qposadr, [])
+    np.testing.assert_array_equal(mj_data.bind(joints[0:1]).qpos, [0])
+    np.testing.assert_array_equal(mj_model.bind(geoms[0]).size, [0.15] * 3)
+    np.testing.assert_array_equal(
+        mj_model.bind(geoms[0:1]).size, [[0.15] * 3]
+    )
+    np.testing.assert_array_equal(
+        mj_model.bind(geoms[0:2]).size, [[0.15] * 3, [0.15] * 3]
+    )
+    np.testing.assert_array_equal(
+        np.asarray(mj_model.bind(geoms[0:1]).size).shape, (1, 3)
+    )
+    np.testing.assert_array_equal(
+        np.asarray(mj_data.bind(geoms[0:1]).xpos).shape, (1, 3)
+    )
+    np.testing.assert_array_equal(
+        np.asarray(mj_model.bind(joints[0:1]).axis).shape, (1, 3)
+    )
     mj_data.bind(joints).qpos = np.array([1, 2])
     np.testing.assert_array_equal(mj_data.bind(joints).qpos, [1, 2])
     with self.assertRaisesRegex(


### PR DESCRIPTION
Fixes #3128.

## Summary
- Preserve the sequence dimension when binding fixed-size per-entity fields from single-element spec slices, e.g. `model.bind(geoms[0:1]).size` now has shape `(1, 3)`.
- Keep scalar and ragged joint-coordinate binding behavior unchanged, e.g. scalar joint fields and `qpos` remain concatenated for sequence binds.
- Add regression coverage for model/data bind behavior with single-element slices.

## Tests
- `python -m py_compile python\mujoco\__init__.py python\mujoco\specs_test.py`
- `python -m pytest python\mujoco\specs_test.py -k test_bind -q`