### PR TITLE
Add continuous collision detection query

### DIFF
--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -630,6 +630,12 @@ MJAPI void mj_objectAcceleration(const mjModel* m, const mjData* d,
 MJAPI mjtNum mj_geomDistance(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum distmax,
                              mjtNum fromto[6]);
 
+// Compute time of impact between two convex geoms within [0, horizon], assuming constant
+// world-frame velocities taken from d. Return TOI, 0 if already touching, -1 if no impact.
+// Nullable: fromto
+MJAPI mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum horizon,
+                        mjtNum fromto[6]);
+
 // Extract 6D force:torque given contact id, in the contact frame.
 MJAPI void mj_contactForce(const mjModel* m, const mjData* d, int id, mjtNum result[6]);
 

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -636,6 +636,12 @@ MJAPI mjtNum mj_geomDistance(const mjModel* m, mjData* d, int geom1, int geom2, 
 MJAPI mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum horizon,
                         mjtNum fromto[6]);
 
+// Compute time of impact between two flex elements within [0, horizon], assuming constant
+// per-vertex velocities taken from d. Return TOI, 0 if already touching, -1 if no impact.
+// Nullable: fromto
+MJAPI mjtNum mj_flexTOI(const mjModel* m, mjData* d, int flex1, int elem1, int flex2, int elem2,
+                        mjtNum horizon, mjtNum fromto[6]);
+
 // Extract 6D force:torque given contact id, in the contact frame.
 MJAPI void mj_contactForce(const mjModel* m, const mjData* d, int id, mjtNum result[6]);
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -77,6 +77,8 @@ set(MUJOCO_ENGINE_SRCS
     engine_support.h
     engine_thread.cc
     engine_thread.h
+    engine_toi.c
+    engine_toi.h
     engine_util_blas.c
     engine_util_blas.h
     engine_util_blas_avx.h

--- a/src/engine/engine_toi.c
+++ b/src/engine/engine_toi.c
@@ -38,35 +38,143 @@ static int isTOISupported(mjtGeom type) {
 }
 
 
-// advance obj pose to time t from initial pose (pos0, quat0) under constant world-frame
-// velocity vel = [rot(3); lin(3)]: center moves linearly, rotation is about the moving center
-static void advancePose(mjCCDObj* obj, const mjtNum pos0[3], const mjtNum quat0[4],
-                        const mjtNum vel[6], mjtNum t) {
-  // linear: pos = pos0 + t * v
-  mju_addScl3(obj->pos, pos0, vel+3, t);
+// advancement context for one object: rigid initial pose, or a local flex element view that
+// lets the support function read advanced vertex positions without touching mjData (all view
+// arrays are indexed with flex id 0 and element 0 after rewiring)
+typedef struct {
+  int isflex;
 
-  // angular: quat = axisAngle(w_hat, |w|*t) * quat0 (left-multiply: w is world-frame)
-  mjtNum speed = mju_norm3(vel);
-  if (speed*t < mjMINVAL) {
-    mju_quat2Mat(obj->mat, quat0);
+  // rigid initial pose
+  mjtNum pos0[3];
+  mjtNum quat0[4];
+
+  // local flex view, read by mjc_flexSupport/mjc_center through obj->data.flex
+  int dim[1];
+  int elemadr[1];
+  int vertadr[1];
+  int elemdataadr[1];
+  int elem[4];
+  mjtNum aabb[6];
+  mjtNum xradius[1];
+  mjtNum vert[12];      // advanced vertex positions
+} mjTOIContext;
+
+
+// initialize advancement context; flex objects are rewired to read the local view
+static void toiInit(mjTOIContext* ctx, mjCCDObj* obj, const mjTOIMotion* motion) {
+  ctx->isflex = motion->nvert > 0;
+
+  // rigid: save initial pose
+  if (!ctx->isflex) {
+    mju_copy3(ctx->pos0, obj->pos);
+    mju_mat2Quat(ctx->quat0, obj->mat);
+    return;
+  }
+
+  // flex: copy the per-flex constants from the original arrays before rewiring
+  int f = obj->flex;
+  ctx->dim[0] = obj->data.flex.dim[f];
+  ctx->xradius[0] = obj->data.flex.xradius[f];
+  ctx->elemadr[0] = 0;
+  ctx->vertadr[0] = 0;
+  ctx->elemdataadr[0] = 0;
+  for (int i=0; i < motion->nvert; i++) {
+    ctx->elem[i] = i;
+  }
+  mju_zero(ctx->aabb, 6);
+
+  // rewire the object to the local view
+  obj->flex = 0;
+  if (obj->elem >= 0) {
+    obj->elem = 0;
   } else {
-    mjtNum axis[3] = {vel[0]/speed, vel[1]/speed, vel[2]/speed};
+    obj->vert = 0;
+  }
+  obj->data.flex.dim = ctx->dim;
+  obj->data.flex.aabb = ctx->aabb;
+  obj->data.flex.elemadr = ctx->elemadr;
+  obj->data.flex.vert_xpos = ctx->vert;
+  obj->data.flex.vertadr = ctx->vertadr;
+  obj->data.flex.xradius = ctx->xradius;
+  obj->data.flex.elemdataadr = ctx->elemdataadr;
+  obj->data.flex.elem = ctx->elem;
+}
+
+
+// advance object configuration to time t
+static void toiAdvance(mjTOIContext* ctx, mjCCDObj* obj, const mjTOIMotion* motion, mjtNum t) {
+  // flex: per-vertex linear motion; keep the aabb center (GJK seed) at the vertex mean
+  if (ctx->isflex) {
+    mju_zero3(ctx->aabb);
+    for (int i=0; i < motion->nvert; i++) {
+      mju_addScl3(ctx->vert + 3*i, motion->vertpos + 3*i, motion->vertvel + 3*i, t);
+      mju_addTo3(ctx->aabb, ctx->vert + 3*i);
+    }
+    mju_scl3(ctx->aabb, ctx->aabb, 1.0/motion->nvert);
+    return;
+  }
+
+  // rigid linear: pos = pos0 + t * v
+  mju_addScl3(obj->pos, ctx->pos0, motion->vel+3, t);
+
+  // rigid angular: quat = axisAngle(w_hat, |w|*t) * quat0 (left-multiply: w is world-frame)
+  mjtNum speed = mju_norm3(motion->vel);
+  if (speed*t < mjMINVAL) {
+    mju_quat2Mat(obj->mat, ctx->quat0);
+  } else {
+    mjtNum axis[3] = {motion->vel[0]/speed, motion->vel[1]/speed, motion->vel[2]/speed};
     mjtNum qrot[4], quat[4];
     mju_axisAngle2Quat(qrot, axis, speed*t);
-    mju_mulQuat(quat, qrot, quat0);
+    mju_mulQuat(quat, qrot, ctx->quat0);
     mju_quat2Mat(obj->mat, quat);
   }
 }
 
 
-// upper bound on the closing speed of the separation along unit direction n (from obj1 to obj2):
-// any surface point of obj i moves no faster than |v_i| + |w_i|*rbound_i, so the separation
-// shrinks at a rate of at most (v1 - v2)'n + |w1|*rbound1 + |w2|*rbound2
-static mjtNum closingSpeedBound(const mjtNum vel1[6], const mjtNum vel2[6],
-                                mjtNum rbound1, mjtNum rbound2, const mjtNum n[3]) {
-  mjtNum vrel[3];
-  mju_sub3(vrel, vel1+3, vel2+3);
-  return mju_dot3(vrel, n) + mju_norm3(vel1)*rbound1 + mju_norm3(vel2)*rbound2;
+// upper bound on the speed of any support point of the object along unit direction n;
+// flex support points move exactly with their vertex (the radius offset has constant
+// magnitude along the query direction), rigid surface points are bounded by |w|*rbound
+static mjtNum toiSpeedAlong(const mjTOIMotion* motion, const mjtNum n[3]) {
+  if (motion->nvert > 0) {
+    mjtNum best = mju_dot3(motion->vertvel, n);
+    for (int i=1; i < motion->nvert; i++) {
+      mjtNum dot = mju_dot3(motion->vertvel + 3*i, n);
+      if (dot > best) {
+        best = dot;
+      }
+    }
+    return best;
+  }
+  return mju_dot3(motion->vel+3, n) + mju_norm3(motion->vel)*motion->rbound;
+}
+
+
+// upper bound on the relative speed of any pair of support points of the two objects
+static mjtNum toiMaxRelSpeed(const mjTOIMotion* motion1, const mjTOIMotion* motion2) {
+  int n1 = motion1->nvert ? motion1->nvert : 1;
+  int n2 = motion2->nvert ? motion2->nvert : 1;
+  mjtNum vmax = 0;
+  for (int i=0; i < n1; i++) {
+    const mjtNum* v1 = motion1->nvert ? motion1->vertvel + 3*i : motion1->vel+3;
+    for (int j=0; j < n2; j++) {
+      const mjtNum* v2 = motion2->nvert ? motion2->vertvel + 3*j : motion2->vel+3;
+      mjtNum vrel[3];
+      mju_sub3(vrel, v1, v2);
+      mjtNum speed = mju_norm3(vrel);
+      if (speed > vmax) {
+        vmax = speed;
+      }
+    }
+  }
+
+  // rotational slack for rigid objects
+  if (!motion1->nvert) {
+    vmax += mju_norm3(motion1->vel)*motion1->rbound;
+  }
+  if (!motion2->nvert) {
+    vmax += mju_norm3(motion2->vel)*motion2->rbound;
+  }
+  return vmax;
 }
 
 
@@ -74,25 +182,20 @@ static mjtNum closingSpeedBound(const mjtNum vel1[6], const mjtNum vel2[6],
 
 // conservative-advancement core, see header for semantics
 mjtNum mjc_toi(const mjCCDConfig* config, mjCCDStatus* status,
-               mjCCDObj* obj1, const mjtNum vel1[6], mjtNum rbound1,
-               mjCCDObj* obj2, const mjtNum vel2[6], mjtNum rbound2,
+               mjCCDObj* obj1, const mjTOIMotion* motion1,
+               mjCCDObj* obj2, const mjTOIMotion* motion2,
                mjtNum horizon, mjtNum tolerance) {
-  // save initial poses
-  mjtNum pos0_1[3], pos0_2[3], quat0_1[4], quat0_2[4];
-  mju_copy3(pos0_1, obj1->pos);
-  mju_copy3(pos0_2, obj2->pos);
-  mju_mat2Quat(quat0_1, obj1->mat);
-  mju_mat2Quat(quat0_2, obj2->mat);
+  mjTOIContext ctx1, ctx2;
+  toiInit(&ctx1, obj1, motion1);
+  toiInit(&ctx2, obj2, motion2);
 
   // direction-independent bound on total closing speed
-  mjtNum vrel[3];
-  mju_sub3(vrel, vel1+3, vel2+3);
-  mjtNum vmax = mju_norm3(vrel) + mju_norm3(vel1)*rbound1 + mju_norm3(vel2)*rbound2;
+  mjtNum vmax = toiMaxRelSpeed(motion1, motion2);
 
   mjtNum t = 0;
   for (int iter=0; iter < mjMAXTOIITER; iter++) {
-    advancePose(obj1, pos0_1, quat0_1, vel1, t);
-    advancePose(obj2, pos0_2, quat0_2, vel2, t);
+    toiAdvance(&ctx1, obj1, motion1, t);
+    toiAdvance(&ctx2, obj2, motion2, t);
 
     // distance query, cutoff at the largest gap still closable in the remaining time
     mjCCDConfig cfg = *config;
@@ -110,12 +213,13 @@ mjtNum mjc_toi(const mjCCDConfig* config, mjCCDStatus* status,
     }
 
     // closing direction from witness points
-    mjtNum n[3];
+    mjtNum n[3], n_neg[3];
     mju_sub3(n, status->x2, status->x1);
     mju_scl3(n, n, 1/dist);
+    mju_scl3(n_neg, n, -1);
 
     // not approaching along the closing direction
-    mjtNum vbound = closingSpeedBound(vel1, vel2, rbound1, rbound2, n);
+    mjtNum vbound = toiSpeedAlong(motion1, n) + toiSpeedAlong(motion2, n_neg);
     if (vbound <= mjMINVAL) {
       return -1;
     }
@@ -166,15 +270,95 @@ mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum hori
   mjc_initCCDObj(&obj1, m, d, geom1, 0);
   mjc_initCCDObj(&obj2, m, d, geom2, 0);
 
-  // world-frame velocities at the geom centers
-  mjtNum vel1[6], vel2[6];
-  mj_objectVelocity(m, d, mjOBJ_GEOM, geom1, vel1, /*flg_local=*/0);
-  mj_objectVelocity(m, d, mjOBJ_GEOM, geom2, vel2, /*flg_local=*/0);
+  // rigid motion: world-frame velocities at the geom centers
+  mjTOIMotion motion1 = {0}, motion2 = {0};
+  mj_objectVelocity(m, d, mjOBJ_GEOM, geom1, motion1.vel, /*flg_local=*/0);
+  mj_objectVelocity(m, d, mjOBJ_GEOM, geom2, motion2.vel, /*flg_local=*/0);
+  motion1.rbound = m->geom_rbound[geom1];
+  motion2.rbound = m->geom_rbound[geom2];
 
-  mjtNum toi = mjc_toi(&config, &status, &obj1, vel1, m->geom_rbound[geom1],
-                       &obj2, vel2, m->geom_rbound[geom2], horizon, m->opt.ccd_tolerance);
+  mjtNum toi = mjc_toi(&config, &status, &obj1, &motion1, &obj2, &motion2,
+                       horizon, m->opt.ccd_tolerance);
 
   // witness points at the impact poses
+  if (toi >= 0 && fromto && status.nx > 0) {
+    mju_copy3(fromto, status.x1);
+    mju_copy3(fromto+3, status.x2);
+  }
+
+  mj_freeStack(d);
+  return toi;
+}
+
+
+// fill a flex element motion descriptor: vertex positions and per-vertex linear velocities
+static void flexElemMotion(const mjModel* m, const mjData* d, int f, int e, mjTOIMotion* motion) {
+  int dim = m->flex_dim[f];
+  const int* edata = m->flex_elem + m->flex_elemdataadr[f] + e*(dim+1);
+
+  motion->nvert = dim + 1;
+  for (int i=0; i <= dim; i++) {
+    int gv = m->flex_vertadr[f] + edata[i];
+    const mjtNum* vert = d->flexvert_xpos + 3*gv;
+    mju_copy3(motion->vertpos + 3*i, vert);
+
+    // vertex velocity: body velocity at the body frame origin, transported to the vertex
+    int bid = m->flex_vertbodyid[gv];
+    mjtNum vel6[6], arm[3], rotvel[3];
+    mj_objectVelocity(m, d, mjOBJ_XBODY, bid, vel6, /*flg_local=*/0);
+    mju_sub3(arm, vert, d->xpos + 3*bid);
+    mju_cross(rotvel, vel6, arm);
+    mju_add3(motion->vertvel + 3*i, vel6+3, rotvel);
+  }
+}
+
+
+// time of impact between two flex elements, see header for semantics
+mjtNum mj_flexTOI(const mjModel* m, mjData* d, int flex1, int elem1, int flex2, int elem2,
+                  mjtNum horizon, mjtNum fromto[6]) {
+  if (fromto) {
+    mju_zero(fromto, 6);
+  }
+
+  // check inputs
+  if (flex1 < 0 || flex1 >= m->nflex || flex2 < 0 || flex2 >= m->nflex) {
+    mjERROR("invalid flex id %d or %d", flex1, flex2);
+  }
+  if (elem1 < 0 || elem1 >= m->flex_elemnum[flex1] ||
+      elem2 < 0 || elem2 >= m->flex_elemnum[flex2]) {
+    mjERROR("invalid element id %d or %d", elem1, elem2);
+  }
+  if (horizon < 0) {
+    mjERROR("negative horizon %g", horizon);
+  }
+
+  mj_markStack(d);
+
+  // set config; dist_cutoff is managed by mjc_toi
+  mjCCDConfig config;
+  mjCCDStatus status;
+  config.max_iterations = m->opt.ccd_iterations;
+  config.tolerance = m->opt.ccd_tolerance;
+  config.max_contacts = 1;
+  config.dist_cutoff = mjMAX_LIMIT;
+  config.buffer = mj_stackAllocByte(d, mjc_ccdSize(config.max_iterations), sizeof(mjtNum));
+
+  mjCCDObj obj1, obj2;
+  mjc_initCCDObj(&obj1, m, d, -1, 0);
+  mjc_initCCDObj(&obj2, m, d, -1, 0);
+  obj1.flex = flex1;
+  obj1.elem = elem1;
+  obj2.flex = flex2;
+  obj2.elem = elem2;
+
+  mjTOIMotion motion1 = {0}, motion2 = {0};
+  flexElemMotion(m, d, flex1, elem1, &motion1);
+  flexElemMotion(m, d, flex2, elem2, &motion2);
+
+  mjtNum toi = mjc_toi(&config, &status, &obj1, &motion1, &obj2, &motion2,
+                       horizon, m->opt.ccd_tolerance);
+
+  // witness points at the impact positions
   if (toi >= 0 && fromto && status.nx > 0) {
     mju_copy3(fromto, status.x1);
     mju_copy3(fromto+3, status.x2);

--- a/src/engine/engine_toi.c
+++ b/src/engine/engine_toi.c
@@ -1,0 +1,185 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "engine/engine_toi.h"
+
+#include <mujoco/mjdata.h>
+#include <mujoco/mjmodel.h>
+#include <mujoco/mjtype.h>
+
+#include "engine/engine_collision_convex.h"
+#include "engine/engine_collision_gjk.h"
+#include "engine/engine_core_util.h"
+#include "engine/engine_memory.h"
+#include "engine/engine_util_blas.h"
+#include "engine/engine_util_errmem.h"
+#include "engine/engine_util_spatial.h"
+
+// maximum number of conservative advancement iterations
+#define mjMAXTOIITER 100
+
+//---------------------------------- internal helpers ---------------------------------------------
+
+// geom types supported by time-of-impact queries (compact convex shapes)
+static int isTOISupported(mjtGeom type) {
+  return type == mjGEOM_SPHERE   || type == mjGEOM_CAPSULE || type == mjGEOM_ELLIPSOID ||
+         type == mjGEOM_CYLINDER || type == mjGEOM_BOX     || type == mjGEOM_MESH;
+}
+
+
+// advance obj pose to time t from initial pose (pos0, quat0) under constant world-frame
+// velocity vel = [rot(3); lin(3)]: center moves linearly, rotation is about the moving center
+static void advancePose(mjCCDObj* obj, const mjtNum pos0[3], const mjtNum quat0[4],
+                        const mjtNum vel[6], mjtNum t) {
+  // linear: pos = pos0 + t * v
+  mju_addScl3(obj->pos, pos0, vel+3, t);
+
+  // angular: quat = axisAngle(w_hat, |w|*t) * quat0 (left-multiply: w is world-frame)
+  mjtNum speed = mju_norm3(vel);
+  if (speed*t < mjMINVAL) {
+    mju_quat2Mat(obj->mat, quat0);
+  } else {
+    mjtNum axis[3] = {vel[0]/speed, vel[1]/speed, vel[2]/speed};
+    mjtNum qrot[4], quat[4];
+    mju_axisAngle2Quat(qrot, axis, speed*t);
+    mju_mulQuat(quat, qrot, quat0);
+    mju_quat2Mat(obj->mat, quat);
+  }
+}
+
+
+// upper bound on the closing speed of the separation along unit direction n (from obj1 to obj2):
+// any surface point of obj i moves no faster than |v_i| + |w_i|*rbound_i, so the separation
+// shrinks at a rate of at most (v1 - v2)'n + |w1|*rbound1 + |w2|*rbound2
+static mjtNum closingSpeedBound(const mjtNum vel1[6], const mjtNum vel2[6],
+                                mjtNum rbound1, mjtNum rbound2, const mjtNum n[3]) {
+  mjtNum vrel[3];
+  mju_sub3(vrel, vel1+3, vel2+3);
+  return mju_dot3(vrel, n) + mju_norm3(vel1)*rbound1 + mju_norm3(vel2)*rbound2;
+}
+
+
+//---------------------------------- time of impact -----------------------------------------------
+
+// conservative-advancement core, see header for semantics
+mjtNum mjc_toi(const mjCCDConfig* config, mjCCDStatus* status,
+               mjCCDObj* obj1, const mjtNum vel1[6], mjtNum rbound1,
+               mjCCDObj* obj2, const mjtNum vel2[6], mjtNum rbound2,
+               mjtNum horizon, mjtNum tolerance) {
+  // save initial poses
+  mjtNum pos0_1[3], pos0_2[3], quat0_1[4], quat0_2[4];
+  mju_copy3(pos0_1, obj1->pos);
+  mju_copy3(pos0_2, obj2->pos);
+  mju_mat2Quat(quat0_1, obj1->mat);
+  mju_mat2Quat(quat0_2, obj2->mat);
+
+  // direction-independent bound on total closing speed
+  mjtNum vrel[3];
+  mju_sub3(vrel, vel1+3, vel2+3);
+  mjtNum vmax = mju_norm3(vrel) + mju_norm3(vel1)*rbound1 + mju_norm3(vel2)*rbound2;
+
+  mjtNum t = 0;
+  for (int iter=0; iter < mjMAXTOIITER; iter++) {
+    advancePose(obj1, pos0_1, quat0_1, vel1, t);
+    advancePose(obj2, pos0_2, quat0_2, vel2, t);
+
+    // distance query, cutoff at the largest gap still closable in the remaining time
+    mjCCDConfig cfg = *config;
+    cfg.dist_cutoff = vmax*(horizon - t) + tolerance;
+    mjtNum dist = mjc_ccd(&cfg, status, obj1, obj2);
+
+    // gap provably unreachable within horizon
+    if (dist == mjMAX_LIMIT) {
+      return -1;
+    }
+
+    // impact (covers t = 0 touching/penetration)
+    if (dist <= tolerance) {
+      return t;
+    }
+
+    // closing direction from witness points
+    mjtNum n[3];
+    mju_sub3(n, status->x2, status->x1);
+    mju_scl3(n, n, 1/dist);
+
+    // not approaching along the closing direction
+    mjtNum vbound = closingSpeedBound(vel1, vel2, rbound1, rbound2, n);
+    if (vbound <= mjMINVAL) {
+      return -1;
+    }
+
+    // advance: objects cannot touch before t + dist/vbound
+    t += dist/vbound;
+    if (t > horizon) {
+      return -1;
+    }
+  }
+
+  // iteration cap: t is a conservative lower bound on the true TOI
+  return t;
+}
+
+
+// time of impact between two geoms, see header for semantics
+mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum horizon,
+                  mjtNum fromto[6]) {
+  if (fromto) {
+    mju_zero(fromto, 6);
+  }
+
+  // check inputs
+  if (geom1 < 0 || geom1 >= m->ngeom || geom2 < 0 || geom2 >= m->ngeom) {
+    mjERROR("invalid geom id %d or %d", geom1, geom2);
+  }
+  if (horizon < 0) {
+    mjERROR("negative horizon %g", horizon);
+  }
+  if (!isTOISupported(m->geom_type[geom1]) || !isTOISupported(m->geom_type[geom2])) {
+    mjERROR("unsupported geom type: supported types are sphere, capsule, ellipsoid, "
+            "cylinder, box, mesh");
+  }
+
+  mj_markStack(d);
+
+  // set config; dist_cutoff is managed by mjc_toi
+  mjCCDConfig config;
+  mjCCDStatus status;
+  config.max_iterations = m->opt.ccd_iterations;
+  config.tolerance = m->opt.ccd_tolerance;
+  config.max_contacts = 1;
+  config.dist_cutoff = mjMAX_LIMIT;
+  config.buffer = mj_stackAllocByte(d, mjc_ccdSize(config.max_iterations), sizeof(mjtNum));
+
+  mjCCDObj obj1, obj2;
+  mjc_initCCDObj(&obj1, m, d, geom1, 0);
+  mjc_initCCDObj(&obj2, m, d, geom2, 0);
+
+  // world-frame velocities at the geom centers
+  mjtNum vel1[6], vel2[6];
+  mj_objectVelocity(m, d, mjOBJ_GEOM, geom1, vel1, /*flg_local=*/0);
+  mj_objectVelocity(m, d, mjOBJ_GEOM, geom2, vel2, /*flg_local=*/0);
+
+  mjtNum toi = mjc_toi(&config, &status, &obj1, vel1, m->geom_rbound[geom1],
+                       &obj2, vel2, m->geom_rbound[geom2], horizon, m->opt.ccd_tolerance);
+
+  // witness points at the impact poses
+  if (toi >= 0 && fromto && status.nx > 0) {
+    mju_copy3(fromto, status.x1);
+    mju_copy3(fromto+3, status.x2);
+  }
+
+  mj_freeStack(d);
+  return toi;
+}

--- a/src/engine/engine_toi.h
+++ b/src/engine/engine_toi.h
@@ -1,0 +1,57 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_SRC_ENGINE_ENGINE_TOI_H_
+#define MUJOCO_SRC_ENGINE_ENGINE_TOI_H_
+
+#include <mujoco/mjdata.h>
+#include <mujoco/mjexport.h>
+#include <mujoco/mjmodel.h>
+#include <mujoco/mjtype.h>
+
+#include "engine/engine_collision_convex.h"
+#include "engine/engine_collision_gjk.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// compute time of impact between two convex geoms within [0, horizon], assuming constant
+// world-frame velocities taken from d:
+//   x_c(t) = x_c(0) + t*v,   R(t) = exp(hat(w)*t) * R(0)
+// return TOI in [0, horizon]; 0 if already touching/penetrating; -1 if no impact
+// on impact, fromto holds witness points on geom1/geom2 at the impact poses
+// supported geom types: sphere, capsule, ellipsoid, cylinder, box, mesh
+// requires up-to-date poses and velocities (call after mj_forward)
+// Nullable: fromto
+MJAPI mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum horizon,
+                        mjtNum fromto[6]);
+
+// conservative-advancement core: obj poses (pos/mat) hold the t = 0 poses on entry and are
+// mutated to the final-iterate poses on return; vel = [rot(3); lin(3)] in the world frame at
+// the object center (mj_objectVelocity convention with flg_local=0); rbound = bounding-sphere
+// radius about the object center; the motion model is rotation about the moving object center
+// plus linear center motion (not a constant spatial twist); config->buffer must be allocated
+// via mjc_ccdSize and config->dist_cutoff is managed internally
+// return TOI in [0, horizon] or -1 if no impact
+MJAPI mjtNum mjc_toi(const mjCCDConfig* config, mjCCDStatus* status,
+                     mjCCDObj* obj1, const mjtNum vel1[6], mjtNum rbound1,
+                     mjCCDObj* obj2, const mjtNum vel2[6], mjtNum rbound2,
+                     mjtNum horizon, mjtNum tolerance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MUJOCO_SRC_ENGINE_ENGINE_TOI_H_

--- a/src/engine/engine_toi.h
+++ b/src/engine/engine_toi.h
@@ -27,6 +27,23 @@
 extern "C" {
 #endif
 
+// motion descriptor for one object in a TOI query
+// rigid objects (geoms) move with a constant world-frame velocity: the center translates
+// linearly and the object rotates about the moving center (not a constant spatial twist);
+// flex elements and vertices move with constant per-vertex linear velocities (nvert > 0),
+// which also captures deformation over the query horizon
+struct _mjTOIMotion {
+  // rigid object (nvert == 0)
+  mjtNum vel[6];        // world-frame [rot(3); lin(3)] at the object center
+  mjtNum rbound;        // bounding-sphere radius about the object center
+
+  // flex object (nvert > 0): element vertices in element-data order, or a single vertex
+  int nvert;            // number of moving vertices: flex_dim+1 for an element, 1 for a vertex
+  mjtNum vertpos[12];   // vertex positions at t = 0 (world frame)
+  mjtNum vertvel[12];   // vertex velocities (world frame)
+};
+typedef struct _mjTOIMotion mjTOIMotion;
+
 // compute time of impact between two convex geoms within [0, horizon], assuming constant
 // world-frame velocities taken from d:
 //   x_c(t) = x_c(0) + t*v,   R(t) = exp(hat(w)*t) * R(0)
@@ -38,16 +55,25 @@ extern "C" {
 MJAPI mjtNum mj_geomTOI(const mjModel* m, mjData* d, int geom1, int geom2, mjtNum horizon,
                         mjtNum fromto[6]);
 
-// conservative-advancement core: obj poses (pos/mat) hold the t = 0 poses on entry and are
-// mutated to the final-iterate poses on return; vel = [rot(3); lin(3)] in the world frame at
-// the object center (mj_objectVelocity convention with flg_local=0); rbound = bounding-sphere
-// radius about the object center; the motion model is rotation about the moving object center
-// plus linear center motion (not a constant spatial twist); config->buffer must be allocated
-// via mjc_ccdSize and config->dist_cutoff is managed internally
+// compute time of impact between two flex elements within [0, horizon], assuming constant
+// per-vertex linear velocities taken from d (deformation-aware)
+// return TOI in [0, horizon]; 0 if already touching/penetrating; -1 if no impact
+// on impact, fromto holds witness points on elem1/elem2 at the impact positions
+// requires up-to-date flex vertex positions and velocities (call after mj_forward)
+// Nullable: fromto
+MJAPI mjtNum mj_flexTOI(const mjModel* m, mjData* d, int flex1, int elem1, int flex2, int elem2,
+                        mjtNum horizon, mjtNum fromto[6]);
+
+// conservative-advancement core: obj1/obj2 are initialized CCD objects (geom or flex element
+// or flex vertex), each paired with a motion descriptor; rigid obj poses (pos/mat) must hold
+// the t = 0 poses on entry; flex objects are rewired internally to read advanced vertex
+// positions, so their mjData arrays are never modified; on return the objects hold the
+// final-iterate configuration; config->buffer must be allocated via mjc_ccdSize and
+// config->dist_cutoff is managed internally
 // return TOI in [0, horizon] or -1 if no impact
 MJAPI mjtNum mjc_toi(const mjCCDConfig* config, mjCCDStatus* status,
-                     mjCCDObj* obj1, const mjtNum vel1[6], mjtNum rbound1,
-                     mjCCDObj* obj2, const mjtNum vel2[6], mjtNum rbound2,
+                     mjCCDObj* obj1, const mjTOIMotion* motion1,
+                     mjCCDObj* obj2, const mjTOIMotion* motion2,
                      mjtNum horizon, mjtNum tolerance);
 
 #ifdef __cplusplus

--- a/test/engine/CMakeLists.txt
+++ b/test/engine/CMakeLists.txt
@@ -67,6 +67,8 @@ mujoco_test(engine_support_test)
 
 mujoco_test(engine_thread_test)
 
+mujoco_test(engine_toi_test ADDITIONAL_LINK_LIBRARIES ccd)
+
 mujoco_test(engine_util_blas_test)
 
 mujoco_test(engine_util_errmem_test)

--- a/test/engine/engine_toi_test.cc
+++ b/test/engine/engine_toi_test.cc
@@ -352,5 +352,183 @@ TEST_F(ToiTest, MeshPair) {
   mj_deleteModel(model);
 }
 
+//---------------------------------- flex elements ------------------------------------------------
+
+// two parallel 1D flex strings along x, axes separated by 0.5 in y
+constexpr char kFlexStringsXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <flexcomp name="string1" type="grid" dim="1" count="5 1 1" spacing="0.1 1 1"
+              radius="0.01" mass="0.05" pos="0 0 0"/>
+    <flexcomp name="string2" type="grid" dim="1" count="5 1 1" spacing="0.1 1 1"
+              radius="0.01" mass="0.05" pos="0 0.5 0"/>
+  </worldbody>
+</mujoco>
+)";
+
+// 2D flex membrane in the xy plane with a 1D flex string above it along x
+constexpr char kStringMembraneXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <flexcomp name="membrane" type="grid" dim="2" count="5 5 1" spacing="0.1 0.1 1"
+              radius="0.005" mass="0.2" pos="0 0 0"/>
+    <flexcomp name="string" type="grid" dim="1" count="5 1 1" spacing="0.1 1 1"
+              radius="0.01" mass="0.05" pos="0 0 0.3"/>
+  </worldbody>
+</mujoco>
+)";
+
+// set the velocity of one flex vertex body (slide joints created by flexcomp)
+static void SetVertVelocity(const mjModel* m, mjData* d, int f, int vert, const mjtNum v[3]) {
+  int bid = m->flex_vertbodyid[m->flex_vertadr[f] + vert];
+  for (int j = 0; j < m->body_jntnum[bid]; j++) {
+    int jid = m->body_jntadr[bid] + j;
+    ASSERT_EQ(m->jnt_type[jid], mjJNT_SLIDE);
+    d->qvel[m->jnt_dofadr[jid]] = mju_dot3(v, m->jnt_axis + 3*jid);
+  }
+}
+
+// set the velocity of every vertex body of a flex
+static void SetFlexVelocity(const mjModel* m, mjData* d, int f, const mjtNum v[3]) {
+  for (int i = 0; i < m->flex_vertnum[f]; i++) {
+    SetVertVelocity(m, d, f, i, v);
+  }
+}
+
+// minimum TOI of all elements of flex f1 against element e2 of flex f2; -1 if no impact
+static mjtNum MinElemTOI(const mjModel* m, mjData* d, int f1, int f2, int e2, mjtNum horizon,
+                         int* argmin = nullptr) {
+  mjtNum best = -1;
+  for (int e1 = 0; e1 < m->flex_elemnum[f1]; e1++) {
+    mjtNum toi = mj_flexTOI(m, d, f1, e1, f2, e2, horizon, nullptr);
+    if (toi >= 0 && (best < 0 || toi < best)) {
+      best = toi;
+      if (argmin) *argmin = e1;
+    }
+  }
+  return best;
+}
+
+// parallel strings approaching: axes gap 0.5, radii 0.01 each, closing speed 2 => TOI = 0.24
+TEST_F(ToiTest, FlexStringsHeadOn) {
+  mjModel* model = LoadModel(kFlexStringsXml);
+  mjData* data = mj_makeData(model);
+  int f1 = mj_name2id(model, mjOBJ_FLEX, "string1");
+  int f2 = mj_name2id(model, mjOBJ_FLEX, "string2");
+
+  mjtNum v[3] = {0, 2, 0};
+  SetFlexVelocity(model, data, f1, v);
+  mj_forward(model, data);
+
+  mjtNum fromto[6];
+  mjtNum toi = mj_flexTOI(model, data, f1, 1, f2, 1, 1.0, fromto);
+  EXPECT_NEAR(toi, 0.24, MjTol(1e-6, 1e-3));
+
+  // witness points coincide at the contact, between the string axes (y = 0.49..0.51)
+  EXPECT_NEAR(fromto[1], 0.49, MjTol(1e-5, 1e-2));
+  EXPECT_NEAR(fromto[4], 0.49, MjTol(1e-5, 1e-2));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// separating and already-touching strings
+TEST_F(ToiTest, FlexNoImpactAndTouching) {
+  mjModel* model = LoadModel(kFlexStringsXml);
+  mjData* data = mj_makeData(model);
+  int f1 = mj_name2id(model, mjOBJ_FLEX, "string1");
+  int f2 = mj_name2id(model, mjOBJ_FLEX, "string2");
+
+  // separating
+  mjtNum v[3] = {0, -2, 0};
+  SetFlexVelocity(model, data, f1, v);
+  mj_forward(model, data);
+  EXPECT_EQ(mj_flexTOI(model, data, f1, 1, f2, 1, 1.0, nullptr), -1);
+
+  // already touching: move string1 axes to y = 0.485, surface gap = 0.5 - 0.485 - 0.02 < 0
+  mjtNum shift[3] = {0, 0.485, 0};
+  SetFlexVelocity(model, data, f1, shift);
+  mj_integratePos(model, data->qpos, data->qvel, 1.0);
+  mju_zero(data->qvel, model->nv);
+  mj_forward(model, data);
+  EXPECT_EQ(mj_flexTOI(model, data, f1, 1, f2, 1, 1.0, nullptr), 0);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// string translating down onto a membrane: axes gap 0.3, radii 0.01+0.005 => TOI = 0.285
+TEST_F(ToiTest, StringOntoMembrane) {
+  mjModel* model = LoadModel(kStringMembraneXml);
+  mjData* data = mj_makeData(model);
+  int fm = mj_name2id(model, mjOBJ_FLEX, "membrane");
+  int fs = mj_name2id(model, mjOBJ_FLEX, "string");
+
+  mjtNum v[3] = {0, 0, -1};
+  SetFlexVelocity(model, data, fs, v);
+  mj_forward(model, data);
+
+  mjtNum toi = MinElemTOI(model, data, fm, fs, 1, 1.0);
+  EXPECT_NEAR(toi, 0.285, MjTol(1e-6, 1e-3));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// pure deformation: a single membrane vertex rises toward the static string above it,
+// stretching its elements; per-vertex motion must detect the impact
+TEST_F(ToiTest, DeformingMembrane) {
+  mjModel* model = LoadModel(kStringMembraneXml);
+  mjData* data = mj_makeData(model);
+  int fm = mj_name2id(model, mjOBJ_FLEX, "membrane");
+  int fs = mj_name2id(model, mjOBJ_FLEX, "string");
+
+  // find the center vertex of the membrane, at the origin
+  mj_forward(model, data);
+  int center = -1;
+  for (int i = 0; i < model->flex_vertnum[fm]; i++) {
+    const mjtNum* p = data->flexvert_xpos + 3*(model->flex_vertadr[fm] + i);
+    if (mju_norm3(p) < 1e-10) {
+      center = i;
+      break;
+    }
+  }
+  ASSERT_GE(center, 0) << "center vertex not found";
+
+  // center vertex rises at 1 m/s; the string axis is at z = 0.3, gap = 0.3 - 0.015
+  mjtNum v[3] = {0, 0, 1};
+  SetVertVelocity(model, data, fm, center, v);
+  mj_forward(model, data);
+
+  int argmin = -1;
+  mjtNum toi = MinElemTOI(model, data, fm, fs, 1, 1.0, &argmin);
+  EXPECT_NEAR(toi, 0.285, MjTol(1e-6, 1e-3));
+
+  // oracle: advance positions to the TOI (slide joints integrate exactly), expect touching
+  mj_integratePos(model, data->qpos, data->qvel, toi);
+  mj_forward(model, data);
+  EXPECT_EQ(mj_flexTOI(model, data, fm, argmin, fs, 1, 1.0, nullptr), 0);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// invalid flex and element ids produce errors
+TEST_F(ToiTest, FlexInvalidIds) {
+  mjModel* model = LoadModel(kFlexStringsXml);
+  mjData* data = mj_makeData(model);
+  mj_forward(model, data);
+
+  EXPECT_THAT(MjuErrorMessageFrom(mj_flexTOI)(model, data, 0, 99, 1, 0, 1.0, nullptr),
+              HasSubstr("invalid element id"));
+  EXPECT_THAT(MjuErrorMessageFrom(mj_flexTOI)(model, data, 5, 0, 1, 0, 1.0, nullptr),
+              HasSubstr("invalid flex id"));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
 }  // namespace
 }  // namespace mujoco

--- a/test/engine/engine_toi_test.cc
+++ b/test/engine/engine_toi_test.cc
@@ -1,0 +1,356 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for engine/engine_toi.c.
+
+#include "src/engine/engine_toi.h"
+
+#include <cmath>
+
+#include <mujoco/mujoco.h>
+#include <mujoco/mjtype.h>
+#include "test/fixture.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace mujoco {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::NotNull;
+
+using ToiTest = MujocoTest;
+
+// two free spheres of radius 0.1, centers at x=0 and x=1
+constexpr char kTwoSpheresXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="ball1">
+      <freejoint/>
+      <geom name="sphere1" type="sphere" size="0.1"/>
+    </body>
+    <body name="ball2" pos="1 0 0">
+      <freejoint/>
+      <geom name="sphere2" type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// thin static wall at x=0.5, free sphere of radius 0.05 at the origin
+constexpr char kThinWallXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <geom name="wall" type="box" size="0.005 0.5 0.5" pos="0.5 0 0"/>
+    <body name="bullet">
+      <freejoint/>
+      <geom name="bullet" type="sphere" size="0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// thin blade centered on a hinge about z, static sphere at (0, 0.5, 0)
+constexpr char kPaddleXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <geom name="target" type="sphere" size="0.05" pos="0 0.5 0"/>
+    <body name="paddle">
+      <joint name="hinge" type="hinge" axis="0 0 1"/>
+      <geom name="blade" type="box" size="0.5 0.02 0.02"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// blade on a hinge plus a free sphere approaching it
+constexpr char kPaddleBallXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="paddle">
+      <joint name="hinge" type="hinge" axis="0 0 1"/>
+      <geom name="blade" type="box" size="0.5 0.02 0.02"/>
+    </body>
+    <body name="ball" pos="0 0.6 0">
+      <freejoint/>
+      <geom name="ball" type="sphere" size="0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// plane and a free sphere (unsupported pair for TOI)
+constexpr char kPlaneSphereXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <geom name="floor" type="plane" size="1 1 1"/>
+    <body name="ball" pos="0 0 1">
+      <freejoint/>
+      <geom name="ball" type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// two free tetrahedral meshes, centers at x=0 and x=1
+constexpr char kTwoMeshesXml[] = R"(
+<mujoco>
+  <option gravity="0 0 0"/>
+  <asset>
+    <mesh name="tetra" vertex="0 0 0  0.1 0 0  0 0.1 0  0 0 0.1"/>
+  </asset>
+  <worldbody>
+    <body name="m1">
+      <freejoint/>
+      <geom name="mesh1" type="mesh" mesh="tetra"/>
+    </body>
+    <body name="m2" pos="1 0 0">
+      <freejoint/>
+      <geom name="mesh2" type="mesh" mesh="tetra"/>
+    </body>
+  </worldbody>
+</mujoco>
+)";
+
+// load a model, asserting success
+static mjModel* LoadModel(const char* xml) {
+  char error[1024];
+  mjModel* model = LoadModelFromString(xml, error, sizeof(error));
+  EXPECT_THAT(model, NotNull()) << error;
+  return model;
+}
+
+// head-on spheres: gap 0.8, closing speed 4 => TOI = 0.2
+TEST_F(ToiTest, HeadOnSpheres) {
+  mjModel* model = LoadModel(kTwoSpheresXml);
+  mjData* data = mj_makeData(model);
+  data->qvel[0] = 2;   // ball1 vx
+  data->qvel[6] = -2;  // ball2 vx
+  mj_forward(model, data);
+
+  int g1 = mj_name2id(model, mjOBJ_GEOM, "sphere1");
+  int g2 = mj_name2id(model, mjOBJ_GEOM, "sphere2");
+  mjtNum fromto[6];
+  mjtNum toi = mj_geomTOI(model, data, g1, g2, 1.0, fromto);
+
+  EXPECT_NEAR(toi, 0.2, MjTol(1e-6, 1e-3));
+
+  // witness points coincide at the analytic contact point (0.5, 0, 0)
+  for (int i = 0; i < 3; i++) {
+    mjtNum expected = i == 0 ? 0.5 : 0;
+    EXPECT_NEAR(fromto[i], expected, MjTol(1e-5, 1e-2));
+    EXPECT_NEAR(fromto[3+i], expected, MjTol(1e-5, 1e-2));
+  }
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// overlapping spheres: TOI = 0 regardless of velocities
+TEST_F(ToiTest, AlreadyPenetrating) {
+  mjModel* model = LoadModel(kTwoSpheresXml);
+  mjData* data = mj_makeData(model);
+
+  // move ball2 to overlap ball1 (free joint qpos is the absolute world position)
+  data->qpos[7] = 0.15;  // ball2 center at x = 0.15, overlap 0.05
+
+  for (mjtNum v : {2.0, -2.0, 0.0}) {
+    data->qvel[0] = v;
+    mj_forward(model, data);
+    mjtNum toi = mj_geomTOI(model, data, 0, 1, 1.0, nullptr);
+    EXPECT_EQ(toi, 0) << "velocity " << v;
+  }
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// separating or parallel-moving spheres: no impact
+TEST_F(ToiTest, NoImpact) {
+  mjModel* model = LoadModel(kTwoSpheresXml);
+  mjData* data = mj_makeData(model);
+
+  // separating
+  data->qvel[0] = -2;
+  data->qvel[6] = 2;
+  mj_forward(model, data);
+  mjtNum fromto[6] = {1, 1, 1, 1, 1, 1};
+  EXPECT_EQ(mj_geomTOI(model, data, 0, 1, 1.0, fromto), -1);
+
+  // fromto is zeroed on no impact
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(fromto[i], 0);
+  }
+
+  // parallel motion
+  data->qvel[0] = 2;
+  data->qvel[6] = 2;
+  mj_forward(model, data);
+  EXPECT_EQ(mj_geomTOI(model, data, 0, 1, 1.0, nullptr), -1);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// impact at t=0.2 is not found with horizon 0.1
+TEST_F(ToiTest, HorizonCutoff) {
+  mjModel* model = LoadModel(kTwoSpheresXml);
+  mjData* data = mj_makeData(model);
+  data->qvel[0] = 2;
+  data->qvel[6] = -2;
+  mj_forward(model, data);
+
+  EXPECT_EQ(mj_geomTOI(model, data, 0, 1, 0.1, nullptr), -1);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// fast sphere tunnels through a thin wall within one horizon: TOI is found even
+// though the endpoint position is past the wall (the discrete-collision failure case)
+TEST_F(ToiTest, TunnelingThinWall) {
+  mjModel* model = LoadModel(kThinWallXml);
+  mjData* data = mj_makeData(model);
+  data->qvel[0] = 100;
+  mj_forward(model, data);
+
+  int wall = mj_name2id(model, mjOBJ_GEOM, "wall");
+  int bullet = mj_name2id(model, mjOBJ_GEOM, "bullet");
+  mjtNum fromto[6];
+  mjtNum toi = mj_geomTOI(model, data, bullet, wall, 0.01, fromto);
+
+  // gap = 0.5 - 0.005 - 0.05 = 0.445, closing speed 100
+  EXPECT_NEAR(toi, 4.45e-3, MjTol(1e-7, 1e-4));
+  EXPECT_NEAR(fromto[0], 0.495, MjTol(1e-5, 1e-2));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// rotating blade with zero linear velocity hits a static sphere: angular-only impact
+TEST_F(ToiTest, AngularOnlyPaddle) {
+  mjModel* model = LoadModel(kPaddleXml);
+  mjData* data = mj_makeData(model);
+  mjtNum omega = 1;
+  data->qvel[0] = omega;
+  mj_forward(model, data);
+
+  int blade = mj_name2id(model, mjOBJ_GEOM, "blade");
+  int target = mj_name2id(model, mjOBJ_GEOM, "target");
+  mjtNum toi = mj_geomTOI(model, data, blade, target, 2.0, nullptr);
+
+  // analytic estimate: blade side face reaches the sphere at
+  // theta = pi/2 - asin((0.05 + 0.02)/0.5)
+  mjtNum expected = (mjPI/2 - std::asin(0.07/0.5)) / omega;
+  EXPECT_GT(toi, 0);
+  EXPECT_NEAR(toi, expected, 0.05*expected);
+
+  // primary oracle: advancing the hinge to the TOI angle (exact integration for a
+  // hinge through the geom center) must close the gap to within tolerance
+  data->qpos[0] = omega*toi;
+  mj_forward(model, data);
+  EXPECT_LE(mj_geomDistance(model, data, blade, target, 1.0, nullptr), MjTol(1e-5, 1e-2));
+
+  // strictly before the TOI there is no contact
+  data->qpos[0] = 0.9*omega*toi;
+  mj_forward(model, data);
+  EXPECT_GT(mj_geomDistance(model, data, blade, target, 1.0, nullptr), 0);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// mixed motion: rotating blade and translating sphere
+TEST_F(ToiTest, MixedLinearAngular) {
+  mjModel* model = LoadModel(kPaddleBallXml);
+  mjData* data = mj_makeData(model);
+  mjtNum omega = 1;
+  mjtNum vy = -0.05;
+  data->qvel[0] = omega;  // hinge
+  data->qvel[2] = vy;     // ball vy (free joint dofs follow the hinge dof)
+  mj_forward(model, data);
+
+  int blade = mj_name2id(model, mjOBJ_GEOM, "blade");
+  int ball = mj_name2id(model, mjOBJ_GEOM, "ball");
+  mjtNum toi = mj_geomTOI(model, data, blade, ball, 2.0, nullptr);
+  EXPECT_GT(toi, 0);
+  EXPECT_LE(toi, 2.0);
+
+  // oracle: advance hinge angle and ball position to the TOI (both exact: the blade
+  // only rotates about its center, the ball only translates), expect near-contact
+  data->qpos[0] = omega*toi;
+  data->qpos[2] += vy*toi;
+  mj_forward(model, data);
+  EXPECT_LE(mj_geomDistance(model, data, blade, ball, 1.0, nullptr), MjTol(1e-5, 1e-2));
+
+  // strictly before the TOI there is no contact
+  data->qpos[0] = 0.9*omega*toi;
+  data->qpos[2] = 0.6 + 0.9*vy*toi;
+  mj_forward(model, data);
+  EXPECT_GT(mj_geomDistance(model, data, blade, ball, 1.0, nullptr), 0);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// unsupported geom types produce an error
+TEST_F(ToiTest, UnsupportedGeomType) {
+  mjModel* model = LoadModel(kPlaneSphereXml);
+  mjData* data = mj_makeData(model);
+  mj_forward(model, data);
+
+  int floor = mj_name2id(model, mjOBJ_GEOM, "floor");
+  int ball = mj_name2id(model, mjOBJ_GEOM, "ball");
+  EXPECT_THAT(MjuErrorMessageFrom(mj_geomTOI)(model, data, floor, ball, 1.0, nullptr),
+              HasSubstr("unsupported geom type"));
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+// approaching convex meshes: TOI is consistent with mj_geomDistance at advanced poses
+TEST_F(ToiTest, MeshPair) {
+  mjModel* model = LoadModel(kTwoMeshesXml);
+  mjData* data = mj_makeData(model);
+  mjtNum vx = 2;
+  data->qvel[0] = vx;
+  mj_forward(model, data);
+
+  int g1 = mj_name2id(model, mjOBJ_GEOM, "mesh1");
+  int g2 = mj_name2id(model, mjOBJ_GEOM, "mesh2");
+  mjtNum toi = mj_geomTOI(model, data, g1, g2, 1.0, nullptr);
+  EXPECT_GT(toi, 0);
+  EXPECT_LE(toi, 1.0);
+
+  // oracle: advance mesh1 by vx*toi (pure translation), expect near-contact
+  data->qpos[0] += vx*toi;
+  mj_forward(model, data);
+  EXPECT_LE(mj_geomDistance(model, data, g1, g2, 1.0, nullptr), MjTol(1e-5, 1e-2));
+
+  // strictly before the TOI there is no contact
+  data->qpos[0] = 0.5*vx*toi;
+  mj_forward(model, data);
+  EXPECT_GT(mj_geomDistance(model, data, g1, g2, 1.0, nullptr), 0);
+
+  mj_deleteData(data);
+  mj_deleteModel(model);
+}
+
+}  // namespace
+}  // namespace mujoco


### PR DESCRIPTION
Add a time-of-impact query between two convex geoms using conservative advancement over the native GJK distance query (mjc_ccd). The motion model is constant world-frame linear and angular velocity over a query horizon; the advancement bound includes the rotational contribution via the geom bounding-sphere radius, so impacts caused purely by rotation are detected. Supported geom types: sphere, capsule, ellipsoid, cylinder, box, mesh.

Public API: mj_geomTOI(m, d, geom1, geom2, horizon, fromto) returns the TOI in [0, horizon], 0 if already touching, or -1 if no impact. The conservative-advancement core mjc_toi is exposed for callers with explicit poses and velocities.