### PR TITLE
Fix x86-windows builds.

### DIFF
--- a/src/engine/engine_crossplatform.h
+++ b/src/engine/engine_crossplatform.h
@@ -78,8 +78,13 @@
 // Atomics helper for size_t.
 #if defined(_MSC_VER) && !defined(__clang__)
   #include <intrin.h>
-  #define mj_atomic_add_size_t(ptr, val) \
-      (size_t)_InterlockedExchangeAdd64((__int64 volatile*)(ptr), (__int64)(val))
+  #if defined(_WIN64)
+    #define mj_atomic_add_size_t(ptr, val) \
+        (size_t)_InterlockedExchangeAdd64((__int64 volatile*)(ptr), (__int64)(val))
+  #else
+    #define mj_atomic_add_size_t(ptr, val) \
+        (size_t)_InterlockedExchangeAdd((long volatile*)(ptr), (long)(val))
+  #endif
 #else
   #define mj_atomic_add_size_t(ptr, val) \
       __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED)


### PR DESCRIPTION
Resolves:  `engine_memory.c.obj : error LNK2019: unresolved external symbol  __InterlockedExchangeAdd64 referenced in function _stackalloc`

This change suggested by GPT 5.5.

This was detected by https://github.com/microsoft/vcpkg/pull/52555