### PR TITLE
Fix Unity importer material compatibility for URP and HDRP

### DIFF
--- a/unity/Runtime/Importer/MjcfImporter.cs
+++ b/unity/Runtime/Importer/MjcfImporter.cs
@@ -28,7 +28,7 @@ public class MjcfImporter {
   public static Material DefaultMujocoMaterial {
     get {
       if (_DefaultMujocoMaterial == null) {
-        _DefaultMujocoMaterial = new Material(Shader.Find("Standard"));
+        _DefaultMujocoMaterial = new Material(GetCompatibleShader());
       }
 
       return _DefaultMujocoMaterial;
@@ -36,6 +36,32 @@ public class MjcfImporter {
     set {
       _DefaultMujocoMaterial = value;
     }
+  }
+
+  // Detects the active render pipeline and returns a compatible shader.
+  private static Shader GetCompatibleShader() {
+    var currentPipeline = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline;
+    if (currentPipeline != null) {
+      var pipelineType = currentPipeline.GetType().ToString();
+      // Check for URP
+      if (pipelineType.Contains("UniversalRenderPipelineAsset") ||
+          pipelineType.Contains("Universal")) {
+        var urpShader = Shader.Find("Universal Render Pipeline/Lit");
+        if (urpShader != null) {
+          return urpShader;
+        }
+      }
+      // Check for HDRP
+      if (pipelineType.Contains("HDRenderPipelineAsset") ||
+          pipelineType.Contains("HighDefinition")) {
+        var hdrpShader = Shader.Find("HDRP/Lit");
+        if (hdrpShader != null) {
+          return hdrpShader;
+        }
+      }
+    }
+    // Fall back to Standard shader for built-in pipeline
+    return Shader.Find("Standard");
   }
 
   // Modifiers that change the settings of parsed nodes. They're limited to the scope of ParseRoot


### PR DESCRIPTION
The Unity MJCF importer previously hard-coded the Standard shader when creating materials, causing imported models to render magenta in URP and HDRP projects. This happened because the Standard shader is only compatible with Unity's built-in render pipeline.

This change adds render pipeline detection in `MjcfImporter.cs` in the `DefaultMujocoMaterial` property getter. The new `GetCompatibleShader()` method checks `GraphicsSettings.currentRenderPipeline` and returns the appropriate shader: `Universal Render Pipeline/Lit` for URP, `HDRP/Lit` for HDRP, or `Standard` for the built-in pipeline. Materials now render correctly without requiring post-import conversion.

Tested with sample models (humanoid.xml, balloons.xml) that previously required manual material upgrade in URP projects.

Fixes #3273
