### PR TITLE
Fix typos in documentation and code comments

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -3650,7 +3650,7 @@ saving the XML:
      for the entire flex, independent of the number of vertices. The positions of the vertices are updated using
      quadratic interpolation over the bounding box. While this option requires more degrees of freedom than trilinear
      flexes, it enables curved deformation modes, while the only modes achievable for trilinear flexes are
-     strech/compression and shear. To understand the difference between the two parametrizations, see `a trilinear cube
+     stretch/compression and shear. To understand the difference between the two parametrizations, see `a trilinear cube
      <https://github.com/google-deepmind/mujoco/blob/main/model/flex/trilinear.xml>`__ and `a quadratic cube
      <https://github.com/google-deepmind/mujoco/blob/main/model/flex/quadratic.xml>`__.
 

--- a/doc/_static/gyroscopic.xml
+++ b/doc/_static/gyroscopic.xml
@@ -7,7 +7,7 @@
 
   <statistic extent="1"/>
 
-  <!-- switch the integrator to "implicit" for better gyroscopic stabillity -->
+  <!-- switch the integrator to "implicit" for better gyroscopic stability -->
   <option timestep="0.01" integrator="implicitfast"/>
 
   <worldbody>

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -245,7 +245,7 @@ General
    :ref:`invdiscrete<option-flag-invdiscrete>` flag now also disables midpoint integration, providing an opt-out
    mechanism.
 5. Added the centripetal/Coriolis acceleration term :math:`\dot{J}v` to the constraint solver bias for
-   :ref:`connect<equality-connect>` and :ref:`weld<equality-weld>` equality constaints. This significantly improves the
+   :ref:`connect<equality-connect>` and :ref:`weld<equality-weld>` equality constraints. This significantly improves the
    stability of constrained mechanisms like four-bar linkages. See :ref:`Dual problem<soDual>` for details.
 
 6. Introduced :ref:`mjpEncoder`, the counterpart to :ref:`mjpDecoder` for encoding of :ref:`mjSpec` and :ref:`mjModel`

--- a/doc/computation/index.rst
+++ b/doc/computation/index.rst
@@ -992,7 +992,7 @@ as defined later. The ``condim`` parameter determines the contact type, and has 
    rolling friction, which can be used for example to stop a ball from rolling indefinitely on a plane. Rolling friction
    in the real world results from energy dissipated by local deformations near the contact point. It can be
    used to model rolling friction between tires and a road, and in general to stabilize contacts. Rolling friction
-   coefficients also have **units of length** which can be interperted as the depth of the local deformation within
+   coefficients also have **units of length** which can be interpreted as the depth of the local deformation within
    which energy is dissipated.
 
 Note that condim cannot be 2 or 5. This is because the two tangential directions and the two rolling directions are

--- a/src/render/classic/render_util.c
+++ b/src/render/classic/render_util.c
@@ -191,7 +191,7 @@ void mjr_perspective(float fovy, float aspect, float znear, float zfar) {
   h = tan((double)fovy / 360.0 * mjPI) * (double)znear;
   w = h * (double)aspect;
 
-  // make symmetric frustrum
+  // make symmetric frustum
   glFrustum(-w, w, -h, h, (double)znear, (double)zfar);
 }
 


### PR DESCRIPTION
This PR fixes five spelling errors in the documentation and one code comment. No functional changes.

| File | Fix |
|------|-----|
| `doc/XMLreference.rst` | `strech` → `stretch` |
| `doc/computation/index.rst` | `interperted` → `interpreted` |
| `doc/_static/gyroscopic.xml` | `stabillity` → `stability` |
| `doc/changelog.rst` | `constaints` → `constraints` |
| `src/render/classic/render_util.c` | `frustrum` → `frustum` (comment) |

These were found with `codespell`. Each was verified in context — notably, the `inteval` occurrence in `doc/changelog.rst` was intentionally left untouched because it documents the historical correction of a misspelled attribute name.
