### PR TITLE
Add test for ellipsoid shell inertia with a != b != c

### DIFF
--- a/test/user/user_objects_test.cc
+++ b/test/user/user_objects_test.cc
@@ -1038,6 +1038,93 @@ TEST_F(MjCGeomTest, ShellInertiaEllipsoid) {
   mj_deleteModel(m);
 }
 
+TEST_F(MjCGeomTest, ShellInertiaEllipsoidAsymmetric) {
+  if constexpr (sizeof(mjtNum) == sizeof(float)) {
+    GTEST_SKIP() << "ShellInertia tests use radii differences of ~1e-8, which vanish in float32 precision";
+  }
+  // test ellipsoid with all-different semi-axes: a != b != c
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <body>
+        <geom type="ellipsoid" size="0.3 0.5 0.7" shellinertia="true"/>
+      </body>
+      <body>
+        <!-- mass is difference of body 4 and 3 masses -->
+        <geom type="ellipsoid" size="0.3 0.5 0.7" mass="3084.614015" shellinertia="true"/>
+      </body>
+      <body>
+        <geom type="ellipsoid" size="0.3 0.5 0.7" density="1e8"/>
+      </body>
+      <body>
+        <geom type="ellipsoid" size="0.30000001 0.50000001 0.70000001" density="1e8"/>
+      </body>
+    </worldbody>
+  </mujoco>
+  )";
+  std::array<char, 1000> error;
+  mjModel* m = LoadModelFromString(xml, error.data(), error.size());
+  ASSERT_THAT(m, NotNull()) << error.data();
+
+  // semi-axes
+  mjtNum a = 0.3;
+  mjtNum b = 0.5;
+  mjtNum c = 0.7;
+
+  // surface area via Thomsen approximation (same formula used by MuJoCo)
+  double p = 1.6075;
+  double tmp = std::pow(a * b, p) + std::pow(b * c, p) + std::pow(c * a, p);
+  double area = 4 * mjPI * std::pow(tmp / 3, 1.0 / p);
+
+  // body 1: shell inertia (default density = 1000)
+  mjtNum mass1 = area * 1000;
+  EXPECT_NEAR(m->body_mass[1], mass1, kInertiaTol);
+
+  // shell inertia via eps-expansion (same algorithm as MuJoCo source)
+  double eps = 1e-6;
+  double Va = 4 * mjPI * a * b * c / 3;
+  double ae = a + eps, be = b + eps, ce = c + eps;
+  double Vb = 4 * mjPI * ae * be * ce / 3;
+  double density = mass1 / (Vb - Va);
+  double mass_a = Va * density;
+  double mass_b = Vb * density;
+  mjtNum I1x = mass_b * (be * be + ce * ce) / 5 - mass_a * (b * b + c * c) / 5;
+  mjtNum I1y = mass_b * (ae * ae + ce * ce) / 5 - mass_a * (a * a + c * c) / 5;
+  mjtNum I1z = mass_b * (ae * ae + be * be) / 5 - mass_a * (a * a + b * b) / 5;
+
+  // note: increased tolerance, due to ellipsoid approximation
+  EXPECT_NEAR(m->body_inertia[3], I1x, 10 * kInertiaTol);
+  EXPECT_NEAR(m->body_inertia[4], I1y, 10 * kInertiaTol);
+  EXPECT_NEAR(m->body_inertia[5], I1z, 10 * kInertiaTol);
+
+  // body 2: shell inertia, with specified mass
+  mjtNum mass2 = 3084.614015;
+  EXPECT_NEAR(m->body_mass[2], mass2, kInertiaTol);
+  EXPECT_FLOAT_EQ(m->body_mass[4] - m->body_mass[3], m->body_mass[2]);
+
+  double density2 = mass2 / (Vb - Va);
+  double mass2_a = Va * density2;
+  double mass2_b = Vb * density2;
+  mjtNum I2x = mass2_b * (be * be + ce * ce) / 5 - mass2_a * (b * b + c * c) / 5;
+  mjtNum I2y = mass2_b * (ae * ae + ce * ce) / 5 - mass2_a * (a * a + c * c) / 5;
+  mjtNum I2z = mass2_b * (ae * ae + be * be) / 5 - mass2_a * (a * a + b * b) / 5;
+  EXPECT_NEAR(m->body_inertia[6], I2x, 10 * kInertiaTol);
+  EXPECT_NEAR(m->body_inertia[7], I2y, 10 * kInertiaTol);
+  EXPECT_NEAR(m->body_inertia[8], I2z, 10 * kInertiaTol);
+
+  // compute approximate shell inertia by subtracting inertias of massive bodies
+  // with small radius difference
+  mjtNum* inertia3 = m->body_inertia + 9;
+  mjtNum* inertia4 = m->body_inertia + 12;
+  mjtNum shell_inertia[3];
+  mju_sub3(shell_inertia, inertia4, inertia3);
+  EXPECT_NEAR(shell_inertia[0], m->body_inertia[6], 10 * kInertiaTol);
+  EXPECT_NEAR(shell_inertia[1], m->body_inertia[7], 10 * kInertiaTol);
+  EXPECT_NEAR(shell_inertia[2], m->body_inertia[8], 10 * kInertiaTol);
+
+  mj_deleteModel(m);
+}
+
 TEST_F(MjCGeomTest, ShellInertiaBox) {
   if constexpr (sizeof(mjtNum) == sizeof(float)) {
     GTEST_SKIP() << "ShellInertia tests use radii differences of ~1e-8, which vanish in float32 precision";

--- a/test/user/user_objects_test.cc
+++ b/test/user/user_objects_test.cc
@@ -1071,7 +1071,7 @@ TEST_F(MjCGeomTest, ShellInertiaEllipsoidAsymmetric) {
   mjtNum b = 0.5;
   mjtNum c = 0.7;
 
-  // surface area via Thomsen approximation (same formula used by MuJoCo)
+  // surface area via Thomsen approximation 
   double p = 1.6075;
   double tmp = std::pow(a * b, p) + std::pow(b * c, p) + std::pow(c * a, p);
   double area = 4 * mjPI * std::pow(tmp / 3, 1.0 / p);
@@ -1080,7 +1080,7 @@ TEST_F(MjCGeomTest, ShellInertiaEllipsoidAsymmetric) {
   mjtNum mass1 = area * 1000;
   EXPECT_NEAR(m->body_mass[1], mass1, kInertiaTol);
 
-  // shell inertia via eps-expansion (same algorithm as MuJoCo source)
+  // shell inertia via eps-expansion 
   double eps = 1e-6;
   double Va = 4 * mjPI * a * b * c / 3;
   double ae = a + eps, be = b + eps, ce = c + eps;


### PR DESCRIPTION
## Summary

Resolves `TODO (@thowell )` in `user_objects_test.cc` by adding a shell inertia test for an **asymmetric** ellipsoid (a ≠ b ≠ c), extending the existing `ShellInertiaEllipsoid` test which only covers the sphere case (a = b = c).

## Motivation

The current test uses equal semi-axes, which means any bug in how the engine maps inertia per-axis (e.g. an Ix/Iy/Iz swap, or an error specific to one axis) would be invisible  symmetry hides it. Testing with genuinely different semi-axes (0.3, 0.5, 0.7) exercises the general case and catches per-axis errors the symmetric test can't.

## My Approach

- Picked fully asymmetric semi-axes: **a=0.3, b=0.5, c=0.7**.
- Computed the expected mass for Body 2 using MuJoCo's own surface-area method (Thomsen's approximation, p=1.6075) × default density (1000) → **3084.614015**.
- Re-implemented the same Thomsen approximation and the ε-expansion method (expand semi-axes by ε=1e-6, subtract solid inertia of the original from the expanded version) directly in the test, so the expected Ix/Iy/Iz values are derived the same way the engine computes them internally.
- Kept the existing numerical cross-check pattern (Body 3 vs. Body 4: solid minus a slightly larger solid ≈ thin shell) as an independent, formula-free ground truth.

## Changes

**XML**
- Added 4-body fixture with `size="0.3 0.5 0.7"`, following the existing pattern:
  - Body 1: default density
  - Body 2: explicit mass (computed value above)
  - Body 3 & 4: ε-expanded solids for numerical subtraction

**C++ (`ShellInertiaEllipsoidAsymmetric`)**
- Implements Thomsen's approximation + ε-expansion analytically to compute expected Ix, Iy, Iz.
- `EXPECT_NEAR` assertions against Body 1 and Body 2, using `10 * kInertiaTol` (looser than default, since Thomsen's formula is itself an approximation  a tighter tolerance would flag approximation noise, not real bugs).
- Retains the Body 3/Body 4 subtraction check as an independent numerical validation.
- Skipped on float32 builds, consistent with the other shell inertia tests (ε=1e-6 needs float64 precision).
