### PR TITLE
Fix mjpython libpython resolution for uv and @rpath interpreters

### DIFF
--- a/python/mujoco/mjpython/mjpython.mm
+++ b/python/mujoco/mjpython/mjpython.mm
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #import <algorithm>
-#import <atomic>
 #import <cstdint>
 #import <cstdlib>
 #import <cstring>
 #import <iostream>
 #import <vector>
 
+#import <dispatch/dispatch.h>
 #import <dlfcn.h>
 #import <mach-o/dyld.h>
 #import <pthread.h>
@@ -76,7 +76,7 @@ struct {
 #undef CPYTHON_FN
 } cpython;
 
-std::atomic_bool py_initialized;
+dispatch_semaphore_t py_initialized;
 
 struct Args {
   int argc;
@@ -109,7 +109,7 @@ void* mjpython_pymain(void* vargs) {
 
   // Set up the condition variable to pass control back to the macOS main thread.
   gil = cpython.PyGILState_Ensure();
-  cpython.PyRun_SimpleStringFlags(R"(
+  if (cpython.PyRun_SimpleStringFlags(R"(
 def _mjpython_make_cond():
   # Don't pollute the global namespace.
   global _mjpython_make_cond
@@ -121,12 +121,15 @@ def _mjpython_make_cond():
   cond = threading.Condition()
 
 _mjpython_make_cond()
-)", nullptr);
-  py_initialized.store(true);
+)", nullptr) != 0) {
+    std::cerr << "mjpython: failed to create the main-thread condition variable\n";
+    std::exit(EXIT_FAILURE);
+  }
+  dispatch_semaphore_signal(py_initialized);
 
   // Wait until GLFW is initialized on macOS main thread, set up the queue and an atexit hook
   // to enqueue a termination flag upon exit.
-  cpython.PyRun_SimpleStringFlags(R"(
+  if (cpython.PyRun_SimpleStringFlags(R"(
 def _mjpython_init():
   # Don't pollute the global namespace.
   global _mjpython_init
@@ -216,7 +219,10 @@ def _mjpython_init():
     cond.notify()
 
 _mjpython_init()
-)", nullptr);
+)", nullptr) != 0) {
+    std::cerr << "mjpython: failed to initialize the viewer dispatch bridge\n";
+    std::exit(EXIT_FAILURE);
+  }
 
   // Run the Python interpreter main loop.
   cpython.Py_RunMain();
@@ -228,7 +234,7 @@ _mjpython_init()
 }  // namespace
 
 int main(int argc, char** argv) {
-  py_initialized.store(false);
+  py_initialized = dispatch_semaphore_create(0);
   const char* libpython_path = getenv("MJPYTHON_LIBPYTHON");
   if (!libpython_path || !libpython_path[0]) {
     std::cerr << "This binary must be launched via the mjpython.py script.\n";
@@ -322,13 +328,13 @@ int main(int argc, char** argv) {
   pthread_attr_destroy(&pthread_attr);
 #undef PTHREAD_CHECKED
 
-  // Busy-wait until Python interpreter is initialized.
-  while (!py_initialized.load()) {}
+  // Wait until the Python interpreter is initialized.
+  dispatch_semaphore_wait(py_initialized, DISPATCH_TIME_FOREVER);
 
   // Initialize GLFW on the macOS main thread, yield control to Python main thread and wait for it
   // to finish setting up _MJPYTHON, then serve incoming viewer launch requests.
   PyGILState_STATE gil = cpython.PyGILState_Ensure();
-  cpython.PyRun_SimpleStringFlags(R"(
+  if (cpython.PyRun_SimpleStringFlags(R"(
 def _mjpython_main():
   # Don't pollute the global namespace.
   global _mjpython_main
@@ -379,7 +385,11 @@ def _mjpython_main():
       mujoco.viewer._MJPYTHON.done()
 
 _mjpython_main()
-)", nullptr);
+)", nullptr) != 0) {
+    std::cerr << "mjpython: viewer event loop terminated abnormally\n";
+    cpython.PyGILState_Release(gil);
+    return EXIT_FAILURE;
+  }
   cpython.PyGILState_Release(gil);
 
   // Tear everything down.

--- a/python/mujoco/mjpython/mjpython.py
+++ b/python/mujoco/mjpython/mjpython.py
@@ -59,9 +59,9 @@ def main(argv):
   # mjpython binary when we execve. We therefore preemptively resolve all
   # @executable_path-relative paths now and add them to
   # DYLD_FALLBACK_LIBRARY_PATH.
-  libpython_dir = os.path.dirname(libpython_path)
+  libpython_dir = os.path.dirname(os.path.realpath(libpython_path))
   dyld_fallback_paths = []
-  pattern = re.compile(r'@executable_path/(.+) \(offset \d+\)\Z')
+  pattern = re.compile(r'^\s*(name|path) @executable_path/(.+) \(offset \d+\)\Z')
   otool_out = subprocess.run(
       ['otool', '-l', libpython_path],
       capture_output=True,
@@ -70,7 +70,8 @@ def main(argv):
   for line in otool_out.split('\n'):
     m = pattern.search(line)
     if m is not None:
-      new_path = os.path.dirname(os.path.join(libpython_dir, m.group(1)))
+      resolved = os.path.join(libpython_dir, m.group(2))
+      new_path = resolved if m.group(1) == 'path' else os.path.dirname(resolved)
       if new_path not in dyld_fallback_paths:
         dyld_fallback_paths.insert(0, new_path)
 


### PR DESCRIPTION
On macOS, running anything under `mjpython` on a `uv` managed Python fails with `dyld: Library not loaded: @rpath/libpython3.x.dylib`. The same failure occurs with any interpreter that links libpython through `@rpath`.

At startup, `mjpython.py` parses `otool -l` and adds the interpreter's library directories to `DYLD_FALLBACK_LIBRARY_PATH` so libpython resolves. Two bugs broke that for `@rpath` interpreters:

- It ran `dirname()` on every entry, but `LC_RPATH` values are already directories, so the real `lib/` got reduced to its parent and libpython was never found.
- It didn't follow the interpreter symlink first, so for a venv (`bin/python` points at the base interpreter) the paths were anchored in the wrong place.

Also swaps the main-thread startup busy-wait (`while (!py_initialized.load()) {}`) for a dispatch semaphore, and makes the three interpreter-bootstrap calls fail loudly instead of silently continuing into a broken state.

All changes are limited to the macOS-only mjpython launcher (`python/mujoco/mjpython/`). Nothing else is affected.

This fixes the failure reported in #1923 (closed without a fix) and astral-sh/uv#8953.
