### PR TITLE
MJX: add missing mesh_* fields to mjx.Model

### DIFF
--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -757,6 +757,7 @@ class Model(PyTreeNode):
   mesh_vertadr: np.ndarray
   mesh_vertnum: np.ndarray
   mesh_faceadr: np.ndarray
+  mesh_facenum: np.ndarray
   mesh_bvhadr: np.ndarray
   mesh_bvhnum: np.ndarray
   mesh_octadr: np.ndarray
@@ -767,12 +768,25 @@ class Model(PyTreeNode):
   mesh_vert: np.ndarray
   mesh_normal: np.ndarray
   mesh_face: np.ndarray
+  mesh_facenormal: np.ndarray
+  mesh_facetexcoord: np.ndarray
   mesh_graph: np.ndarray
+  mesh_scale: np.ndarray
   mesh_pos: np.ndarray
   mesh_quat: np.ndarray
+  mesh_pathadr: np.ndarray
   mesh_texcoordadr: np.ndarray
   mesh_texcoordnum: np.ndarray
   mesh_texcoord: np.ndarray
+  mesh_polynum: np.ndarray
+  mesh_polyadr: np.ndarray
+  mesh_polynormal: np.ndarray
+  mesh_polyvertadr: np.ndarray
+  mesh_polyvertnum: np.ndarray
+  mesh_polyvert: np.ndarray
+  mesh_polymapadr: np.ndarray
+  mesh_polymapnum: np.ndarray
+  mesh_polymap: np.ndarray
   flex_vertadr: np.ndarray
   flex_vertnum: np.ndarray
   flex_interp: np.ndarray


### PR DESCRIPTION
﻿Closes #2685.

## Summary

Adds the missing `mesh_*` fields to `mjx.Model` (in `mjx/_src/types.py`) so they can be accessed alongside the rest of the mesh metadata after `put_model`.

Fields added:
- `mesh_facenum` (companion to existing `mesh_faceadr`)
- `mesh_facenormal`, `mesh_facetexcoord`
- `mesh_scale`
- `mesh_pathadr`
- `mesh_poly*` family: `mesh_polyadr`, `mesh_polynum`, `mesh_polynormal`, `mesh_polyvertadr`, `mesh_polyvertnum`, `mesh_polyvert`, `mesh_polymapadr`, `mesh_polymapnum`, `mesh_polymap`

## Why

The reporter (#2685) called out that `mesh_faceadr` is on `mjx.Model` but `mesh_facenum` is not -- you need both to slice the faces of a specific mesh. Several other `mesh_*` fields were similarly absent. Each of these exists on `mujoco.MjModel` and is just metadata (no compute path), so the only thing preventing access through MJX was the missing declaration on `types.Model`.

## What changed

Only `mjx/mujoco/mjx/_src/types.py` -- 14 new `np.ndarray` field declarations on `class Model(PyTreeNode)`, matching the existing `mesh_*` block convention.

`io.py` already builds the field set dynamically:

```python
mj_field_names = {f.name for f in types.Model.fields() if f.name != ''_impl''}
fields = {f: getattr(m, f) for f in mj_field_names}
```

so adding the names to `types.py` is sufficient -- no `io.py` changes needed (also confirmed by @crisiumnih in the issue thread).

## Verification

Smoke test against `put_model` on a 2-mesh scene:

```
mesh_facenum           mjx-shape=(2,)   match=True
mesh_facenormal        mjx-shape=(8, 3) match=True
mesh_facetexcoord      mjx-shape=(8, 3) match=True
mesh_scale             mjx-shape=(2, 3) match=True
mesh_pathadr           mjx-shape=(2,)   match=True
mesh_polynum           mjx-shape=(2,)   match=True
mesh_polyadr           mjx-shape=(2,)   match=True
mesh_polynormal        mjx-shape=(8, 3) match=True
mesh_polyvertadr       mjx-shape=(8,)   match=True
mesh_polyvertnum       mjx-shape=(8,)   match=True
mesh_polyvert          mjx-shape=(24,)  match=True
mesh_polymapadr        mjx-shape=(8,)   match=True
mesh_polymapnum        mjx-shape=(8,)   match=True
mesh_polymap           mjx-shape=(24,)  match=True
```

All fields propagate from `MjModel` and round-trip equal.

`mjx/mujoco/mjx/_src/io_test.py::ModelIOTest` -- 18 passed, 6 skipped, 0 failures.

## Test plan

- [x] `put_model` populates all 14 new fields with values matching `MjModel`
- [x] `ModelIOTest` passes locally
- [ ] CLA check
- [ ] CI
