### PR TITLE
fix: fix USD loading for simulate (#3004, #3099)

### DIFF
--- a/simulate/main.cc
+++ b/simulate/main.cc
@@ -233,6 +233,12 @@ mjModel* LoadModel(const char* file, mj::Simulate& sim) {
     extension = filename_str.substr(dot_pos);
   }
 
+  std::string content_type;
+  if (extension == ".usd" || extension == ".usda" ||
+      extension == ".usdc" || extension == ".usdz") {
+    content_type = "model/usd";
+  }
+
   if (extension == ".mjb") {
     mnew = mj_loadModel(filename, nullptr);
     if (!mnew) {
@@ -241,7 +247,9 @@ mjModel* LoadModel(const char* file, mj::Simulate& sim) {
   } else if (extension == ".xml") {
     mnew = mj_loadXML(filename, nullptr, loadError, kErrorLength);
   } else {
-    mjSpec* spec = mj_parse(filename, nullptr, nullptr, loadError, kErrorLength);
+    mjSpec* spec = mj_parse(
+        filename, content_type.empty() ? nullptr : content_type.c_str(), nullptr,
+        loadError, kErrorLength);
     if (!spec) {
       mju::strcpy_arr(loadError, "could not parse model");
     } else {

--- a/src/user/user_util.cc
+++ b/src/user/user_util.cc
@@ -1038,6 +1038,11 @@ std::string mjuu_extToContentType(std::string_view filename) {
     return "model/obj";
   } else if (!strcasecmp(ext.c_str(), ".ply")) {
     return "model/ply";
+  } else if (!strcasecmp(ext.c_str(), ".usd") ||
+             !strcasecmp(ext.c_str(), ".usda") ||
+             !strcasecmp(ext.c_str(), ".usdc") ||
+             !strcasecmp(ext.c_str(), ".usdz")) {
+    return "model/usd";
   } else if (!strcasecmp(ext.c_str(), ".msh")) {
     return "model/vnd.mujoco.msh";
   } else if (!strcasecmp(ext.c_str(), ".png")) {


### PR DESCRIPTION
Route USD file extensions through the USD decoder and   content-type mapping so drag-and-drop loads .usd/.usda/.usdc/.usdz instead of falling back to XML. #3004, #3099 
