### PR TITLE
Fix set_to_muscle() to accept tuple arguments for timeconst and range

### DIFF
--- a/python/mujoco/specs.cc
+++ b/python/mujoco/specs.cc
@@ -1446,17 +1446,17 @@ PYBIND11_MODULE(_specs, m) {
       py::arg("diameter") = -1);
   mjsActuator.def(
       "set_to_muscle",
-      [](raw::MjsActuator* self, double timeconst[2], double tausmooth,
-         double range[2], double force, double scale, double lmin, double lmax,
+      [](raw::MjsActuator* self, std::array<double, 2> timeconst, double tausmooth,
+         std::array<double, 2> range, double force, double scale, double lmin, double lmax,
          double vmax, double fpmax, double fvmax) {
         std::string err =
-            mjs_setToMuscle(self, timeconst, tausmooth, range, force, scale,
+            mjs_setToMuscle(self, timeconst.data(), tausmooth, range.data(), force, scale,
                             lmin, lmax, vmax, fpmax, fvmax);
         if (!err.empty()) {
           throw pybind11::value_error(err);
         }
       },
-      py::arg("timeconst") = -1, py::arg("tausmooth"),
+      py::arg("timeconst") = std::array<double, 2>{-1, -1}, py::arg("tausmooth"),
       py::arg("range") = std::array<double, 2>{-1, -1}, py::arg("force") = -1,
       py::arg("scale") = -1, py::arg("lmin") = -1, py::arg("lmax") = -1,
       py::arg("vmax") = -1, py::arg("fpmax") = -1, py::arg("fvmax") = -1);

--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -1636,6 +1636,17 @@ class SpecsTest(absltest.TestCase):
     self.assertEqual(actuator.gainprm[7], 1.3)
     self.assertEqual(actuator.gainprm[8], 1.2)
 
+    # Verify biasprm matches gainprm (copied by set_to_muscle)
+    self.assertEqual(actuator.biasprm[0], 0.75)
+    self.assertEqual(actuator.biasprm[1], 1.05)
+    self.assertEqual(actuator.biasprm[2], -1.)
+    self.assertEqual(actuator.biasprm[3], 200.)
+    self.assertEqual(actuator.biasprm[4], 0.5)
+    self.assertEqual(actuator.biasprm[5], 1.6)
+    self.assertEqual(actuator.biasprm[6], 1.5)
+    self.assertEqual(actuator.biasprm[7], 1.3)
+    self.assertEqual(actuator.biasprm[8], 1.2)
+
     # Verify actuator type settings
     self.assertEqual(actuator.dyntype, mujoco.mjtDyn.mjDYN_MUSCLE)
     self.assertEqual(actuator.gaintype, mujoco.mjtGain.mjGAIN_MUSCLE)

--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -1602,6 +1602,45 @@ class SpecsTest(absltest.TestCase):
     self.assertEqual(actuator.gaintype, mujoco.mjtGain.mjGAIN_DCMOTOR)
     self.assertEqual(actuator.biastype, mujoco.mjtBias.mjBIAS_DCMOTOR)
 
+  def test_set_to_muscle(self):
+    spec = mujoco.MjSpec()
+    actuator = spec.add_actuator()
+
+    # Test with tuple/list arguments for timeconst and range
+    actuator.set_to_muscle(
+        timeconst=(0.01, 0.04),
+        tausmooth=0.,
+        range=(0.75, 1.05),
+        force=-1.,
+        scale=200.,
+        lmin=0.5,
+        lmax=1.6,
+        vmax=1.5,
+        fpmax=1.3,
+        fvmax=1.2
+    )
+
+    # Verify dynprm contains timeconst values
+    self.assertEqual(actuator.dynprm[0], 0.01)
+    self.assertEqual(actuator.dynprm[1], 0.04)
+    self.assertEqual(actuator.dynprm[2], 0.)
+
+    # Verify gainprm contains range and muscle parameters
+    self.assertEqual(actuator.gainprm[0], 0.75)
+    self.assertEqual(actuator.gainprm[1], 1.05)
+    self.assertEqual(actuator.gainprm[2], -1.)
+    self.assertEqual(actuator.gainprm[3], 200.)
+    self.assertEqual(actuator.gainprm[4], 0.5)
+    self.assertEqual(actuator.gainprm[5], 1.6)
+    self.assertEqual(actuator.gainprm[6], 1.5)
+    self.assertEqual(actuator.gainprm[7], 1.3)
+    self.assertEqual(actuator.gainprm[8], 1.2)
+
+    # Verify actuator type settings
+    self.assertEqual(actuator.dyntype, mujoco.mjtDyn.mjDYN_MUSCLE)
+    self.assertEqual(actuator.gaintype, mujoco.mjtGain.mjGAIN_MUSCLE)
+    self.assertEqual(actuator.biastype, mujoco.mjtBias.mjBIAS_MUSCLE)
+
   def test_bad_contact_sensor(self):
     test_cases = [
         dict(


### PR DESCRIPTION
The `set_to_muscle()` method in the Python bindings incorrectly declared `timeconst` and `range` parameters as C-style array pointers (`double timeconst[2]`), which prevented Python callers from passing tuples or lists as intended for musculoskeletal modeling. The underlying C function expects 2-element arrays representing min/max pairs, but the pybind11 binding only accepted scalar values.

Changed the lambda signature in `python/mujoco/specs.cc` to use `std::array<double, 2>` for both `timeconst` and `range` parameters, matching the pattern used in `set_to_dcmotor()`. Updated the default argument for `timeconst` from a scalar `-1` to `std::array<double, 2>{-1, -1}` for consistency. The arrays are correctly unpacked using `.data()` when calling the underlying `mjs_setToMuscle()` C function.

Added a test in `specs_test.py` that verifies tuple arguments are properly mapped to the `dynprm` and `gainprm` arrays, and that muscle actuator types are set correctly.

Fixes #3282
