### PR TITLE
Use box midpoint to choose finite-difference direction in jacobian_fd

### DIFF
--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -505,7 +505,7 @@ def jacobian_fd(
   if bounds is None:
     eps_vec = eps * np.ones((n, 1))
   else:
-    mid = 0.5 * (bounds[1] - bounds[0])
+    mid = 0.5 * (bounds[0] + bounds[1])
     eps_vec = np.where(x > mid, -eps, eps)
   eps_vec *= np.maximum(1.0, np.abs(x))
   eps_vec = (eps_vec + x) - x

--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -505,7 +505,7 @@ def jacobian_fd(
   if bounds is None:
     eps_vec = eps * np.ones((n, 1))
   else:
-    mid = 0.5 * (bounds[0] + bounds[1])
+    mid = 0.5 * bounds[0] + 0.5 * bounds[1]
     eps_vec = np.where(x > mid, -eps, eps)
   eps_vec *= np.maximum(1.0, np.abs(x))
   eps_vec = (eps_vec + x) - x

--- a/python/mujoco/minimize_test.py
+++ b/python/mujoco/minimize_test.py
@@ -156,28 +156,30 @@ class MinimizeTest(absltest.TestCase):
       with self.assertRaises(ValueError):
         minimize.least_squares(x0, residual, bounds=bounds, output=out)
 
-  def test_jacobian_fd_respects_off_center_bounds(self) -> None:
-    # jacobian_fd must step *away* from the nearer bound, i.e. compare x to the
-    # box midpoint (lo + hi) / 2. With x at the lower bound of an off-center box
-    # the finite-difference perturbation must step inward (+eps), keeping every
-    # residual evaluation inside the bounds.
-    lo, hi = 10.0, 20.0
-    bounds = [np.array([[lo]]), np.array([[hi]])]
-    x = np.array([[lo]])
+  def test_jacobian_fd_respects_bounds(self) -> None:
+    # jacobian_fd must step inward from whichever bound x sits on, which
+    # requires comparing x to the box midpoint (lo+hi)/2, not the half-width.
     eps = np.float64(np.finfo(np.float64).eps ** 0.5)
+    cases = {
+        'lower_positive_box': (10.0, 20.0, 10.0),
+        'upper_positive_box': (10.0, 20.0, 20.0),
+        'lower_negative_box': (-20.0, -10.0, -20.0),
+        'upper_negative_box': (-20.0, -10.0, -10.0),
+    }
+    for name, (lo, hi, x0) in cases.items():
+      with self.subTest(name):
+        bounds = [np.array([[lo]]), np.array([[hi]])]
+        x = np.array([[x0]])
+        evaluated = []
 
-    evaluated = []
+        def residual(xx, _ev=evaluated):
+          _ev.append(np.asarray(xx, dtype=np.float64).copy())
+          return np.atleast_2d(np.sum(xx, axis=0))
 
-    def residual(xx):
-      evaluated.append(np.asarray(xx, dtype=np.float64).copy())
-      return np.atleast_2d(np.sum(xx, axis=0))
-
-    r = residual(x)
-    minimize.jacobian_fd(residual, x, r, eps, 0, bounds)
-
-    all_points = np.concatenate([e.ravel() for e in evaluated])
-    self.assertGreaterEqual(all_points.min(), lo)
-    self.assertLessEqual(all_points.max(), hi)
+        minimize.jacobian_fd(residual, x, residual(x), eps, 0, bounds)
+        pts = np.concatenate([e.ravel() for e in evaluated])
+        self.assertGreaterEqual(pts.min(), lo)
+        self.assertLessEqual(pts.max(), hi)
 
   def test_iter_callback(self) -> None:
     def residual(x):

--- a/python/mujoco/minimize_test.py
+++ b/python/mujoco/minimize_test.py
@@ -156,6 +156,29 @@ class MinimizeTest(absltest.TestCase):
       with self.assertRaises(ValueError):
         minimize.least_squares(x0, residual, bounds=bounds, output=out)
 
+  def test_jacobian_fd_respects_off_center_bounds(self) -> None:
+    # jacobian_fd must step *away* from the nearer bound, i.e. compare x to the
+    # box midpoint (lo + hi) / 2. With x at the lower bound of an off-center box
+    # the finite-difference perturbation must step inward (+eps), keeping every
+    # residual evaluation inside the bounds.
+    lo, hi = 10.0, 20.0
+    bounds = [np.array([[lo]]), np.array([[hi]])]
+    x = np.array([[lo]])
+    eps = np.float64(np.finfo(np.float64).eps ** 0.5)
+
+    evaluated = []
+
+    def residual(xx):
+      evaluated.append(np.asarray(xx, dtype=np.float64).copy())
+      return np.atleast_2d(np.sum(xx, axis=0))
+
+    r = residual(x)
+    minimize.jacobian_fd(residual, x, r, eps, 0, bounds)
+
+    all_points = np.concatenate([e.ravel() for e in evaluated])
+    self.assertGreaterEqual(all_points.min(), lo)
+    self.assertLessEqual(all_points.max(), hi)
+
   def test_iter_callback(self) -> None:
     def residual(x):
       return np.stack([1 - x[0, :], 10 * (x[1, :] - x[0, :] ** 2)])


### PR DESCRIPTION
## Problem

In `minimize.py`, `jacobian_fd` chooses each coordinate's finite-difference direction so the perturbation steps *away* from the nearer bound. It compared `x` against

```python
mid = 0.5 * (bounds[1] - bounds[0])
eps_vec = np.where(x > mid, -eps, eps)
```

but `0.5 * (bounds[1] - bounds[0])` is half the box **width**, not the box midpoint. For bounds that are not centered on the origin this picks the wrong direction. Concretely, with `bounds = [10, 20]` the comparison value is `5.0` (true midpoint is `15.0`), so a point at the lower bound `x = 10` satisfies `x > 5` and steps **−eps**, i.e. to `9.9999998` — outside the box.

## Fix

Compare against the actual midpoint:

```python
mid = 0.5 * (bounds[0] + bounds[1])
```

At the lower bound the step is now `+eps` (inward); at the upper bound `−eps` (inward).

## Tests

Adds `test_jacobian_fd_respects_off_center_bounds`, which records every point `jacobian_fd` evaluates with `x` at the lower bound of the off-center box `[10, 20]` and asserts they all stay within `[lo, hi]`. It fails before this change (evaluates `9.9999998`) and passes after; the rest of `minimize_test.py` remains green.