### PR TITLE
Fix set_to_muscle() to accept 2-element arrays for timeconst and range

### DIFF
--- a/python/mujoco/specs.cc
+++ b/python/mujoco/specs.cc
@@ -1577,17 +1577,19 @@ PYBIND11_MODULE(_specs, m) {
       py::arg("diameter") = -1);
   mjsActuator.def(
       "set_to_muscle",
-      [](raw::MjsActuator* self, double timeconst[2], double tausmooth,
-         double range[2], double force, double scale, double lmin, double lmax,
-         double vmax, double fpmax, double fvmax) {
+      [](raw::MjsActuator* self, std::array<double, 2> timeconst,
+         double tausmooth, std::array<double, 2> range, double force,
+         double scale, double lmin, double lmax, double vmax, double fpmax,
+         double fvmax) {
         std::string err =
-            mjs_setToMuscle(self, timeconst, tausmooth, range, force, scale,
-                            lmin, lmax, vmax, fpmax, fvmax);
+            mjs_setToMuscle(self, timeconst.data(), tausmooth, range.data(),
+                            force, scale, lmin, lmax, vmax, fpmax, fvmax);
         if (!err.empty()) {
           throw pybind11::value_error(err);
         }
       },
-      py::arg("timeconst") = -1, py::arg("tausmooth"),
+      py::arg("timeconst") = std::array<double, 2>{-1, -1},
+      py::arg("tausmooth"),
       py::arg("range") = std::array<double, 2>{-1, -1}, py::arg("force") = -1,
       py::arg("scale") = -1, py::arg("lmin") = -1, py::arg("lmax") = -1,
       py::arg("vmax") = -1, py::arg("fpmax") = -1, py::arg("fvmax") = -1);


### PR DESCRIPTION
## Description

Fixes #3282.

`set_to_muscle()` in the Python bindings uses C-style array parameters `double timeconst[2]` and `double range[2]` in the pybind11 lambda. These decay to `double*`, which pybind11 does not convert from Python tuples/lists. This makes it impossible to pass 2D arguments:

```python
actuator.set_to_muscle(timeconst=(0.01, 0.04), range=(0.5, 1.0))
```

## Fix

Change the parameter types to `std::array<double, 2>`, which pybind11 natively supports for Python sequences of length 2. The `.data()` method provides the `double*` pointer expected by the underlying `mjs_setToMuscle` C API.

Also fixes the default for `timeconst` from scalar `-1` to `std::array<double, 2>{-1, -1}` to match the `range` default and the C API expectation.

## Testing

- Existing tests should pass (default `{-1, -1}` values are handled by the C API, which skips setting when values are negative)
- Users can now pass both `(tau_act, tau_deact)` and `(range_min, range_max)` as 2-element tuples