### PR TITLE
Fix Unity importer material shader selection for URP compatibility

### DIFF
--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Mujoco {
 // API for importing Mujoco XML files into Unity scenes.
@@ -28,7 +29,13 @@ public class MjcfImporter {
   public static Material DefaultMujocoMaterial {
     get {
       if (_DefaultMujocoMaterial == null) {
-        _DefaultMujocoMaterial = new Material(Shader.Find("Standard"));
+        var shaderName = GetDefaultShaderName();
+        var shader = Shader.Find(shaderName);
+        if (shader == null) {
+          Debug.LogWarning($"Shader '{shaderName}' not found. Falling back to 'Standard'.");
+          shader = Shader.Find("Standard");
+        }
+        _DefaultMujocoMaterial = new Material(shader);
       }
 
       return _DefaultMujocoMaterial;
@@ -36,6 +43,24 @@ public class MjcfImporter {
     set {
       _DefaultMujocoMaterial = value;
     }
+  }
+
+  // Detects the active render pipeline and returns the appropriate default shader name.
+  private static string GetDefaultShaderName() {
+    var currentPipeline = GraphicsSettings.currentRenderPipeline;
+    if (currentPipeline != null) {
+      var pipelineType = currentPipeline.GetType().Name;
+      // Universal Render Pipeline (URP)
+      if (pipelineType.Contains("Universal")) {
+        return "Universal Render Pipeline/Lit";
+      }
+      // High Definition Render Pipeline (HDRP)
+      if (pipelineType.Contains("HDRenderPipeline")) {
+        return "HDRP/Lit";
+      }
+    }
+    // Built-in render pipeline (default)
+    return "Standard";
   }
 
   // Modifiers that change the settings of parsed nodes. They're limited to the scope of ParseRoot


### PR DESCRIPTION
The MuJoCo Unity importer was creating materials with the built-in "Standard" shader regardless of the active render pipeline. When importing MJCF models into a Universal Render Pipeline (URP) project, this caused materials to render magenta because the Standard shader is incompatible with URP.

The root cause is in `MjcfImporter.cs` at line 31, where `DefaultMujocoMaterial` always instantiated materials with `Shader.Find("Standard")` without detecting the active render pipeline.

The fix adds a `GetDefaultShaderName()` method that detects the active render pipeline using `GraphicsSettings.currentRenderPipeline` and returns the appropriate shader name: "Universal Render Pipeline/Lit" for URP, "HDRP/Lit" for HDRP, and "Standard" for the built-in pipeline. This ensures imported materials work correctly in URP and HDRP projects without requiring post-import material conversion.

Fixes #3273
