### PR TITLE
python: restore CGL→GLFW fallback on macOS for missing CGLSetCurrentContext

### DIFF
--- a/python/mujoco/rendering/classic/gl_context.py
+++ b/python/mujoco/rendering/classic/gl_context.py
@@ -41,7 +41,13 @@ if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
     from mujoco.egl import GLContext as _GLContext
     GLContext = _GLContext
   elif _SYSTEM == 'Darwin':
-    from mujoco.cgl import GLContext as _GLContext
+    if _MUJOCO_GL == 'glfw':
+      from mujoco.glfw import GLContext as _GLContext
+    else:
+      try:
+        from mujoco.cgl import GLContext as _GLContext
+      except Exception:  # CGLSetCurrentContext may be absent on newer macOS
+        from mujoco.glfw import GLContext as _GLContext
     GLContext = _GLContext
   else:
     from mujoco.glfw import GLContext as _GLContext


### PR DESCRIPTION
On Darwin 25.x (macOS 16), CGLSetCurrentContext is no longer exported by Apple's OpenGL framework, causing an AttributeError when importing the CGL backend. MuJoCo 3.8.1 handled this with a try/except that fell back to GLFW; 3.9.0 dropped that guard. This restores the original fallback logic so that users on newer macOS releases are not broken by default.
