### PR TITLE
Fix missing f-string prefix in `msh2obj` texcoord error message

### DIFF
--- a/python/mujoco/msh2obj.py
+++ b/python/mujoco/msh2obj.py
@@ -62,7 +62,7 @@ class Msh:
     if vertex_texcoords.size != 2 * ntexcoord:
       raise ValueError(
           f"Invalid number of texcoords: {vertex_texcoords.size} != "
-          "2*{ntexcoord}."
+          f"2*{ntexcoord}."
       )
     if face_vertex_indices.size != 3 * nface:
       raise ValueError(

--- a/python/mujoco/msh2obj_test.py
+++ b/python/mujoco/msh2obj_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for msh2obj.py."""
 
+import struct
+import tempfile
 
 from absl.testing import absltest
 from etils import epath
@@ -74,6 +76,19 @@ class MshTest(absltest.TestCase):
           atol=1e-6,
           err_msg=f"Field {field} does not match between msh and obj models.",
       )
+
+  def test_texcoord_size_mismatch_error_reports_expected_count(self) -> None:
+    # A .msh that declares ntexcoord=5 but supplies only 2 texcoord floats.
+    # The error message must report the expected count (2*5), not a literal
+    # "{ntexcoord}" placeholder.
+    header = struct.pack("<4i", 1, 0, 5, 0)  # nvertex, nnormal, ntexcoord, nface
+    body = struct.pack("<3f", 0.0, 0.0, 0.0)  # 1 vertex
+    body += struct.pack("<2f", 0.5, 0.5)  # only 2 texcoord floats (expected 10)
+    with tempfile.NamedTemporaryFile(suffix=".msh") as f:
+      f.write(header + body)
+      f.flush()
+      with self.assertRaisesRegex(ValueError, r"texcoords: 2 != 2\*5\."):
+        msh2obj.Msh.create(epath.Path(f.name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

In `msh2obj.py`, the texcoord-count validation in `Msh.create` spans two string literals, but only the first has an `f` prefix:

```python
if vertex_texcoords.size != 2 * ntexcoord:
    raise ValueError(
        f"Invalid number of texcoords: {vertex_texcoords.size} != "
        "2*{ntexcoord}."        # <-- missing f
    )
```

So the message emits the literal text `2*{ntexcoord}` instead of the expected count, e.g.:

```
Invalid number of texcoords: 2 != 2*{ntexcoord}.
```

rather than the intended `... != 2*5.`. The sibling `vertices`, `normals`, and `faces` messages interpolate correctly; only this one was missed.

## Fix

Add the `f` prefix to the continuation literal.

## Tests

Adds `test_texcoord_size_mismatch_error_reports_expected_count`, which feeds a `.msh` declaring `ntexcoord=5` but only 2 texcoord floats and asserts the error reports the computed count (`2 != 2*5.`). It fails before this change (the message contains the literal `{ntexcoord}`) and passes after; the rest of `msh2obj_test.py` remains green.