### PR TITLE
Accept numpy integers for rollout nstep and chunk_size

### DIFF
--- a/python/mujoco/rollout.py
+++ b/python/mujoco/rollout.py
@@ -130,9 +130,9 @@ class Rollout:
       raise ValueError('control_spec can only contain bits in mjSTATE_USER')
 
     # check types
-    if nstep and not isinstance(nstep, int):
+    if nstep and not isinstance(nstep, (int, np.integer)):
       raise ValueError('nstep must be an integer')
-    if chunk_size and not isinstance(chunk_size, int):
+    if chunk_size and not isinstance(chunk_size, (int, np.integer)):
       raise ValueError('chunk_size must be an integer')
     _check_must_be_numeric(
         initial_state=initial_state,

--- a/python/mujoco/rollout_test.py
+++ b/python/mujoco/rollout_test.py
@@ -732,6 +732,28 @@ class MuJoCoRolloutTest(parameterized.TestCase):
     ):
       rollout.rollout(model, data, initial_state, control)
 
+  def test_numpy_integer_nstep_and_chunk_size(self):
+    # nstep and chunk_size are commonly derived from numpy operations (e.g.
+    # array.shape[i]), which yield numpy integers. These are not instances of
+    # the Python `int` type, so they must be accepted explicitly.
+    model = mujoco.MjModel.from_xml_string(TEST_XML)
+    nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)
+    data = mujoco.MjData(model)
+    initial_state = np.zeros((1, nstate))
+
+    nstep = 3
+    state, _ = rollout.rollout(
+        model, data, initial_state, nstep=np.int64(nstep)
+    )
+    self.assertEqual(state.shape[1], nstep)
+
+    # chunk_size is also accepted as a numpy integer.
+    state, _ = rollout.rollout(
+        model, data, initial_state, nstep=np.int64(nstep),
+        chunk_size=np.int64(1)
+    )
+    self.assertEqual(state.shape[1], nstep)
+
   def test_bad_sizes(self):
     model = mujoco.MjModel.from_xml_string(TEST_XML)
     nstate = mujoco.mj_stateSize(model, mujoco.mjtState.mjSTATE_FULLPHYSICS)


### PR DESCRIPTION
## Problem

`rollout` rejects `nstep` and `chunk_size` arguments whose type is a numpy integer (e.g. `np.int64`):

```python
if nstep and not isinstance(nstep, int):
    raise ValueError('nstep must be an integer')
if chunk_size and not isinstance(chunk_size, int):
    raise ValueError('chunk_size must be an integer')
```

`isinstance(np.int64(3), int)` is `False`, so a numpy integer is rejected even though it is a valid integer. These values very commonly come from numpy operations (`array.shape[i]`, products of dimensions, `np.arange(...)[i]`, etc.), so this raises `ValueError: nstep must be an integer`:

```python
rollout.rollout(model, data, initial_state, nstep=np.int64(3))
```

while the identical call with a Python `int` works.

## Fix

Accept `numpy.integer` in addition to the built-in `int` for both checks (`numpy` is already imported as `np`). The downstream C++ call already handles the value numerically, so no other change is needed.

## Tests

Adds `test_numpy_integer_nstep_and_chunk_size`, which calls `rollout` with `np.int64` values for `nstep` and `chunk_size`. It fails before this change (`ValueError`) and passes after; the rest of `rollout_test.py` remains green.