### PR TITLE
Validate sysid Parameter modifier; warn on silent no-op (#3286)

### DIFF
--- a/python/mujoco/sysid/_src/model_modifier.py
+++ b/python/mujoco/sysid/_src/model_modifier.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 
+from absl import logging
 import mujoco
 from mujoco.sysid._src.parameter import InertiaType
 from mujoco.sysid._src.parameter import ModifierFn
@@ -60,6 +61,24 @@ def _get_obj_or_raise(spec: mujoco.MjSpec, obj_type: str, obj_name: str) -> Any:
 def apply_param_modifiers_spec(
     params: ParameterDict, spec: mujoco.MjSpec
 ) -> mujoco.MjSpec:
+  # Warn (once per ParameterDict) about non-frozen parameters whose modifier
+  # is None: those values are present in the decision vector but never reach
+  # the spec, which produces a zero gradient and a 0-iteration optimize. A
+  # common cause is a modifier factory whose `return modifier` line is
+  # indented one level too deep, making the factory return None.
+  if not getattr(params, "_sysid_warned_none_modifier", False):
+    no_mod = [
+        p.name for p in params.values() if not p.frozen and p.modifier is None
+    ]
+    if no_mod:
+      logging.warning(
+          "Non-frozen sysid parameters have modifier=None and will not "
+          "affect the spec: %s. If you passed a factory like "
+          "make_X_modifier(...), verify the `return modifier` is at the "
+          "outer function's indent, not inside the inner closure.",
+          ", ".join(no_mod),
+      )
+      setattr(params, "_sysid_warned_none_modifier", True)
   for key in params.keys():
     param = params[key]
     if not param.frozen:

--- a/python/mujoco/sysid/_src/parameter.py
+++ b/python/mujoco/sysid/_src/parameter.py
@@ -75,6 +75,11 @@ class Parameter:
       frozen: bool = False,
       modifier: ModifierFn | None = None,
   ):
+    if modifier is not None and not callable(modifier):
+      raise TypeError(
+          f"Parameter '{name}': modifier must be callable or None, got "
+          f"{type(modifier).__name__}."
+      )
     self.name = name
     self.nominal = np.atleast_1d(nominal)
     self.min_value = np.atleast_1d(min_value)

--- a/python/mujoco/sysid/tests/test_model_modifier.py
+++ b/python/mujoco/sysid/tests/test_model_modifier.py
@@ -14,8 +14,11 @@
 # ==============================================================================
 """Tests for the model_modifier module."""
 
+import logging
+
 import mujoco
 from mujoco.sysid._src import model_modifier
+from mujoco.sysid._src import parameter
 import numpy as np
 
 
@@ -129,3 +132,47 @@ def test_apply_param_modifiers(box_spec, box_params):
   spec2 = box_spec.copy()
   result = model_modifier.apply_param_modifiers_spec(box_params, spec2)
   assert isinstance(result, mujoco.MjSpec)
+
+
+def test_apply_param_modifiers_warns_on_none_modifier(box_spec, caplog):
+  """Non-frozen parameters whose modifier is None trigger a warning naming them.
+
+  This catches the issue #3286 footgun: a modifier-factory whose `return modifier`
+  is misindented returns None, which silently no-ops at apply time and produces
+  a zero-gradient optimization.
+  """
+  params = parameter.ParameterDict()
+  params.add(parameter.Parameter("orphan_no_modifier", 1.0, 0.0, 2.0))
+
+  with caplog.at_level(logging.WARNING, logger="absl"):
+    model_modifier.apply_param_modifiers_spec(params, box_spec.copy())
+
+  assert any(
+      "orphan_no_modifier" in r.message and "modifier=None" in r.message
+      for r in caplog.records
+  ), "Expected a warning naming the parameter with modifier=None."
+
+  # Dedup: a second apply on the same ParameterDict does not re-warn.
+  caplog.clear()
+  with caplog.at_level(logging.WARNING, logger="absl"):
+    model_modifier.apply_param_modifiers_spec(params, box_spec.copy())
+  assert not any("modifier=None" in r.message for r in caplog.records), (
+      "Warning should fire at most once per ParameterDict instance."
+  )
+
+
+def test_apply_param_modifiers_silent_for_frozen_none_modifier(
+    box_spec, caplog
+):
+  """A frozen parameter with modifier=None is legitimate and must not warn."""
+  params = parameter.ParameterDict()
+  params.add(
+      parameter.Parameter("frozen_no_modifier", 1.0, 0.0, 2.0, frozen=True)
+  )
+
+  with caplog.at_level(logging.WARNING, logger="absl"):
+    model_modifier.apply_param_modifiers_spec(params, box_spec.copy())
+
+  assert not any("modifier=None" in r.message for r in caplog.records), (
+      "Did not expect a modifier=None warning for a frozen parameter."
+  )

--- a/python/mujoco/sysid/tests/test_parameter.py
+++ b/python/mujoco/sysid/tests/test_parameter.py
@@ -16,6 +16,7 @@
 
 from mujoco.sysid._src import parameter
 import numpy as np
+import pytest
 
 
 def test_scalar_parameter():
@@ -146,3 +147,22 @@ def test_frozen_param_excluded():
   np.testing.assert_array_equal(params["free"].value, [1.5])
   # Frozen param unchanged.
   np.testing.assert_array_equal(params["frozen"].value, [5.0])
+
+
+def test_modifier_must_be_callable_or_none():
+  """A non-callable, non-None modifier is rejected at construction."""
+  with pytest.raises(TypeError, match="bad_param"):
+    parameter.Parameter("bad_param", 1.0, 0.0, 2.0, modifier=42)  # type: ignore[arg-type]
+
+
+def test_modifier_callable_class_accepted():
+  """A class instance with __call__ is a valid modifier (not just plain functions)."""
+
+  class CallableMod:
+
+    def __call__(self, spec, param):
+      del spec, param
+
+  # No exception.
+  p = parameter.Parameter("p", 1.0, 0.0, 2.0, modifier=CallableMod())
+  assert callable(p.modifier)


### PR DESCRIPTION
In #3286, a user's modifier factory returned `None` because `return modifier` was indented one level too deep. `Parameter` accepted the `None` silently, so the parameter never reached the spec.

This PR adds two checks to prevent this silent footgun in the future:

- `Parameter.__init__` raises `TypeError` when `modifier` is non-None and not callable.
- `apply_param_modifiers_spec` warns once per `ParameterDict` when a non-frozen parameter has `modifier=None`, naming the parameter and pointing at the likely indentation cause.

Frozen parameters and custom `build_model` flows are unaffected.