### PR TITLE
Fix Filament emissive material factors

### DIFF
--- a/src/render/filament/assets/pbr.mat
+++ b/src/render/filament/assets/pbr.mat
@@ -25,7 +25,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
 
     ],
     requires : [
@@ -48,6 +49,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_Metallic, uv).r;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/render/filament/assets/pbr_packed.mat
+++ b/src/render/filament/assets/pbr_packed.mat
@@ -23,7 +23,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
     ],
     requires : [
         uv0
@@ -45,6 +46,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_ORM, uv).b;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/render/filament/assets/pbr_packed_transparent.mat
+++ b/src/render/filament/assets/pbr_packed_transparent.mat
@@ -25,7 +25,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
     ],
     requires : [
         uv0
@@ -48,6 +49,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_ORM, uv).b;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/render/filament/assets/pbr_transparent.mat
+++ b/src/render/filament/assets/pbr_transparent.mat
@@ -27,7 +27,8 @@ material {
         { type : sampler2d, name : Emissive },
         { type : float4, name : BaseColorFactor },
         { type : float, name : MetallicFactor },
-        { type : float, name : RoughnessFactor }
+        { type : float, name : RoughnessFactor },
+        { type : float, name : EmissiveFactor }
 
     ],
     requires : [
@@ -51,6 +52,8 @@ fragment {
     material.metallic         = materialParams.MetallicFactor;
     material.metallic         *= texture(materialParams_Metallic, uv).r;
     material.emissive         = texture(materialParams_Emissive, uv);
-    material.emissive.a       = 1.0 - material.emissive.a;
+    material.emissive.rgb     *= materialParams.EmissiveFactor;
+    material.emissive.a       = (1.0 - material.emissive.a) *
+                                materialParams.EmissiveFactor;
   }
 }

--- a/src/render/filament/assets/phong_2d.mat
+++ b/src/render/filament/assets/phong_2d.mat
@@ -45,6 +45,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_2d_fade.mat
+++ b/src/render/filament/assets/phong_2d_fade.mat
@@ -46,6 +46,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_2d_reflect.mat
+++ b/src/render/filament/assets/phong_2d_reflect.mat
@@ -48,7 +48,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/render/filament/assets/phong_2d_uv.mat
+++ b/src/render/filament/assets/phong_2d_uv.mat
@@ -37,6 +37,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_2d_uv_fade.mat
+++ b/src/render/filament/assets/phong_2d_uv_fade.mat
@@ -38,6 +38,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_2d_uv_reflect.mat
+++ b/src/render/filament/assets/phong_2d_uv_reflect.mat
@@ -40,7 +40,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/render/filament/assets/phong_color.mat
+++ b/src/render/filament/assets/phong_color.mat
@@ -29,6 +29,7 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_color_fade.mat
+++ b/src/render/filament/assets/phong_color_fade.mat
@@ -30,6 +30,7 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_color_reflect.mat
+++ b/src/render/filament/assets/phong_color_reflect.mat
@@ -33,7 +33,8 @@ fragment {
     material.baseColor     = materialParams.BaseColorFactor;
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/render/filament/assets/phong_cube.mat
+++ b/src/render/filament/assets/phong_cube.mat
@@ -44,6 +44,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_cube_fade.mat
+++ b/src/render/filament/assets/phong_cube_fade.mat
@@ -45,6 +45,7 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
   }
 }

--- a/src/render/filament/assets/phong_cube_reflect.mat
+++ b/src/render/filament/assets/phong_cube_reflect.mat
@@ -47,7 +47,8 @@ fragment {
     material.baseColor     *= texture(materialParams_BaseColor, uv);
     material.specularColor = vec3(materialParams.SpecularFactor);
     material.glossiness    = materialParams.GlossinessFactor;
-    material.emissive      = vec4(materialParams.EmissiveFactor);
+    material.emissive      = vec4(
+        materialParams.BaseColorFactor.rgb * materialParams.EmissiveFactor, 0.0);
 
     // Apply reflection.
     vec4 reflection = texture(materialParams_Reflection, screen_uv);

--- a/src/render/filament/core/material_manager.cc
+++ b/src/render/filament/core/material_manager.cc
@@ -251,7 +251,11 @@ void MaterialManager::UpdateMaterialInstance(
                            color);
   }
   if (fmaterial->hasParameter("EmissiveFactor")) {
-    instance->setParameter("EmissiveFactor", material.emissive);
+    const float emissive =
+        material.emissive > 0
+            ? material.emissive
+            : (material.emissive_texture != nullptr ? 1.0f : 0.0f);
+    instance->setParameter("EmissiveFactor", emissive);
   }
   if (fmaterial->hasParameter("SpecularFactor")) {
     instance->setParameter("SpecularFactor", material.specular);

--- a/src/render/filament/core/object_manager.cc
+++ b/src/render/filament/core/object_manager.cc
@@ -115,7 +115,7 @@ ObjectManager::ObjectManager(filament::Engine* engine) : engine_(engine) {
   fallback_textures_[mjTEXROLE_ROUGHNESS] = fallback_white_;
   fallback_textures_[mjTEXROLE_METALLIC] = fallback_black_;
   fallback_textures_[mjTEXROLE_NORMAL] = fallback_normal_;
-  fallback_textures_[mjTEXROLE_EMISSIVE] = fallback_black_;
+  fallback_textures_[mjTEXROLE_EMISSIVE] = fallback_white_;
   fallback_textures_[mjTEXROLE_ORM] = fallback_orm_;
 
   CreateQuadBuffers();


### PR DESCRIPTION
Split out from #3254 in response to Haroon's request for smaller Filament PRs.

## Summary
- Adds `EmissiveFactor` to PBR material variants and applies it to sampled emissive output.
- Changes Phong emissive output to use base color times the emissive scalar, avoiding white scalar-only emission.
- Uses a white fallback emissive texture so scalar emissive factors still work when no emissive texture is present.
- Preserves emissive texture visibility by defaulting the scalar to `1.0` when a texture exists and the MuJoCo material scalar is zero.

## Validation
- `git diff --check`

## Notes
- Draft PR: needs Filament material compilation and visual/GPU validation in a Filament-enabled environment.
