### PR TITLE
fix: correct set_to_muscle() arg types from C arrays to std::array

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,6 +39,9 @@ General
 Bug fixes
 ^^^^^^^^^
 - Fixed a bug in the ``mjz`` :ref:`decoder <mjpDecoder>` where unnormalized paths would fail to be read.
+- Fixed Python ``MjsActuator.set_to_muscle`` ignoring the ``timeconst`` and ``range`` arguments. The pybind11 lambda
+  declared these as bare C arrays (``double[2]``) which decayed to pointers; they now use ``std::array<double, 2>``
+  consistent with the other array-valued setters (:issue:`3282`).
 
 Version 3.9.0 (May 27, 2026)
 ----------------------------

--- a/python/mujoco/specs.cc
+++ b/python/mujoco/specs.cc
@@ -1576,17 +1576,19 @@ PYBIND11_MODULE(_specs, m) {
       py::arg("diameter") = -1);
   mjsActuator.def(
       "set_to_muscle",
-      [](raw::MjsActuator* self, double timeconst[2], double tausmooth,
-         double range[2], double force, double scale, double lmin, double lmax,
-         double vmax, double fpmax, double fvmax) {
-        std::string err =
-            mjs_setToMuscle(self, timeconst, tausmooth, range, force, scale,
-                            lmin, lmax, vmax, fpmax, fvmax);
+      [](raw::MjsActuator* self, std::array<double, 2> timeconst,
+         double tausmooth, std::array<double, 2> range, double force,
+         double scale, double lmin, double lmax, double vmax, double fpmax,
+         double fvmax) {
+        std::string err = mjs_setToMuscle(self, timeconst.data(), tausmooth,
+                                          range.data(), force, scale, lmin,
+                                          lmax, vmax, fpmax, fvmax);
         if (!err.empty()) {
           throw pybind11::value_error(err);
         }
       },
-      py::arg("timeconst") = -1, py::arg("tausmooth"),
+      py::arg("timeconst") = std::array<double, 2>{-1, -1},
+      py::arg("tausmooth"),
       py::arg("range") = std::array<double, 2>{-1, -1}, py::arg("force") = -1,
       py::arg("scale") = -1, py::arg("lmin") = -1, py::arg("lmax") = -1,
       py::arg("vmax") = -1, py::arg("fpmax") = -1, py::arg("fvmax") = -1);


### PR DESCRIPTION
Closes #3282.

The pybind11 binding for `MjsActuator.set_to_muscle` declared `timeconst` and `range` as bare C arrays (`double[2]`), which pybind11 cannot properly handle for tuple/list defaults. Changed to `std::array<double, 2>` consistent with how `set_to_dcmotor` and other array-valued setters handle these parameters. The default for `timeconst` is now `{-1, -1}` matching the existing pattern for `range`.