### PR TITLE
Package Filament runtime assets

### DIFF
--- a/python/mujoco/CMakeLists.txt
+++ b/python/mujoco/CMakeLists.txt
@@ -597,6 +597,18 @@ if(APPLE)
 endif()
 
 if(MUJOCO_PYTHON_MAKE_WHEEL)
+  set(WHEEL_FILAMENT_COMMANDS "")
+  if(MUJOCO_USE_FILAMENT AND DEFINED MUJOCO_FILAMENT_ASSETS_DIR)
+    set(FILAMENT_ASSETS_FOR_WHEEL "${CMAKE_CURRENT_BINARY_DIR}/dist/mujoco/assets")
+    list(
+      APPEND
+      WHEEL_FILAMENT_COMMANDS
+      COMMAND "${CMAKE_COMMAND}" -E make_directory "${FILAMENT_ASSETS_FOR_WHEEL}"
+      COMMAND "${CMAKE_COMMAND}" -E copy_directory "${MUJOCO_FILAMENT_ASSETS_DIR}"
+              "${FILAMENT_ASSETS_FOR_WHEEL}"
+    )
+  endif()
+
   add_custom_target(
     wheel ALL
     COMMAND "${CMAKE_COMMAND}" -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/dist"
@@ -606,6 +618,7 @@ if(MUJOCO_PYTHON_MAKE_WHEEL)
             "${CMAKE_CURRENT_BINARY_DIR}/dist/LICENSE"
     COMMAND "${CMAKE_COMMAND}" -E copy ${LIBRARIES_FOR_WHEEL}
             "${CMAKE_CURRENT_BINARY_DIR}/dist/mujoco"
+    ${WHEEL_FILAMENT_COMMANDS}
     COMMAND "${Python3_EXECUTABLE}" -m pip wheel --wheel-dir "${CMAKE_BINARY_DIR}" --no-deps -vvv
             "${CMAKE_CURRENT_BINARY_DIR}/dist"
   )
@@ -626,6 +639,9 @@ if(MUJOCO_PYTHON_MAKE_WHEEL)
   )
   if(MUJOCO_STUDIO_TARGETS)
     add_dependencies(wheel ${MUJOCO_STUDIO_TARGETS})
+  endif()
+  if(TARGET mujoco_filament_assets)
+    add_dependencies(wheel mujoco_filament_assets)
   endif()
   if(APPLE)
     add_dependencies(wheel mjpython)

--- a/python/mujoco/renderer_test.py
+++ b/python/mujoco/renderer_test.py
@@ -16,11 +16,37 @@
 
 import gc
 import sys
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
 import mujoco
+from mujoco.rendering.classic import gl_context
+from mujoco.rendering.classic import renderer as renderer_module
 import numpy as np
+
+
+class MuJoCoRendererNoGLContextTest(absltest.TestCase):
+
+  def test_renderer_allows_missing_gl_context_symbol(self):
+    xml = '<mujoco><worldbody/></mujoco>'
+    model = mujoco.MjModel.from_xml_string(xml)
+    had_gl_context = hasattr(gl_context, 'GLContext')
+    original_gl_context = getattr(gl_context, 'GLContext', None)
+    fake_mjr_context = mock.Mock()
+
+    try:
+      if had_gl_context:
+        delattr(gl_context, 'GLContext')
+      with mock.patch.object(renderer_module, 'GLContext', None):
+        with mock.patch.object(renderer_module.mujoco, 'MjrContext',
+                               return_value=fake_mjr_context):
+          with mock.patch.object(renderer_module.mujoco, 'mjr_setBuffer'):
+            renderer = renderer_module.Renderer(model, 50, 50)
+            self.assertIsNone(renderer._gl_context)  # pylint: disable=protected-access
+    finally:
+      if had_gl_context:
+        gl_context.GLContext = original_gl_context
 
 
 @absltest.skipUnless(

--- a/python/mujoco/rendering/classic/renderer.py
+++ b/python/mujoco/rendering/classic/renderer.py
@@ -84,9 +84,8 @@ the clause:
     self._rect = mujoco.MjrRect(0, 0, self._width, self._height)
 
     # Create render contexts.
-    # TODO(nimrod): Figure out why pytype doesn't like gl_context.GLContext
-    if gl_context.GLContext is not None:
-      self._gl_context = gl_context.GLContext(width, height)  # type: ignore
+    if GLContext is not None:
+      self._gl_context = GLContext(width, height)
     if self._gl_context:
       self._gl_context.make_current()
     self._mjr_context = mujoco.MjrContext(model, font_scale.value)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,6 +54,8 @@ mujoco = [
     "libmujoco.*.dylib",
     "libmujoco*.so.*",
     "mujoco.dll",
+    "assets/*.filamat",
+    "assets/*.ktx",
     "include/mujoco/*.h",
     "testdata/*.xml",
     "testdata/*.msh",

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@
 import fnmatch
 import logging
 import os
+import pathlib
 import platform
 import random
 import re
@@ -34,6 +35,9 @@ MUJOCO_CMAKE = 'MUJOCO_CMAKE'
 MUJOCO_CMAKE_ARGS = 'MUJOCO_CMAKE_ARGS'
 MUJOCO_PATH = 'MUJOCO_PATH'
 MUJOCO_PLUGIN_PATH = 'MUJOCO_PLUGIN_PATH'
+MUJOCO_FILAMENT_ASSETS_DIR = 'MUJOCO_FILAMENT_ASSETS_DIR'
+FILAMENT_ASSET_PATTERNS = ('*.filamat', '*.ktx')
+FILAMENT_SENTINEL_ASSET = 'pbr.filamat'
 
 EXT_PREFIX = 'mujoco.'
 
@@ -75,7 +79,7 @@ def get_plugin_lib_patterns():
   elif platform.system() == 'Darwin':
     return ['lib*.dylib']
   else:
-    return ['lib*']
+    return ['lib*.so*']
 
 
 def start_and_end(iterable):
@@ -157,6 +161,7 @@ class BuildCMakeExtension(build_ext.build_ext):
       assert ext.name.startswith(EXT_PREFIX)
       self.build_extension(ext)
     self._copy_external_libraries()
+    self._copy_filament_assets()
     self._copy_mujoco_headers()
     self._copy_plugin_libraries()
     self._copy_studio_assets()
@@ -197,6 +202,60 @@ class BuildCMakeExtension(build_ext.build_ext):
           shutil.copyfile(
               os.path.join(directory, filename), os.path.join(dst, filename)
           )
+
+  def _find_filament_assets_dir(self):
+    explicit_dir = os.environ.get(MUJOCO_FILAMENT_ASSETS_DIR)
+    if explicit_dir:
+      if os.path.isfile(os.path.join(explicit_dir, FILAMENT_SENTINEL_ASSET)):
+        return explicit_dir
+      raise RuntimeError(
+          f'{MUJOCO_FILAMENT_ASSETS_DIR} does not contain '
+          f'{FILAMENT_SENTINEL_ASSET}: {explicit_dir}'
+      )
+
+    candidate_dirs = []
+    mujoco_path = os.environ.get(MUJOCO_PATH)
+    if mujoco_path:
+      candidate_dirs.extend([
+          os.path.join(mujoco_path, 'lib', 'assets'),
+          os.path.join(mujoco_path, 'bin', 'assets'),
+          os.path.join(mujoco_path, 'assets'),
+      ])
+
+    for directory, _, filenames in os.walk(self.build_temp):
+      if FILAMENT_SENTINEL_ASSET in filenames:
+        candidate_dirs.append(directory)
+
+    seen = set()
+    for directory in candidate_dirs:
+      directory = os.path.normpath(directory)
+      if directory in seen or not os.path.isdir(directory):
+        continue
+      seen.add(directory)
+      if os.path.isfile(os.path.join(directory, FILAMENT_SENTINEL_ASSET)):
+        return directory
+
+    if mujoco_path:
+      for directory, _, filenames in os.walk(mujoco_path):
+        if FILAMENT_SENTINEL_ASSET in filenames:
+          return directory
+
+    return None
+
+  def _copy_filament_assets(self):
+    filament_assets_dir = self._find_filament_assets_dir()
+    if filament_assets_dir is None:
+      return
+
+    dst = os.path.join(
+        os.path.dirname(self.get_ext_fullpath(self.extensions[0].name)),
+        'assets',
+    )
+    os.makedirs(dst, exist_ok=True)
+    for pattern in FILAMENT_ASSET_PATTERNS:
+      for asset in pathlib.Path(filament_assets_dir).glob(pattern):
+        if asset.is_file():
+          shutil.copyfile(asset, os.path.join(dst, asset.name))
 
   def _copy_plugin_libraries(self):
     dst = os.path.join(

--- a/src/experimental/studio/README.md
+++ b/src/experimental/studio/README.md
@@ -35,6 +35,9 @@ If you intend to develop the application you may prefer to work from an IDE:
 ## Known Bugs
 
 * MuJoCo Studio does not yet work using Wayland on Linux, use X11 instead.
+* On Linux, build Filament-backed targets with a single C++ standard library.
+  If Filament is built with `libc++`, configure MuJoCo with clang and matching
+  `-stdlib=libc++` compiler/linker flags to avoid mixed-stdlib link failures.
 
 ## Future Work
 

--- a/src/render/filament/CMakeLists.txt
+++ b/src/render/filament/CMakeLists.txt
@@ -158,4 +158,15 @@ list(APPEND MUJOCO_FILAMENT_ASSET_FILES "${OUTPUT_ASSETS_DIR}/ibl.ktx")
 add_custom_target(mujoco_filament_assets DEPENDS ${MUJOCO_FILAMENT_ASSET_FILES})
 add_dependencies(${MUJOCO_FILAMENT_TARGET_NAME} mujoco_filament_assets)
 
-set(MUJOCO_FILAMENT_ASSETS_DIR ${OUTPUT_ASSETS_DIR})
+set(MUJOCO_FILAMENT_ASSETS_DIR
+    ${OUTPUT_ASSETS_DIR}
+    CACHE PATH "Directory containing generated MuJoCo Filament runtime assets."
+)
+
+install(
+    DIRECTORY "${OUTPUT_ASSETS_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/assets"
+    FILES_MATCHING
+    PATTERN "*.filamat"
+    PATTERN "*.ktx"
+)


### PR DESCRIPTION
Split out from #3254 in response to Haroon's request for smaller Filament PRs.

## Summary
- Copies generated Filament `.filamat` and `.ktx` assets into Python wheel package data when present.
- Installs generated Filament runtime assets under `${CMAKE_INSTALL_LIBDIR}/assets`.
- Narrows Linux plugin library matching to shared objects.
- Makes the classic Python renderer tolerate builds where `GLContext` is intentionally unavailable.
- Documents the Linux mixed-stdlib source-build caveat for Studio.

## Validation
- `git diff --check`
- `python3 -m py_compile python/setup.py python/mujoco/rendering/classic/renderer.py python/mujoco/renderer_test.py`
- `cmake -S . -B /tmp/mujoco-packaging-runtime-build -DMUJOCO_BUILD_TESTS=OFF -DMUJOCO_TEST_PYTHON_UTIL=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/mujoco-packaging-runtime-build --target mujoco -j2`

## Notes
- Draft PR: wheel-building with generated Filament assets should still be run in CI / a Filament-enabled environment.
