### PR TITLE
Fix out-of-bounds access on invalid mjvCamera->fixedcamid

### DIFF
--- a/src/engine/engine_vis_visualize.c
+++ b/src/engine/engine_vis_visualize.c
@@ -2952,16 +2952,16 @@ void mjv_updateCamera(const mjModel* m, const mjData* d, mjvCamera* cam, mjvScen
     mju_copy3(cam->lookat, d->subtree_com + 3*bid);
   }
 
-  // get camera frame
-  mjtNum headpos[3], forward[3], up[3], right[3];
-  mjv_cameraFrame(headpos, forward, up, right, d, cam);
-
-  // get camera frustum
+  // get camera frustum; for a fixed camera this validates fixedcamid
   float zver[2], zhor[2], zclip[2] = {0, 0};
   mjv_cameraFrustum(zver, zhor, zclip, m, cam);
 
+  // get camera frame (fixedcamid already validated by mjv_cameraFrustum above)
+  mjtNum headpos[3], forward[3], up[3], right[3];
+  mjv_cameraFrame(headpos, forward, up, right, d, cam);
+
   // get ipd, orthographic
-  int cid, orthographic = 0;
+  int orthographic = 0;
   mjtNum ipd;
 
   switch (cam->type) {
@@ -2970,15 +2970,13 @@ void mjv_updateCamera(const mjModel* m, const mjData* d, mjvCamera* cam, mjvScen
     ipd = m->vis.global.ipd;
     orthographic = m->vis.global.orthographic;
     break;
-  case mjCAMERA_FIXED:
-    // get id, check range
-    cid = cam->fixedcamid;
-    if (cid < 0 || cid >= m->ncam) {
-      mjERROR("fixed camera id is outside valid range");
-    }
+  case mjCAMERA_FIXED: {
+    // fixedcamid range already validated by mjv_cameraFrustum
+    int cid = cam->fixedcamid;
     ipd = m->cam_ipd[cid];
     orthographic = m->cam_projection[cid] == mjPROJ_ORTHOGRAPHIC;
     break;
+  }
 
   default:
     mjERROR("unknown camera type");


### PR DESCRIPTION
The `mjv_updateCamera` method currently does bound checking for the `fixedcamid` only after calling both `mjv_cameraFrame` and `mjv_cameraFrustum`. Unlike  `mjv_cameraFrustum`, the `mjv_cameraFrame` method does not do bound checking for the `fixedcamid`, which results in  **out-of-bounds access and thus undefined behavior**, when `fixedcamid` is outside the valid range.

While the program will exit in error via `mjERROR` most of the time, this is still undefined behavior and can lead to random segmentation faults with no clear errors about what happened.

This pull request fixes this by reordering the method calls, resulting in the fixed camera's ID being checked prior to first indexing. A redundant check was also removed in `mjv_updateCamera`, because `mjv_cameraFrustum` already does the checking.