### PR TITLE
MuJoCo Live: pre-fetch model assets in parallel before compilation.

### DIFF
--- a/src/experimental/studio/emscripten.cc
+++ b/src/experimental/studio/emscripten.cc
@@ -108,8 +108,9 @@ EM_ASYNC_JS(int, FetchUrl,
               }
             });
 
-// Cache for data fetched via HTTP/HTTPS. Stores the downloaded bytes keyed by
-// the resource name (URL) so that read() can return a pointer to the data.
+// Cache for data fetched via HTTP/HTTPS. Stores downloaded (or pre-primed)
+// bytes keyed by the resource URL so that the resource provider's read()
+// can return a pointer into stable storage.
 class FetchCache {
  public:
   static FetchCache& Instance() {
@@ -117,50 +118,63 @@ class FetchCache {
     return instance;
   }
 
-  // Fetches the URL and stores the result. Returns the size (>0) on success.
+  // Returns the size of the entry for `url`, fetching it over the network
+  // if necessary. Entries that have been pre-populated via Prime() are
+  // returned without touching the network. Returns 0 on fetch failure.
   int Fetch(const char* url) {
-    char* data = nullptr;
+    if (auto it = entries_.find(url); it != entries_.end()) {
+      return static_cast<int>(it->second.size());
+    }
+    char* buf = nullptr;
     std::int32_t size = 0;
-    if (!FetchUrl(url, &data, &size)) {
+    if (!FetchUrl(url, &buf, &size)) {
       return 0;
     }
-    entries_[url] = Entry{UniquePtrWasm<char[]>(data), size};
-    return size;
+    // FetchUrl hands us a malloc'd buffer; take ownership of the bytes via
+    // a std::string and release the original allocation.
+    std::string bytes(buf, size);
+    std::free(buf);
+    return static_cast<int>(entries_.emplace(url, std::move(bytes))
+                                .first->second.size());
   }
 
-  // Returns pointer and size for a previously fetched URL.
-  int Read(const char* url, const void** buffer) {
+  // Pre-populates the cache so a subsequent Fetch() of the same URL hits
+  // memory instead of the network. First writer wins.
+  void Prime(std::string url, std::string bytes) {
+    entries_.try_emplace(std::move(url), std::move(bytes));
+  }
+
+  // Hands back a pointer into the cached bytes for the given URL.
+  // Returns -1 if the URL has not been fetched or primed.
+  int Read(const char* url, const void** buffer) const {
     auto it = entries_.find(url);
-    if (it == entries_.end()) {
-      return -1;
-    }
-    *buffer = it->second.data.get();
-    return it->second.size;
+    if (it == entries_.end()) return -1;
+    *buffer = it->second.data();
+    return static_cast<int>(it->second.size());
   }
 
-  // Frees the data for a URL.
   void Close(const char* url) { entries_.erase(url); }
 
  private:
-  struct FreeDeleter {
-    void operator()(void* p) const { std::free(p); }
-  };
-  template <typename T>
-  using UniquePtrWasm = std::unique_ptr<T, FreeDeleter>;
-
-  struct Entry {
-    UniquePtrWasm<char[]> data;
-    int size;
-  };
-  std::unordered_map<std::string, Entry> entries_;
+  std::unordered_map<std::string, std::string> entries_;
 };
 
 // ---------------------------------------------------------------------------
 
-// Javascript-facing function to register an asset.
+// Javascript-facing function to register a build-time asset (font, IBL,
+// .filamat material) that is fetched via the static AssetRegistry rather
+// than over HTTP.
 void RegisterAsset(std::string filename, std::string contents) {
   AssetRegistry::Instance().RegisterAsset(std::move(filename),
                                           std::move(contents));
+}
+
+// Javascript-facing function to pre-populate the HTTP/HTTPS fetch cache.
+// Used by the JS-side parallel prefetcher to feed already-downloaded asset
+// bytes to MuJoCo's compiler before LoadUrl is invoked, sidestepping the
+// otherwise strictly-serial EM_ASYNC_JS fetch chain.
+void PrimeFetchCache(std::string url, std::string bytes) {
+  FetchCache::Instance().Prime(std::move(url), std::move(bytes));
 }
 
 // Javascript-facing function to initialize the app.
@@ -306,6 +320,7 @@ void Deinit() {
 
 EMSCRIPTEN_BINDINGS(studio_bindings) {
   emscripten::function("registerAsset", &RegisterAsset);
+  emscripten::function("primeFetchCache", &PrimeFetchCache);
   emscripten::function("init", &Init);
   emscripten::function("loadFile", &LoadFile);
   emscripten::function("loadUrl", &LoadUrl);

--- a/src/experimental/studio/live.js
+++ b/src/experimental/studio/live.js
@@ -21,6 +21,159 @@ function hideLoading() {
   loadingOverlay.style.display = 'none';
 }
 
+// ---------------------------------------------------------------------------
+// Parallel asset prefetcher.
+//
+// MuJoCo's XML compiler walks the model and synchronously opens every
+// referenced mesh / texture / include via mjpResourceProvider. In WASM that
+// becomes a chain of ASYNCIFY-suspended fetch() calls — strictly serial,
+// one RTT per asset. For Menagerie models that's ~80 round trips and ~10 s
+// of avoidable wall time on a cold cache.
+//
+// This module mirrors MuJoCo's resource-discovery rules in JavaScript
+// (xml_native_reader.cc, xml.cc): it fetches the root XML, recursively
+// follows <include>s, walks all file-bearing tags, resolves each path
+// against <compiler assetdir|meshdir|texturedir>, and feeds the bytes
+// into the WASM-side FetchCache via Module.primeFetchCache(). When
+// LoadUrl subsequently asks for any of those URLs, the resource provider
+// returns immediately from memory.
+//
+// Keep the scheme list and the file-bearing tags in sync with
+// src/experimental/studio/emscripten.cc and src/xml/xml_native_reader.cc.
+// ---------------------------------------------------------------------------
+
+// MuJoCo Live custom URL schemes that the C++ resource providers rewrite
+// before fetching. JS must do the same so primed cache keys match what
+// the provider eventually asks for.
+function resolveScheme(url) {
+  if (url.startsWith('github:')) {
+    return 'https://raw.githubusercontent.com/' + url.slice('github:'.length);
+  }
+  return url;
+}
+
+// Resolve `file` against a directory URL (one that ends with '/'). Handles
+// '..' segments and absolute URLs via the WHATWG URL parser.
+function resolveAgainst(file, baseDir) {
+  try {
+    return new URL(file, baseDir).href;
+  } catch {
+    return baseDir + file;  // fallback for unrecognised base schemes
+  }
+}
+
+const ASSET_TAGS = [
+  // tag       => attribute(s) + which compiler-dir its files resolve under.
+  { tag: 'mesh',     dir: 'mesh',    attrs: ['file'] },
+  { tag: 'hfield',   dir: 'asset',   attrs: ['file'] },
+  { tag: 'skin',     dir: 'asset',   attrs: ['file'] },
+  { tag: 'texture',  dir: 'texture', attrs: ['file', 'fileright', 'fileleft',
+                                              'fileup', 'filedown',
+                                              'filefront', 'fileback'] },
+  // <flexcomp file=...> and inline <model file=...> resolve against the
+  // *model* file directory, not assetdir.
+  { tag: 'flexcomp', dir: null,      attrs: ['file'] },
+  { tag: 'model',    dir: null,      attrs: ['file'] },
+];
+
+async function prefetchModelAssets(rootUrl, onProgress) {
+  const visited = new Set();   // dedupe by resolved http(s) URL
+  const stats = { files: 0, bytes: 0, errors: 0 };
+
+  // Fetch a single URL and prime it into the WASM-side cache.
+  // Returns the decoded text iff `decodeText` is true (used for XMLs);
+  // otherwise returns null. Idempotent on the visited set.
+  async function fetchAndPrime(httpUrl, decodeText) {
+    if (visited.has(httpUrl)) return null;
+    visited.add(httpUrl);
+    try {
+      const response = await fetch(httpUrl);
+      if (!response.ok) {
+        console.warn('[prefetch] HTTP', response.status, httpUrl);
+        stats.errors++;
+        return null;
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      Module.primeFetchCache(httpUrl, bytes);
+      stats.files++;
+      stats.bytes += bytes.length;
+      onProgress?.(stats);
+      return decodeText ? new TextDecoder().decode(bytes) : null;
+    } catch (err) {
+      console.warn('[prefetch] error', httpUrl, err);
+      stats.errors++;
+      return null;
+    }
+  }
+
+  // Resolve the effective {asset,mesh,texture} directory URLs for one
+  // XML document, given the dirs inherited from its parent (if any).
+  // Empty <compiler> attributes inherit from the parent; missing ones
+  // fall back to the corresponding assetdir (matching xml_native_reader.cc).
+  function compilerDirs(doc, baseDir, inherited) {
+    const compiler = doc.getElementsByTagName('compiler')[0];
+    const attr = (name) => {
+      const v = compiler?.getAttribute(name);
+      return v == null ? null : (v.endsWith('/') ? v : v + '/');
+    };
+    const asset = attr('assetdir');
+    const mesh = attr('meshdir');
+    const tex = attr('texturedir');
+    const assetDir = asset !== null ? resolveAgainst(asset, baseDir)
+                                    : inherited.asset ?? baseDir;
+    return {
+      asset: assetDir,
+      mesh:    mesh !== null ? resolveAgainst(mesh, baseDir)
+                             : inherited.mesh    ?? assetDir,
+      texture: tex  !== null ? resolveAgainst(tex,  baseDir)
+                             : inherited.texture ?? assetDir,
+    };
+  }
+
+  // Walk an already-fetched XML: schedule every referenced asset fetch in
+  // parallel, then recurse into <include>s. The included XML inherits the
+  // current dirs.
+  async function walk(httpUrl, xmlText, inheritedDirs) {
+    const doc = new DOMParser().parseFromString(xmlText, 'application/xml');
+    if (doc.documentElement.tagName === 'parsererror') {
+      console.warn('[prefetch] XML parse failed:', httpUrl);
+      return;
+    }
+    const baseDir = httpUrl.slice(0, httpUrl.lastIndexOf('/') + 1);
+    const dirs = compilerDirs(doc, baseDir, inheritedDirs);
+
+    const pending = [];
+    for (const { tag, dir, attrs } of ASSET_TAGS) {
+      const base = dir ? dirs[dir] : baseDir;
+      for (const el of doc.getElementsByTagName(tag)) {
+        for (const a of attrs) {
+          const file = el.getAttribute(a);
+          if (file) pending.push(fetchAndPrime(resolveAgainst(file, base), false));
+        }
+      }
+    }
+    for (const el of doc.getElementsByTagName('include')) {
+      const file = el.getAttribute('file');
+      if (!file) continue;
+      const child = resolveAgainst(file, baseDir);
+      // Fetch + walk in parallel with the binary fetches above.
+      pending.push((async () => {
+        const text = await fetchAndPrime(child, true);
+        if (text) await walk(child, text, dirs);
+      })());
+    }
+    await Promise.all(pending);
+  }
+
+  const rootHttp = resolveScheme(rootUrl);
+  const rootXml = await fetchAndPrime(rootHttp, true);
+  if (rootXml) {
+    await walk(rootHttp, rootXml,
+               { asset: null, mesh: null, texture: null });
+  }
+  return stats;
+}
+
 var Module = {
   preRun: [],
   postRun: [],
@@ -111,13 +264,26 @@ var Module = {
             // loop until the load completes, otherwise renderFrame will
             // hit "Cannot have multiple async operations in flight".
             showLoading();
+            // Update the loading screen's "Downloading asset file" line with
+            // live progress from the JS prefetcher.
+            const dlEl = document.getElementById('loadingDownload');
+            const dlFileEl = document.getElementById('loadingDownloadFile');
+            if (dlEl) dlEl.style.display = 'block';
+            const onProgress = (s) => {
+              if (dlFileEl) {
+                dlFileEl.textContent =
+                  `${s.files} files · ${(s.bytes/1024/1024).toFixed(1)} MB`;
+              }
+            };
             requestAnimationFrame(() => {
               requestAnimationFrame(async () => {
                 try {
+                  await prefetchModelAssets(modelUrl, onProgress);
                   await Module.loadUrl(modelUrl);
                 } catch (error) {
                   console.error('Failed to load model from URL:', error);
                 } finally {
+                  if (dlEl) dlEl.style.display = 'none';
                   hideLoading();
                   requestAnimationFrame(Module.animate);
                 }


### PR DESCRIPTION
MuJoCo's XML compiler synchronously opens each referenced asset (mesh, texture, include, etc.) via the registered `mjpResourceProvider`. In the WASM build that becomes a chain of `EM_ASYNC_JS` fetch/suspend/resume round trips, strictly serial, one RTT per asset. For a Menagerie scene that's 60-100 RTTs and many seconds of avoidable wall time on a cold cache.

This PR adds a JS-side prefetcher in `live.js` that walks the model XML before compilation. It mirrors MuJoCo's resource discovery rules from `src/xml/xml_native_reader.cc` and `src/xml/xml.cc`: rewrites the `github:` scheme to `https://raw.githubusercontent.com/...` so primed keys match what the C++ provider will request, walks `<compiler assetdir|meshdir|texturedir>` with inheritance into included files, enumerates `mesh`, `hfield`, `skin`, `texture` (plus the six cubemap face attributes), `flexcomp`, `model`, and `include`, recursing into includes. Every reference is fetched concurrently via `Promise.all` and fed into a new `Module.primeFetchCache(url, Uint8Array)` binding.

On the C++ side, `FetchCache` gains a `Prime(url, bytes)` method so the cache can be populated from JS, and its storage moves from `UniquePtrWasm<char[]>` to `std::string`, dropping the bespoke allocator wrappers. The network path is functionally equivalent.

Assets the prefetcher can't resolve (parse failure, unsupported scheme, HTTP 4xx) fall back to the existing `EM_ASYNC_JS` path with no behavioral change. Degradation is per-asset and silent, logged as `[prefetch]` warnings.

## Results

Measured on `anybotics_anymal_c/scene.xml` (89 fetches, ~71 MB) via headless Chromium:

| scenario           | before  | after  | speedup |
|--------------------|--------:|-------:|--------:|
| cold, no throttle  |  9.19 s | 2.29 s |   4.0 x |
| cold, slow-4g      | 19.80 s | 2.84 s |   7.0 x |
| warm, no throttle  |  1.27 s | 1.23 s | (WASM compute floor) |
| warm, slow-4g      |  1.31 s | 1.26 s | (WASM compute floor) |

Warm wall is unchanged because we've hit the WASM compute floor (XML parse, mesh decode, GPU upload, first render). Further reductions need profiling on the parser/scene side, not the network.

Verified end-to-end on `anybotics_anymal_c`, `unitree_g1`, and `shadow_hand`. All compile cleanly with the expected page title.
