### PR TITLE
Include user sensor dimensions in model signature

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -5481,7 +5481,10 @@ uint64_t mjCModel::Signature() {
     tree << "<actuator/>\n";
   }
   for (unsigned int i = 0; i < sensors_.size(); ++i) {
-    tree << "<sensor>" << std::to_string(sensors_[i]->spec.type) << "<sensor/>\n";
+    tree << "<sensor>"
+         << std::to_string(sensors_[i]->spec.type) << " "
+         << std::to_string(sensors_[i]->spec.dim)
+         << "<sensor/>\n";
   }
   for (unsigned int i = 0; i < keys_.size(); ++i) {
     tree << "<key/>\n";

--- a/test/user/user_objects_test.cc
+++ b/test/user/user_objects_test.cc
@@ -625,6 +625,36 @@ TEST_F(SensorTest, OjbtypeParsedButNotRequired) {
   mj_deleteModel(model);
 }
 
+TEST_F(SensorTest, UserSensorDimAffectsModelSignature) {
+  static constexpr char xml1[] = R"(
+  <mujoco>
+    <sensor>
+      <user name="user_sensor" dim="100"/>
+    </sensor>
+  </mujoco>
+  )";
+
+  static constexpr char xml2[] = R"(
+  <mujoco>
+    <sensor>
+      <user name="user_sensor" dim="200"/>
+    </sensor>
+  </mujoco>
+  )";
+
+  mjModel* model1 = LoadModelFromString(xml1, nullptr, 0);
+  mjModel* model2 = LoadModelFromString(xml2, nullptr, 0);
+
+  ASSERT_THAT(model1, NotNull());
+  ASSERT_THAT(model2, NotNull());
+  EXPECT_EQ(model1->nsensordata, 100);
+  EXPECT_EQ(model2->nsensordata, 200);
+  EXPECT_NE(model1->signature, model2->signature);
+
+  mj_deleteModel(model1);
+  mj_deleteModel(model2);
+}
+
 TEST_F(SensorTest, NegativeIntervalError) {
   static constexpr char xml[] = R"(
   <mujoco>


### PR DESCRIPTION
## Summary

Fixes #3307.

`mjCModel::Signature()` currently includes each sensor's type, but not its dimension. For `mjSENS_USER`, the sensor `dim` directly affects `nsensordata` and therefore the compiled model memory layout. This meant two models with different user sensor dimensions could incorrectly share the same model signature.

This PR includes sensor `dim` in the model signature and adds a regression test for user sensors with different dimensions.

## Changes

- Include `sensor.spec.dim` when hashing sensors in `mjCModel::Signature()`.
- Add a regression test verifying that two `mjSENS_USER` sensors with different dimensions produce different model signatures.

## Test

```bash
./build-appleld/bin/user_objects_test --gtest_filter=SensorTest.UserSensorDimAffectsModelSignature