### PR TITLE
Fix missing default class name when attaching a spec without prefix or suffix

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -642,6 +642,16 @@ mjCModel& mjCModel::operator-=(const mjCBody& subtree) {
 
 // add default tree to this model
 mjCModel& mjCModel::operator+=(mjCDef& subtree) {
+  // if the name is already in use, make it unique; this happens when a spec is
+  // attached without prefix or suffix, since the global default is always named 'main'
+  if (FindDefault(subtree.name)) {
+    int i = 1;
+    while (FindDefault(subtree.name + "_" + std::to_string(i))) {
+      i++;
+    }
+    subtree.name += "_" + std::to_string(i);
+  }
+
   defaults_.push_back(&subtree);
   def_map[subtree.name] = &subtree;
   subtree.model = this;

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -1701,6 +1701,91 @@ TEST_F(MujocoTest, AttachCompiled) {
   mj_deleteModel(m_child);
 }
 
+TEST_F(MujocoTest, AttachDefaultsWithoutPrefix) {
+  std::array<char, 1024> er;
+  mjtNum tol = 0;
+  std::string field = "";
+
+  static constexpr char xml_parent[] = R"(
+  <mujoco model="parent">
+    <default>
+      <default class="parent_class">
+        <geom size="0.25"/>
+      </default>
+    </default>
+
+    <worldbody>
+      <body name="sphere">
+        <geom class="parent_class"/>
+        <frame name="frame"/>
+      </body>
+    </worldbody>
+  </mujoco>)";
+
+  static constexpr char xml_child2[] = R"(
+  <mujoco model="child">
+    <default>
+      <geom size="0.3"/>
+      <default class="cylinder">
+        <geom type="cylinder" size=".1 1 0"/>
+      </default>
+    </default>
+
+    <worldbody>
+      <body name="body">
+        <geom class="cylinder"/>
+        <geom name="sphere_geom"/>
+      </body>
+    </worldbody>
+  </mujoco>)";
+
+  mjSpec* parent = mj_parseXMLString(xml_parent, 0, er.data(), er.size());
+  ASSERT_THAT(parent, NotNull()) << er.data();
+  mjSpec* child = mj_parseXMLString(xml_child2, 0, er.data(), er.size());
+  ASSERT_THAT(child, NotNull()) << er.data();
+
+  // store the parent's global default before attaching
+  mjsDefault* parent_main = mjs_getSpecDefault(parent);
+
+  // attach child body to parent frame without prefix or suffix
+  mjsFrame* frame = mjs_findFrame(parent, "frame");
+  ASSERT_THAT(frame, NotNull());
+  mjsBody* body = mjs_findBody(child, "body");
+  ASSERT_THAT(body, NotNull());
+  ASSERT_THAT(mjs_attach(frame->element, body->element, "", ""), NotNull())
+      << mjs_getError(parent);
+
+  // the copy of the child's global default should be renamed to a unique name
+  EXPECT_EQ(mjs_findDefault(parent, "main"), parent_main);
+  EXPECT_THAT(mjs_findDefault(parent, "main_1"), NotNull());
+  EXPECT_THAT(mjs_findDefault(parent, "cylinder"), NotNull());
+
+  // the parent's elements should still resolve to the parent's global default
+  mjsBody* sphere = mjs_findBody(parent, "sphere");
+  ASSERT_THAT(sphere, NotNull());
+  EXPECT_EQ(mjs_getDefault(sphere->element), parent_main);
+
+  // compile and save to XML
+  mjModel* m_attached = mj_compile(parent, 0);
+  ASSERT_THAT(m_attached, NotNull()) << mjs_getError(parent);
+  std::array<char, 4096> xml;
+  ASSERT_GE(mj_saveXMLString(parent, xml.data(), xml.size(), er.data(),
+                             er.size()), 0) << er.data();
+
+  // the saved XML should be loadable and produce the same model
+  mjModel* m_reloaded = LoadModelFromString(xml.data(), er.data(), er.size());
+  ASSERT_THAT(m_reloaded, NotNull()) << er.data();
+  EXPECT_LE(CompareModel(m_attached, m_reloaded, field), tol)
+            << "Attached and reloaded models are different!\n"
+            << "Different field: " << field << '\n';
+
+  // destroy everything
+  mj_deleteModel(m_reloaded);
+  mj_deleteModel(m_attached);
+  mj_deleteSpec(parent);
+  mj_deleteSpec(child);
+}
+
 void TestDetachBody(bool compile) {
   std::array<char, 1000> er;
   mjtNum tol = 0;


### PR DESCRIPTION
Fixes #2707.

The attach paths copy the child's root default tree and only apply
`mjCDef::NameSpace`, which prepends the prefix/suffix to each name. With an
empty prefix and suffix the copy keeps the reserved name `main`, and
`mjCModel::operator+=(mjCDef&)` inserted it without a collision check, silently
overwriting `def_map["main"]`. Since the XML writer omits the `class` attribute
for any default named `main` and resolves every element's class through
`def_map`, this both emits the nameless nested `<default/>` and corrupts how the
parent's own elements are serialized.

This change renames the incoming default tree's root to a unique name
(`main_1`, ...) in `mjCModel::operator+=(mjCDef&)` before insertion, mirroring
the disambiguation that non-empty prefixes already provide. It also covers the
more general collision — e.g. parent and child both defining a class with the
same name, or attaching the same spec twice with identical prefixes — which
previously serialized as duplicate class names that fail to reload with
"repeated default class name".

Added a regression test that attaches a child spec with defaults using empty
prefix/suffix and checks that the parent's global default is not clobbered, the
saved XML loads back, and the reloaded model is identical. Before the fix it
fails with `XML Error: empty class name`; with the fix the user and XML test
suites pass.
