### PR TITLE
fix(unity): use URP-compatible shaders for imported materials

### DIFF
--- a/unity/Editor/Importer/MjImporterWithAssets.cs
+++ b/unity/Editor/Importer/MjImporterWithAssets.cs
@@ -226,11 +226,10 @@ public class MjImporterWithAssets : MjcfImporter {
       material = new Material(AssetDatabase.LoadMainAssetAtPath(
         AssetDatabase.GUIDToAssetPath(
           AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
+      material.shader = FindCompatibleShader(_standardShaderName);
     } else {
-      material = new Material(Shader.Find("Standard"));
+      material = new Material(FindCompatibleShader(_standardShaderName));
     }
-    material.SetColor("_Color", albedo);
-    material.SetFloat("_Metallic", reflectance);
 
     // In order to convert the specular/shininess parameters into glossiness/roughness,
     // we perform a coarse approximation.
@@ -245,7 +244,7 @@ public class MjImporterWithAssets : MjcfImporter {
     // Instead of modifying the Shininess parameter however, we're dirrectly modifying
     // the glossiness by bringing the value closer to the upper boundary.
     glossiness = (1.0f - reflectance) * glossiness + reflectance;
-    material.SetFloat("_Glossiness", glossiness);
+    ConfigureMujocoMaterial(material, albedo, reflectance, glossiness, rgba[3] < 1f);
 
     // We choose to define a simple emission model that only emits light, without scaling
     // the brightness of the defined color. If the user requires, they should tweak the material
@@ -283,10 +282,12 @@ public class MjImporterWithAssets : MjcfImporter {
             AssetDatabase.LoadMainAssetAtPath(
               AssetDatabase.GUIDToAssetPath(
                 AssetDatabase.FindAssets(_semiTransparentMaterialName)[0])) as Material);
+          material.shader = FindCompatibleShader(_standardShaderName);
         } else {
-          material = new Material(Shader.Find("Standard"));
+          material = new Material(FindCompatibleShader(_standardShaderName));
         }
-        material.color = new Color(rgba[0], rgba[1], rgba[2], rgba[3]);
+        ConfigureMujocoMaterial(
+          material, new Color(rgba[0], rgba[1], rgba[2], rgba[3]), transparent: rgba[3] < 1f);
         // We use the geom's name, guaranteed to be unique, as the asset name.
         // If geom is nameless, use a random number.
         var name =

--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -17,10 +17,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mujoco {
 // API for importing Mujoco XML files into Unity scenes.
 public class MjcfImporter {
+  protected const string _standardShaderName = "Standard";
+  protected const string _urpLitShaderName = "Universal Render Pipeline/Lit";
+
   // Any materials created at runtime will only be automatically cleaned up if no other objects
   // reference it AND Unity changes scenes. In long-running worlds with no scene resets, this means
   // those materials are never cleaned even after their MjBodies are destroyed, so we cache a
@@ -28,7 +32,7 @@ public class MjcfImporter {
   public static Material DefaultMujocoMaterial {
     get {
       if (_DefaultMujocoMaterial == null) {
-        _DefaultMujocoMaterial = new Material(Shader.Find("Standard"));
+        _DefaultMujocoMaterial = new Material(FindCompatibleShader(_standardShaderName));
       }
 
       return _DefaultMujocoMaterial;
@@ -57,6 +61,71 @@ public class MjcfImporter {
   }
 
   public MjcfImporter() {}
+
+  protected static Shader FindCompatibleShader(string builtInShaderName) {
+    if (IsUniversalRenderPipelineActive()) {
+      var urpLitShader = Shader.Find(_urpLitShaderName);
+      if (urpLitShader != null) {
+        return urpLitShader;
+      }
+    }
+
+    return Shader.Find(builtInShaderName);
+  }
+
+  private static bool IsUniversalRenderPipelineActive() {
+    var renderPipeline = GraphicsSettings.currentRenderPipeline;
+    return renderPipeline != null
+        && renderPipeline.GetType().Name.Contains("UniversalRenderPipelineAsset");
+  }
+
+  protected static void ConfigureMujocoMaterial(Material material, Color color, float metallic = 0f,
+      float smoothness = 0.5f, bool transparent = false) {
+    if (material.HasProperty("_Color")) {
+      material.SetColor("_Color", color);
+    }
+    if (material.HasProperty("_BaseColor")) {
+      material.SetColor("_BaseColor", color);
+    }
+    if (material.HasProperty("_Metallic")) {
+      material.SetFloat("_Metallic", metallic);
+    }
+    if (material.HasProperty("_Glossiness")) {
+      material.SetFloat("_Glossiness", smoothness);
+    }
+    if (material.HasProperty("_Smoothness")) {
+      material.SetFloat("_Smoothness", smoothness);
+    }
+    if (transparent) {
+      ConfigureTransparentMaterial(material);
+    }
+  }
+
+  protected static void ConfigureTransparentMaterial(Material material) {
+    if (material.shader == null || material.shader.name != _urpLitShaderName) {
+      return;
+    }
+
+    material.SetOverrideTag("RenderType", "Transparent");
+    if (material.HasProperty("_Surface")) {
+      material.SetFloat("_Surface", 1f);
+    }
+    if (material.HasProperty("_Blend")) {
+      material.SetFloat("_Blend", 0f);
+    }
+    if (material.HasProperty("_SrcBlend")) {
+      material.SetFloat("_SrcBlend", (float)BlendMode.SrcAlpha);
+    }
+    if (material.HasProperty("_DstBlend")) {
+      material.SetFloat("_DstBlend", (float)BlendMode.OneMinusSrcAlpha);
+    }
+    if (material.HasProperty("_ZWrite")) {
+      material.SetFloat("_ZWrite", 0f);
+    }
+    material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+    material.renderQueue = (int)RenderQueue.Transparent;
+  }
 
   public GameObject ImportString(string mjcfString, string name = null) {
     var mjcfXml = new XmlDocument();

--- a/unity/Tests/Editor/Importer/MjImporterTests.cs
+++ b/unity/Tests/Editor/Importer/MjImporterTests.cs
@@ -98,7 +98,11 @@ public class MjMaterialImportTests {
     Assert.That(meshRenderer.sharedMaterial, Is.Not.Null);
     Assert.That(meshRenderer.sharedMaterial.color, Is.EqualTo(new Color(0.7f, 0.5f, 0.3f, 0.1f)));
     Assert.That(meshRenderer.sharedMaterial.GetFloat("_Metallic"), Is.EqualTo(0.2f));
-    Assert.That(meshRenderer.sharedMaterial.GetFloat("_Glossiness"), Is.GreaterThan(0.0f));
+    var smoothnessProperty = meshRenderer.sharedMaterial.HasProperty("_Glossiness")
+        ? "_Glossiness"
+        : "_Smoothness";
+    Assert.That(meshRenderer.sharedMaterial.HasProperty(smoothnessProperty), Is.True);
+    Assert.That(meshRenderer.sharedMaterial.GetFloat(smoothnessProperty), Is.GreaterThan(0.0f));
   }
 
   [Test]


### PR DESCRIPTION
## Summary

Fixes #3273.

Updates the Unity MJCF importer to use a render-pipeline-compatible shader when creating imported materials. In URP projects, the importer now uses `Universal Render Pipeline/Lit` when available, instead of creating materials that render magenta until Unity's Render Pipeline Converter is run.

Built-in Render Pipeline behavior is preserved by falling back to the existing `Standard` shader path.

## Validation

- Reproduced the issue in Unity 6000.3.10f1 LTS using the Universal 3D / URP template.
- Imported `model/humanoid/humanoid.xml` and confirmed materials rendered magenta before the fix.
- Reimported after the fix and confirmed the model renders correctly without running Render Pipeline Converter.
- Reimported `model/balloons/balloons.xml` and confirmed it also renders correctly.
- Ran `git diff --check`.