### PR TITLE
Fix MJX make_data/put_data int dtype mismatches under jax_enable_x64

### DIFF
--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -651,7 +651,9 @@ def _make_data_jax(
   efc_address = constraint.make_efc_address(m, dim, efc_type)
 
   float_ = jp.zeros(1, float).dtype
-  int_ = np.int32
+  # let jax pick the tendon wrap int precision, for interop with
+  # jax_enable_x64 (smooth.tendon emits these fields with the canonical int)
+  int_ = jp.zeros(1, int).dtype
   contact = _make_data_contact_jax(dim, efc_address)
 
   if m.opt.cone == types.ConeType.ELLIPTIC and np.any(contact.dim == 1):
@@ -660,12 +662,12 @@ def _make_data_jax(
     )
 
   zero_impl_fields = {
-      'solver_niter': (int_,),
+      'solver_niter': (np.int32,),
       'cinert': (m.nbody, 10, float_),
-      'ten_wrapadr': (m.ntendon, np.int32),
-      'ten_wrapnum': (m.ntendon, np.int32),
+      'ten_wrapadr': (m.ntendon, int_),
+      'ten_wrapnum': (m.ntendon, int_),
       'ten_J': (m.ntendon, m.nv, float_),
-      'wrap_obj': (m.nwrap, 2, np.int32),
+      'wrap_obj': (m.nwrap, 2, int_),
       'wrap_xpos': (m.nwrap, 6, float_),
       'actuator_moment': (m.nu, m.nv, float_),
       'crb': (m.nbody, 10, float_),
@@ -892,6 +894,11 @@ def _put_contact(
   """Converts mujoco.structs._MjContactList into mjx.Contact."""
   fields = {f.name: getattr(c, f.name) for f in types.Contact.fields()}
   fields['frame'] = fields['frame'].reshape((-1, 3, 3))
+  # let jax pick contact.geom int precision, for interop with
+  # jax_enable_x64 (matches _make_data_contact_jax)
+  int_ = jp.zeros(1, int).dtype
+  for fname in ('geom1', 'geom2', 'geom'):
+    fields[fname] = fields[fname].astype(int_)
   # reorder contacts so that their condims match those specified in dim.
   # if we have fewer Contacts for a condim range, pad the range with zeros
 
@@ -963,6 +970,12 @@ def _put_data_jax(
   }
   # MJX does not support islanding, so only transfer the first solver_niter
   impl_fields['solver_niter'] = impl_fields['solver_niter'][0]
+
+  # let jax pick the tendon wrap int precision, for interop with
+  # jax_enable_x64 (matches _make_data_jax and smooth.tendon)
+  int_ = jp.zeros(1, int).dtype
+  for fname in ('ten_wrapadr', 'ten_wrapnum', 'wrap_obj'):
+    impl_fields[fname] = impl_fields[fname].astype(int_)
 
   # convert sparse actuator_moment to dense matrix
   moment = np.zeros((m.nu, m.nv))

--- a/mjx/mujoco/mjx/_src/io_test.py
+++ b/mjx/mujoco/mjx/_src/io_test.py
@@ -847,6 +847,32 @@ class DataIOTest(parameterized.TestCase):
     # calling make_data.  they should be interchangeable for jax functions:
     step_fn_jit(mjx.make_data(m, impl=impl))
 
+  def test_make_matches_put_x64(self):
+    """Test that put_data matches make_data and step dtypes under x64."""
+    m = mujoco.MjModel.from_xml_string(_MULTIPLE_CONSTRAINTS)
+    d = mujoco.MjData(m)
+    mujoco.mj_step(m, d, 2)
+
+    with jax.enable_x64(True):
+      mx = mjx.put_model(m, impl='jax')
+      dx = mjx.put_data(m, d, impl='jax')
+
+      # these dtypes follow the canonical jax int precision, matching the
+      # Data that jit-compiled functions produce:
+      int_ = jp.zeros(1, int).dtype
+      self.assertEqual(dx._impl.contact.geom1.dtype, int_)
+      self.assertEqual(dx._impl.contact.geom2.dtype, int_)
+      self.assertEqual(dx._impl.contact.geom.dtype, int_)
+      self.assertEqual(dx._impl.ten_wrapadr.dtype, int_)
+      self.assertEqual(dx._impl.ten_wrapnum.dtype, int_)
+      self.assertEqual(dx._impl.wrap_obj.dtype, int_)
+
+      # step AOT-compiled against put_data should accept make_data and its
+      # own output (the mjx viewer AOT path):
+      step_fn = jax.jit(mjx.step).lower(mx, dx).compile()
+      step_fn(mx, mjx.make_data(m, impl='jax'))
+      step_fn(mx, step_fn(mx, dx))
+
   def test_contact_elliptic_condim1(self):
     """Test that condim=1 with ConeType.ELLIPTIC is not implemented."""
     m = mujoco.MjModel.from_xml_string("""


### PR DESCRIPTION
Fixes #2565.

Two families of int fields are involved, both with the same mechanism. For the
`contact.geom1/geom2/geom` fields in the traceback: `_make_data_contact_jax`
deliberately allocates them with the canonical JAX int dtype ("let jax pick
contact.geom int precision, for interop with jax_enable_x64"), but
`_put_contact` copies the raw int32 arrays from `MjData.contact`, and
`jax.device_put` preserves them when x64 is enabled. Separately,
`smooth.tendon` emits `ten_wrapadr/ten_wrapnum/wrap_obj` with the canonical int
dtype inside jit, while `_make_data_jax` hardcodes `np.int32` for them and
`put_data` again copies int32 from `MjData` — this second mismatch hits any
model with tendons (e.g. `model/humanoid/humanoid.xml`) and breaks `make_data`
the same way. Either one makes the viewer's AOT-compiled step reject its own
output on the second call.

This change casts both groups to the canonical int dtype (in `_put_contact`,
`_make_data_jax`, and `_put_data_jax`), extending the design intent already
documented in `_make_data_contact_jax`. Under the default config every cast is
a no-op; under x64 a full pytree dtype audit on the humanoid model shows
`make_data`, `put_data`, and jitted `Data` now agree on all 85 leaves, so they
stay interchangeable for any AOT consumer without touching `viewer.py`.
(`solver_niter` is left int32 on purpose: jitted solvers produce it from
weakly-typed Python ints, so it is int32 even under x64.)

Added `test_make_matches_put_x64` next to the existing `test_make_matches_put`:
under `jax.enable_x64` it asserts these dtypes follow the canonical int
precision and that `mjx.step` AOT-compiled against `put_data` output accepts
`make_data` output and its own output — the exact viewer failure mode (the
existing test model's fixed tendon exercises the wrap fields). It fails before
this change and passes after; the full `io_test.py` still passes under the
default config.
