### PR TITLE
Tutorial: Fix qpos error

### DIFF
--- a/python/tutorial.ipynb
+++ b/python/tutorial.ipynb
@@ -1060,7 +1060,7 @@
     "  for i in range(n_steps):\n",
     "    mujoco.mj_step(model, data)\n",
     "    sim_time[i] = data.time\n",
-    "    angle[i] = data.joint('root').qpos\n",
+    "    angle[i] = data.joint('root').qpos.item()\n",
     "    energy[i] = data.energy[0] + data.energy[1]\n",
     "\n",
     "  # plot\n",


### PR DESCRIPTION
Fixes ValueError: setting an array element with a sequence.

Test Plan: Run tutorial.ipynb in jupyter lab and ensure all cells now run correctly