### PR TITLE
Fix island disabled warp field dimension mismatch

### DIFF
--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -1307,6 +1307,10 @@ def _get_data_into_warp(
       if isinstance(value, np.ndarray) and value.shape:
         result_field = getattr(result_i, field.name)
         if result_field.shape != value.shape:
+          # When ENABLE_ISLANDS is False, mujoco_warp allocates island fields with width 0,
+          # while the host MjData sizes to nv/ntree. Skip to prevent mismatch.
+          if value.size == 0 and not mjxw.mjwp_io.ENABLE_ISLANDS:
+            continue
           raise ValueError(
               f'Input field {field.name} has shape {value.shape}, but output'
               f' has shape {result_field.shape}'

--- a/mjx/mujoco/mjx/_src/io_test.py
+++ b/mjx/mujoco/mjx/_src/io_test.py
@@ -799,7 +799,7 @@ class DataIOTest(parameterized.TestCase):
 
     # Use a model with at least one kinematic tree so that island
     # fields (e.g. dof_island, tree_island) are populated on the host
-    # MjData. 
+    # MjData.
     m = mujoco.MjModel.from_xml_string("""
       <mujoco>
         <worldbody>

--- a/mjx/mujoco/mjx/_src/io_test.py
+++ b/mjx/mujoco/mjx/_src/io_test.py
@@ -797,11 +797,29 @@ class DataIOTest(parameterized.TestCase):
     if not mjx_io.has_cuda_gpu_device():
       self.skipTest('No CUDA GPU device.')
 
-    m = mujoco.MjModel.from_xml_string('<mujoco></mujoco>')
+    # Use a model with at least one kinematic tree so that island
+    # fields (e.g. dof_island, tree_island) are populated on the host
+    # MjData. 
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <worldbody>
+          <body>
+            <freejoint/>
+            <geom size="0.1"/>
+          </body>
+        </worldbody>
+      </mujoco>
+    """)
     d = mujoco.MjData(m)
     mx = mjx.put_model(m, impl='warp')
     dx = mjx.make_data(m, impl='warp')
     mjx.get_data_into(d, mx, dx)
+
+    # Island data is not populated when ENABLE_ISLANDS is False, so the host
+    # MjData island fields should be left at their default (nv,)/(ntree,)
+    # shapes rather than triggering a shape mismatch.
+    self.assertEqual(d.dof_island.shape, (m.nv,))
+    self.assertEqual(d.tree_island.shape, (m.ntree,))
 
   @parameterized.parameters(('jax',))
   def test_get_data_into_wrong_shape(self, impl):


### PR DESCRIPTION
Post the new MJWarp update sync an issue has come up where the `ENABLE_ISLANDS` flag being set to false causes the `_get_data_into_warp` call to fail. In this case the island fields are not allocated and set to a size of 0 on the mjwarp side but they are sized to the size of nv/ntree on the host MjData side. 

This PR checks if the flag is set to false and if there are fields that have size 0 and skips those fields. This PR also makes additions to the `test_get_data_into_warp` to validate this.