### PR TITLE
Fix compilation error (error: assigning to 'char *' from 'const char *' discards qualifiers)

### DIFF
--- a/python/mujoco/indexer_xmacro.h
+++ b/python/mujoco/indexer_xmacro.h
@@ -273,7 +273,7 @@
   X( int,     tex_, height,   ntex,     1 ) \
   X( int,     tex_, width,    ntex,     1 ) \
   X( int,     tex_, nchannel, ntex,     1 ) \
-  X( int,     tex_, adr,      ntex,     1 ) \
+  X( mjtSize, tex_, adr,      ntex,     1 ) \
   X( mjtByte, tex_, data,     ntexdata, 1 )
 
 #define MJMODEL_TUPLE                         \

--- a/python/mujoco/indexer_xmacro.h
+++ b/python/mujoco/indexer_xmacro.h
@@ -273,7 +273,7 @@
   X( int,     tex_, height,   ntex,     1 ) \
   X( int,     tex_, width,    ntex,     1 ) \
   X( int,     tex_, nchannel, ntex,     1 ) \
-  X( mjtSize, tex_, adr,      ntex,     1 ) \
+  X( int,     tex_, adr,      ntex,     1 ) \
   X( mjtByte, tex_, data,     ntexdata, 1 )
 
 #define MJMODEL_TUPLE                         \

--- a/src/engine/engine_print.c
+++ b/src/engine/engine_print.c
@@ -480,7 +480,7 @@ static bool validateFloatFormat(const char* float_format) {
   // flag characters. allow at most one of each flag
   const char flag_characters[] = "-+ #0";
   int flag_character_counts[sizeof(flag_characters)] = { 0 };
-  char* c;
+  const char* c;
   while (c = strchr(flag_characters, float_format[cur_idx]), c != NULL) {
     int flag_idx = (c - flag_characters)/sizeof(char);
     flag_character_counts[flag_idx]++;


### PR DESCRIPTION
Fixes compilation error on **Fedora 44 (KDE)**, with **Clang 22.1.5**.

Without this fix, the following error is produced:

```
src/engine/engine_print.c:484:12: error: assigning to 'char *' from 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
  484 |   while (c = strchr(flag_characters, float_format[cur_idx]), c != NULL) {
      |            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

## To reproduce the compilation error without this change
1. Setup:
```
cmake -S . -B build     -DCMAKE_BUILD_TYPE:STRING=Release     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON     -DCMAKE_INSTALL_PREFIX:STRING="$(pwd)/mujoco_install"     -DMUJOCO_BUILD_EXAMPLES:BOOL=OFF     -DMUJOCO_BUILD_SIMULATE:BOOL=ON     -DMUJOCO_BUILD_TESTS=OFF     -DBUILD_SHARED_LIBS:BOOL=OFF     -G Ninja     -DCMAKE_C_COMPILER:STRING=clang     -DCMAKE_CXX_COMPILER:STRING=clang++
```
2. Compile: ``cmake --build build --parallel --target mujoco``