### PR TITLE
Fix flex contact filtering compaction

### DIFF
--- a/src/engine/engine_collision_driver.c
+++ b/src/engine/engine_collision_driver.c
@@ -398,7 +398,7 @@ mjSORT(contactSort, mjContact, contactcompare);
 
 
 // filter flex contacts based on distance
-static void filterFlexContacts(mjData* d, int ncon_before) {
+MJAPI void mj_filterFlexContacts(mjData* d, int ncon_before) {
   int n = d->ncon - ncon_before;
   if (n <= mjMAXCONPAIR) {
     return;
@@ -407,6 +407,7 @@ static void filterFlexContacts(mjData* d, int ncon_before) {
   mjContact* contacts = d->contact + ncon_before;
 
   mj_markStack(d);
+  mjContact* selected_contacts = mjSTACKALLOC(d, mjMAXCONPAIR, mjContact);
   mjtByte* selected = mjSTACKALLOC(d, n, mjtByte);
   mjtNum* min_dist = mjSTACKALLOC(d, n, mjtNum);
   memset(selected, 0, n);
@@ -428,7 +429,8 @@ static void filterFlexContacts(mjData* d, int ncon_before) {
 
   while (nselected < mjMAXCONPAIR && best >= 0) {
     selected[best] = 1;
-    mjtNum* bestpos = contacts[best].pos;
+    selected_contacts[nselected] = contacts[best];
+    const mjtNum* bestpos = contacts[best].pos;
 
     int nextbest = -1;
     mjtNum nextbestdist = -1;
@@ -448,18 +450,12 @@ static void filterFlexContacts(mjData* d, int ncon_before) {
       }
     }
 
-    if (nselected < mjMAXCONPAIR - 1) {
-      mjContact temp = contacts[nselected];
-      contacts[nselected] = contacts[best];
-      contacts[best] = temp;
-
-      if (nextbest == nselected) {
-        nextbest = best;
-      }
-    }
-
     nselected++;
     best = nextbest;
+  }
+
+  for (int i = 0; i < nselected; i++) {
+    contacts[i] = selected_contacts[i];
   }
 
   mj_freeStack(d);
@@ -654,7 +650,7 @@ void mj_collision(const mjModel* m, mjData* d) {
 
       // filter flex contacts (limit per geom-flex or flex-flex pair)
       if (bf1 >= nbody || bf2 >= nbody) {
-        filterFlexContacts(d, ncon_before);
+        mj_filterFlexContacts(d, ncon_before);
         ncon_after = d->ncon;
       }
 
@@ -709,7 +705,7 @@ void mj_collision(const mjModel* m, mjData* d) {
           if (m->geom_type[g] == mjGEOM_PLANE) {
             int ncon_before = d->ncon;
             mj_collidePlaneFlex(m, d, g, f);
-            filterFlexContacts(d, ncon_before);
+            mj_filterFlexContacts(d, ncon_before);
             continue;
           }
 
@@ -717,7 +713,7 @@ void mj_collision(const mjModel* m, mjData* d) {
           if (m->geom_type[g] == mjGEOM_SDF) {
             int ncon_before = d->ncon;
             mj_collideSdfFlex(m, d, g, f);
-            filterFlexContacts(d, ncon_before);
+            mj_filterFlexContacts(d, ncon_before);
             continue;
           }
 
@@ -727,7 +723,7 @@ void mj_collision(const mjModel* m, mjData* d) {
           for (int e=0; e < elemnum; e++) {
             mj_collideGeomElem(m, d, g, f, e);
           }
-          filterFlexContacts(d, ncon_before);
+          mj_filterFlexContacts(d, ncon_before);
         }
         // realign the arena after adding contacts
         parena = alignArena(d, _Alignof(int));
@@ -751,7 +747,7 @@ void mj_collision(const mjModel* m, mjData* d) {
             mj_collideElems(m, d, f1, e1, f2, e2);
           }
         }
-        filterFlexContacts(d, ncon_before);
+        mj_filterFlexContacts(d, ncon_before);
 
         // realign the arena after adding contacts
         parena = alignArena(d, _Alignof(int));
@@ -785,7 +781,7 @@ void mj_collision(const mjModel* m, mjData* d) {
       if (m->flex_internal[f]) {
         int ncon_before = d->ncon;
         mj_collideFlexInternal(m, d, f);
-        filterFlexContacts(d, ncon_before);
+        mj_filterFlexContacts(d, ncon_before);
       }
 
       // active element collisions
@@ -819,7 +815,7 @@ void mj_collision(const mjModel* m, mjData* d) {
           }
         }
 
-        filterFlexContacts(d, ncon_before);
+        mj_filterFlexContacts(d, ncon_before);
       }
     }
   }

--- a/src/engine/engine_collision_driver.h
+++ b/src/engine/engine_collision_driver.h
@@ -68,6 +68,9 @@ void mj_collideElems(const mjModel* m, mjData* d, int f1, int e1, int f2, int e2
 // test element and vertex for collision, add to contact list
 void mj_collideElemVert(const mjModel* m, mjData* d, int f, int e, int v);
 
+// filter flex contacts to at most mjMAXCONPAIR using farthest-point sampling
+MJAPI void mj_filterFlexContacts(mjData* d, int ncon_before);
+
 
 #ifdef __cplusplus
 }

--- a/test/engine/engine_collision_driver_test.cc
+++ b/test/engine/engine_collision_driver_test.cc
@@ -23,10 +23,12 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <mujoco/mjdata.h>
 #include <mujoco/mjmodel.h>
 #include <mujoco/mujoco.h>
-#include "test/fixture.h"
 #include "src/engine/engine_collision_driver.h"
+#include "src/engine/engine_memory.h"
+#include "test/fixture.h"
 
 
 namespace mujoco {
@@ -50,6 +52,55 @@ static std::vector<GeomPair> colliding_pairs(
   }
   std::sort(result.begin(), result.end());
   return result;
+}
+
+static std::vector<mjContact> ReferenceFlexContacts(const mjContact* contacts,
+                                                    int ncontact,
+                                                    int max_select) {
+  std::vector<mjContact> selected_contacts;
+  selected_contacts.reserve(max_select);
+
+  std::vector<mjtByte> selected(ncontact, 0);
+  std::vector<mjtNum> min_dist(ncontact, mjMAXVAL);
+
+  int best = 0;
+  mjtNum bestdist = -contacts[0].dist;
+  for (int i = 1; i < ncontact; i++) {
+    if (-contacts[i].dist > bestdist) {
+      bestdist = -contacts[i].dist;
+      best = i;
+    }
+  }
+
+  while (selected_contacts.size() < max_select && best >= 0) {
+    selected[best] = 1;
+    selected_contacts.push_back(contacts[best]);
+    const mjtNum* bestpos = contacts[best].pos;
+
+    int nextbest = -1;
+    mjtNum nextbestdist = -1;
+    for (int i = 0; i < ncontact; i++) {
+      if (selected[i]) {
+        continue;
+      }
+
+      mjtNum dx = contacts[i].pos[0] - bestpos[0];
+      mjtNum dy = contacts[i].pos[1] - bestpos[1];
+      mjtNum dz = contacts[i].pos[2] - bestpos[2];
+      mjtNum d2 = dx*dx + dy*dy + dz*dz;
+      if (d2 < min_dist[i]) {
+        min_dist[i] = d2;
+      }
+      if (min_dist[i] > nextbestdist) {
+        nextbestdist = min_dist[i];
+        nextbest = i;
+      }
+    }
+
+    best = nextbest;
+  }
+
+  return selected_contacts;
 }
 
 TEST_F(MjCollisionTest, AllCollisions) {
@@ -132,6 +183,48 @@ TEST_F(MjCollisionTest, ContactCount) {
 
   // there are 8 spheres, all touching the floor
   EXPECT_EQ(d->ncon, 8);
+
+  mj_deleteData(d);
+  mj_deleteModel(m);
+}
+
+TEST_F(MjCollisionTest, FilterFlexContactsMatchesReferenceSelection) {
+  constexpr int kNumContacts = mjMAXCONPAIR + 1;
+  constexpr char xml[] = R"(
+  <mujoco>
+    <size memory="64K"/>
+  </mujoco>
+  )";
+
+  char error[1024];
+  mjModel* m = LoadModelFromString(xml, error, sizeof(error));
+  ASSERT_THAT(m, NotNull()) << error;
+  mjData* d = mj_makeData(m);
+  ASSERT_THAT(d, NotNull());
+
+  mjContact* contacts = static_cast<mjContact*>(
+      mj_arenaAllocByte(d, sizeof(mjContact) * kNumContacts, alignof(mjContact)));
+  ASSERT_THAT(contacts, NotNull());
+  ASSERT_EQ(contacts, d->contact);
+
+  d->ncon = kNumContacts;
+  for (int i = 0; i < kNumContacts; i++) {
+    mjContact contact = {};
+    contact.pos[0] = i;
+    contact.dist = -(((2 * i) % kNumContacts) + 1);
+    d->contact[i] = contact;
+  }
+
+  std::vector<mjContact> expected =
+      ReferenceFlexContacts(d->contact, kNumContacts, mjMAXCONPAIR);
+
+  mj_filterFlexContacts(d, 0);
+
+  EXPECT_EQ(d->ncon, mjMAXCONPAIR);
+  for (int i = 0; i < mjMAXCONPAIR; i++) {
+    EXPECT_MJTNUM_EQ(d->contact[i].pos[0], expected[i].pos[0]);
+    EXPECT_MJTNUM_EQ(d->contact[i].dist, expected[i].dist);
+  }
 
   mj_deleteData(d);
   mj_deleteModel(m);


### PR DESCRIPTION
Fixes #3297.

This changes the flex contact filtering pass so it no longer reorders `contacts[]` while the farthest-point sampling loop is still using index-based selection state.

Before this change, `mj_filterFlexContacts` could keep a different set of contacts than the one the selector actually picked. In the bad cases, the retained prefix after filtering could drop or replace the final selected contact.

What changed:
- keep the contacts selected by FPS in a temporary buffer
- compact the filtered prefix once at the end of the loop
- add a regression test that compares the helper against a small reference FPS implementation

Validation:
- ran `../build/bin/engine_collision_driver_test` from `test/`
