### PR TITLE
fix(python): restore CGL→GLFW fallback on macOS for missing CGLSetCurrentContext

### DIFF
--- a/python/mujoco/rendering/classic/gl_context.py
+++ b/python/mujoco/rendering/classic/gl_context.py
@@ -41,7 +41,13 @@ if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
     from mujoco.egl import GLContext as _GLContext
     GLContext = _GLContext
   elif _SYSTEM == 'Darwin':
-    from mujoco.cgl import GLContext as _GLContext
+    if _MUJOCO_GL == 'glfw':
+      from mujoco.glfw import GLContext as _GLContext
+    else:
+      try:
+        from mujoco.cgl import GLContext as _GLContext
+      except Exception:  # CGLSetCurrentContext may be absent on newer macOS
+        from mujoco.glfw import GLContext as _GLContext
     GLContext = _GLContext
   else:
     from mujoco.glfw import GLContext as _GLContext


### PR DESCRIPTION
**Problem**

On Darwin 25.x (macOS 16 beta), `CGLSetCurrentContext` is no longer exported
by Apple's OpenGL framework. Importing `mujoco` raises:

    AttributeError: dlsym(..., CGLSetCurrentContext): symbol not found

**Root cause**

MuJoCo 3.8.1 had a `try/except` around the CGL import that fell back to GLFW
when the CGL backend failed. That fallback was removed in 3.9.0, making 3.9.0
broken on macOS 16 by default.

**Fix**

Restore the original fallback logic in
`python/mujoco/rendering/classic/gl_context.py`:
- If `MUJOCO_GL=glfw` is set explicitly, use GLFW directly (no change).
- Otherwise, try CGL first; if it fails (e.g. missing symbol), fall back to GLFW.

**Tested on**

- macOS Darwin 25.x (macOS 16 beta)
- MuJoCo 3.9.0 (broken without patch, works with patch)
