### PR TITLE
Fix Unity passive flag compatibility

### DIFF
--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -103,8 +103,9 @@ public struct MjcfOptionFlag {
                                                             localDefault.FrictionLoss);
     Limit = mjcf.GetEnumAttribute<EnableDisableFlag>("limit", localDefault.Limit);
     Contact = mjcf.GetEnumAttribute<EnableDisableFlag>("contact", localDefault.Contact);
-    Spring = mjcf.GetEnumAttribute<EnableDisableFlag>("spring", localDefault.Spring);
-    Damper = mjcf.GetEnumAttribute<EnableDisableFlag>("damper", localDefault.Damper);
+    var passive = mjcf.GetEnumAttribute<EnableDisableFlag>("passive", localDefault.Spring);
+    Spring = mjcf.GetEnumAttribute<EnableDisableFlag>("spring", passive);
+    Damper = mjcf.GetEnumAttribute<EnableDisableFlag>("damper", passive);
     Gravity = mjcf.GetEnumAttribute<EnableDisableFlag>("gravity", localDefault.Gravity);
     ClampCtrl = mjcf.GetEnumAttribute<EnableDisableFlag>("clampctrl", localDefault.ClampCtrl);
     WarmStart = mjcf.GetEnumAttribute<EnableDisableFlag>("warmstart", localDefault.WarmStart);

--- a/unity/Tests/Editor/Components/MjGlobalSettingsTests.cs
+++ b/unity/Tests/Editor/Components/MjGlobalSettingsTests.cs
@@ -94,6 +94,7 @@ public class MjGlobalSettingsGenerationTests {
     Assert.That(_doc.OuterXml, Does.Contain(@"contact="));
     Assert.That(_doc.OuterXml, Does.Contain(@"spring="));
     Assert.That(_doc.OuterXml, Does.Contain(@"damper="));
+    Assert.That(_doc.OuterXml, Does.Not.Contain(@"passive="));
     Assert.That(_doc.OuterXml, Does.Contain(@"clampctrl="));
     Assert.That(_doc.OuterXml, Does.Contain(@"warmstart="));
     Assert.That(_doc.OuterXml, Does.Contain(@"filterparent="));
@@ -183,6 +184,16 @@ public class MjGlobalSettingsParsingTests {
     Assert.That(_settings.CustomNumeric.Count, Is.EqualTo(1));
     Assert.That(_settings.CustomNumeric[0].Name, Is.EqualTo("numeric_name"));
     Assert.That(_settings.CustomNumeric[0].Data, Is.EqualTo("1 2 3"));
+  }
+
+  [Test]
+  public void ParseLegacyPassiveFlagAsSpringAndDamper() {
+    _flag.SetAttribute("passive", "disable");
+
+    _settings.ParseGlobalMjcfSections(_root);
+
+    Assert.That(_settings.GlobalOptions.Flag.Spring, Is.EqualTo(EnableDisableFlag.disable));
+    Assert.That(_settings.GlobalOptions.Flag.Damper, Is.EqualTo(EnableDisableFlag.disable));
   }
 }
 }


### PR DESCRIPTION
Fixes #2972.

Summary:
- Preserve compatibility for legacy MJCF files that contain `<flag passive="...">` by mapping `passive` to both `spring` and `damper` on import.
- Keep generated MJCF compatible with the current MuJoCo schema by writing `spring` and `damper`, and never writing obsolete `passive`.
- Add regression coverage for both legacy passive parsing and generated XML.

Verification:
- `git diff --check`
- Unity EditMode: `Mujoco.MjGlobalSettingsGenerationTests` — 2 passed, 0 failed
- Unity EditMode: `Mujoco.MjGlobalSettingsParsingTests` — 2 passed, 0 failed

Unity environment:
- Unity 6000.3.15f1
- macOS Apple Silicon / arm64
- Editor path: `/Volumes/AppsSSD/Unity/Hub/Editor/6000.3.15f1`