### PR TITLE
Make mju_getXMLDependencies read XMLs through the resource provider.

### DIFF
--- a/src/xml/xml_util.cc
+++ b/src/xml/xml_util.cc
@@ -222,34 +222,46 @@ void mjCopyError(char* dst, const char* src, int maxlen) {
 }
 
 void mju_getXMLDependencies(const char* filename, mjStringVec* dependencies) {
-  // load XML file or parse string
-  tinyxml2::XMLDocument doc;
-  doc.LoadFile(filename);
-
-  // error checking
-  if (doc.Error()) {
-    mju_error("Problem reading XML file '%s': %s", filename, doc.ErrorStr());
+  // Open through the resource provider so the function works against any
+  // registered backend (OS file system, VFS, HTTP, "github:", ...) rather
+  // than only the OS file system.
+  mjResource* resource = mju_openResource("", filename, nullptr, nullptr, 0);
+  if (resource == nullptr) {
+    mju_error("Could not open '%s'", filename);
   }
 
-  // get top-level element
-  tinyxml2::XMLElement *root = doc.RootElement();
-  if (!root) {
-    mju_error("XML root element not found");
-  }
-  std::unordered_set<std::string> files = {filename};
-
-  std::optional<FilePath> model_dir = std::nullopt;
-  mjResource *resource = mju_openResource("", filename, nullptr,
-                                          nullptr, 0);
-  if (resource != nullptr) {
-    const char* dir;
-    int ndir;
-    mju_getResourceDir(resource, &dir, &ndir);
-    model_dir = FilePath(std::string(dir, ndir));
+  // Read the XML bytes and parse from buffer.
+  const void* buffer = nullptr;
+  int size = mju_readResource(resource, &buffer);
+  if (size < 0 || buffer == nullptr) {
     mju_closeResource(resource);
+    mju_error("Could not read '%s'", filename);
   }
-  // Get file references from include and model tags.
-  AccumulateFiles(files, root, model_dir.value());
+
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLError err =
+      doc.Parse(static_cast<const char*>(buffer), static_cast<size_t>(size));
+  if (err != tinyxml2::XML_SUCCESS) {
+    std::string msg = doc.ErrorStr() ? doc.ErrorStr() : "";
+    mju_closeResource(resource);
+    mju_error("Problem reading XML file '%s': %s", filename, msg.c_str());
+  }
+
+  tinyxml2::XMLElement* root = doc.RootElement();
+  if (!root) {
+    mju_closeResource(resource);
+    mju_error("XML root element not found in '%s'", filename);
+  }
+
+  // Capture the model directory while the resource is still open.
+  const char* dir = nullptr;
+  int ndir = 0;
+  mju_getResourceDir(resource, &dir, &ndir);
+  FilePath model_dir(std::string(dir, ndir));
+  mju_closeResource(resource);
+
+  std::unordered_set<std::string> files = {filename};
+  AccumulateFiles(files, root, model_dir);
 
   *dependencies = {files.begin(), files.end()};
 }

--- a/test/xml/xml_utils_test.cc
+++ b/test/xml/xml_utils_test.cc
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <mujoco/mjplugin.h>
 #include <mujoco/mujoco.h>
 #include "test/fixture.h"
 
@@ -41,6 +44,65 @@ TEST_F(MujocoTest, GetXMLDependenciesTest) {
   std::set<std::string> expected_dependency_set{kModelPaths.begin(),
                                                 kModelPaths.end()};
   EXPECT_EQ(dependency_set, expected_dependency_set);
+}
+
+// Custom resource provider that serves XML strings from an in-memory map,
+// used to exercise the non-filesystem code path.
+namespace memxml {
+static const std::map<std::string, std::string>* g_files = nullptr;
+
+int Open(mjResource* resource) {
+  return g_files && g_files->count(resource->name) ? 1 : 0;
+}
+int Read(mjResource* resource, const void** buffer) {
+  auto it = g_files->find(resource->name);
+  if (it == g_files->end()) return -1;
+  *buffer = it->second.data();
+  return static_cast<int>(it->second.size());
+}
+void Close(mjResource* resource) {}
+}  // namespace memxml
+
+// Verifies mju_getXMLDependencies works against a non-filesystem resource
+// provider (the case the WASM/HTTP build relies on).
+TEST_F(MujocoTest, GetXMLDependenciesViaResourceProvider) {
+  const std::map<std::string, std::string> files = {
+      {"memxml:/scene.xml",
+       "<mujoco>\n"
+       "  <include file=\"child.xml\"/>\n"
+       "  <compiler meshdir=\"meshes\"/>\n"
+       "  <asset>\n"
+       "    <mesh name=\"m\" file=\"m.obj\"/>\n"
+       "  </asset>\n"
+       "</mujoco>"},
+      {"memxml:/child.xml",
+       "<mujoco>\n"
+       "  <asset>\n"
+       "    <texture name=\"t\" type=\"2d\" file=\"t.png\"/>\n"
+       "  </asset>\n"
+       "</mujoco>"},
+  };
+  memxml::g_files = &files;
+
+  mjpResourceProvider provider = {
+      .prefix = "memxml",
+      .open = memxml::Open,
+      .read = memxml::Read,
+      .close = memxml::Close,
+  };
+  ASSERT_GT(mjp_registerResourceProvider(&provider), 0);
+
+  mjStringVec dependencies;
+  mju_getXMLDependencies("memxml:/scene.xml", &dependencies);
+  std::set<std::string> dep_set(dependencies.begin(), dependencies.end());
+
+  EXPECT_THAT(dep_set, testing::UnorderedElementsAre(
+      "memxml:/scene.xml",
+      "memxml:/child.xml",
+      "memxml:/meshes/m.obj",
+      "memxml:/t.png"));
+
+  memxml::g_files = nullptr;
 }
 }  // namespace
 }  // namespace mujoco


### PR DESCRIPTION
`mju_getXMLDependencies` previously read its XML through tinyxml2's `doc.LoadFile`, restricting it to the OS file system. Any caller that supplied a URL or VFS-backed resource name would fail before the function ever consulted the resource provider it nonetheless opened for `mju_getResourceDir`.

This change reads the XML bytes via `mju_openResource` + `mju_readResource` and parses them from buffer, so the function now works against any registered resource provider (VFS, HTTP, `github:`, ...). The recursive call into included XMLs naturally inherits the same behavior. The OS file-system path is unchanged because the default file provider already handles plain filenames.

This is a prerequisite for a follow-up that uses `mju_getXMLDependencies` from JavaScript in MuJoCo Live to drive parallel asset prefetching, instead of duplicating XML discovery rules in `live.js`.

## Testing

The existing `GetXMLDependenciesTest` exercises the OS-file-system path and still passes unchanged. A new `GetXMLDependenciesViaResourceProvider` test registers a custom in-memory provider with prefix `memxml`, then verifies that `mju_getXMLDependencies` walks an XML served through that provider, follows an `<include>`, applies `<compiler meshdir>`, and returns the full set of dependent URLs.
