### PR TITLE
fix: preserve batch dimension in model.bind() / data.bind()

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,6 +39,7 @@ General
 Bug fixes
 ^^^^^^^^^
 - Fixed a bug in the ``mjz`` :ref:`decoder <mjpDecoder>` where unnormalized paths would fail to be read.
+- Fixed a bug in ``model.bind()`` / ``data.bind()`` where the batch dimension was incorrectly squeezed when binding a single element (:issue:`3128`).
 
 Version 3.9.0 (May 27, 2026)
 ----------------------------

--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -161,6 +161,25 @@ def from_zip(file: Union[str, IO[bytes]]) -> _specs.MjSpec:
   return _specs.MjSpec.from_string(xml_string, assets=assets)
 
 
+def _accumulate_bind_item(items: list, value: Any) -> None:
+  """Adds a per-element attribute value to a batched bind result.
+
+  Scalar-valued attributes (e.g. ``qposadr`` for a hinge joint) are flattened
+  into ``items`` to preserve the historical dm_control-compatible layout. Array-
+  valued attributes (e.g. ``geom.size``) are kept as a leading batch dimension
+  so that a length-1 slice does not silently squeeze it away.
+  """
+  size = getattr(value, 'size', None)
+  if size is None or size == 1:
+    try:
+      items.extend(value)
+      return
+    except TypeError:
+      items.append(value)
+      return
+  items.append(value)
+
+
 class _MjBindModel:
   """Wrapper for MjModel that allows binding multiple specs."""
 
@@ -170,7 +189,7 @@ class _MjBindModel:
   def __getattr__(self, key: str):
     items = []
     for e in self.elements:
-      items.extend(getattr(e, key))
+      _accumulate_bind_item(items, getattr(e, key))
     return items
 
   def __setattr__(self, key: str, value: Any):
@@ -186,7 +205,7 @@ class _MjBindData:
   def __getattr__(self, key: str):
     items = []
     for e in self.elements:
-      items.extend(getattr(e, key))
+      _accumulate_bind_item(items, getattr(e, key))
     return items
 
   def __setattr__(self, key: str, value: Any):

--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -1489,6 +1489,17 @@ class SpecsTest(absltest.TestCase):
     np.testing.assert_array_equal(mj_model.bind(joint_box).qposadr, 7)
     np.testing.assert_array_equal(mj_data.bind(joints).qpos, [0, 0])
     np.testing.assert_array_equal(mj_model.bind(joints).qposadr, [7, 8])
+    # Length-1 slice preserves the batch dimension for array-valued attrs
+    # (issue #3128).
+    np.testing.assert_array_equal(
+        mj_model.bind(spec.geoms[0:1]).size, mj_model.geom_size[0:1]
+    )
+    np.testing.assert_array_equal(
+        mj_data.bind(spec.geoms[0:1]).xpos, mj_data.geom_xpos[0:1]
+    )
+    np.testing.assert_array_equal(
+        mj_model.bind(spec.geoms[0:2]).size, mj_model.geom_size[0:2]
+    )
     np.testing.assert_array_equal(mj_data.bind([]).qpos, [])
     np.testing.assert_array_equal(mj_model.bind([]).qposadr, [])
     mj_data.bind(joints).qpos = np.array([1, 2])


### PR DESCRIPTION
Closes #3128.

When binding a single-element slice (e.g. `model.bind(geoms[0:1])`), the `_MjBindModel` / `_MjBindData` wrappers extended array-valued attributes into a flat list, squeezing the batch dimension.

Added `_accumulate_bind_item` helper that appends array-valued attributes (size > 1) instead of extending, preserving the leading batch dimension. Scalar-valued attributes (`qposadr` etc.) are still flattened for dm_control compatibility.