### PR TITLE
fix: prevent segfault in mjCModel::ResolvePlugin when instance is missing

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -5952,15 +5952,14 @@ void mjCModel::ResolvePlugin(mjCBase* obj, const std::string& plugin_name,
   else if (!*plugin_instance) {
     *plugin_instance =
       static_cast<mjCPlugin*>(FindObject(mjOBJ_PLUGIN, plugin_instance_name));
-    (*plugin_instance)->plugin_slot = plugin_slot;
     if (!*plugin_instance) {
       throw mjCError(
               obj, "unrecognized name '%s' for plugin instance", plugin_instance_name.c_str());
     }
+    (*plugin_instance)->plugin_slot = plugin_slot;
     if (plugin_slot != -1 && plugin_slot != (*plugin_instance)->plugin_slot) {
       throw mjCError(
               obj, "'plugin' attribute does not match that of the instance");
     }
-    plugin_slot = (*plugin_instance)->plugin_slot;
   }
 }

--- a/test/user/CMakeLists.txt
+++ b/test/user/CMakeLists.txt
@@ -14,7 +14,10 @@
 
 mujoco_test(
   user_model_test
-  ADDITIONAL_LINK_LIBRARIES absl::str_format compare_model
+  ADDITIONAL_LINK_LIBRARIES absl::str_format compare_model 
+  PROPERTIES
+  ENVIRONMENT
+  "MUJOCO_PLUGIN_DIR=$<TARGET_FILE_DIR:actuator>"
 )
 
 mujoco_test(user_objects_test)

--- a/test/user/CMakeLists.txt
+++ b/test/user/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 mujoco_test(
   user_model_test
-  ADDITIONAL_LINK_LIBRARIES absl::str_format compare_model 
+  ADDITIONAL_LINK_LIBRARIES absl::str_format compare_model
   PROPERTIES
   ENVIRONMENT
   "MUJOCO_PLUGIN_DIR=$<TARGET_FILE_DIR:actuator>"

--- a/test/user/user_model_test.cc
+++ b/test/user/user_model_test.cc
@@ -872,6 +872,43 @@ TEST_F(LengthRangeTest, LengthRangeThreading) {
   mj_deleteSpec(spec);
 }
 
+
+TEST_F(MujocoTest, ResolvePluginMissingInstanceThrowsError) {
+  // Instance name="my_pid_config" dos not match actuator plugin's instance="pid_config",
+  // this should throw an appropriate error
+  static constexpr char xml_mismatch[] = R"(
+  <mujoco>
+    <extension>
+      <plugin plugin="mujoco.pid">
+        <instance name="my_pid_config" /> 
+      </plugin>
+    </extension>
+    <worldbody>
+      <body name="block" pos="0 0 0.5">
+        <joint name="slide_z" type="slide" axis="0 0 1" />
+        <geom type="box" size="0.1 0.1 0.1" mass="1.0" rgba="0 0.7 0 1"/>
+      </body>
+    </worldbody>
+    <actuator>
+      <plugin name="pid_actuator" joint="slide_z" plugin="mujoco.pid" instance="pid_config" />
+    </actuator>
+  </mujoco>
+  )";
+
+  std::array<char, 1024> error_buffer;
+  mjSpec* spec = mj_parseXMLString(xml_mismatch, 0, error_buffer.data(), error_buffer.size());
+  ASSERT_THAT(spec, NotNull()) << error_buffer.data();
+
+  mjModel* model = mj_compile(spec, nullptr);
+  EXPECT_THAT(model, IsNull());
+ 
+  std::string error_msg = mjs_getError(spec);
+  EXPECT_THAT(error_msg, HasSubstr("unrecognized name 'pid_config' for plugin instance")); 
+  
+  if (model) mj_deleteModel(model);
+  mj_deleteSpec(spec);
+}
+
 // ----------------------------- test modeldir  --------------------------------
 
 TEST_F(MujocoTest, Modeldir) {

--- a/test/user/user_model_test.cc
+++ b/test/user/user_model_test.cc
@@ -880,7 +880,7 @@ TEST_F(MujocoTest, ResolvePluginMissingInstanceThrowsError) {
   <mujoco>
     <extension>
       <plugin plugin="mujoco.pid">
-        <instance name="my_pid_config" /> 
+        <instance name="my_pid_config" />
       </plugin>
     </extension>
     <worldbody>
@@ -901,13 +901,13 @@ TEST_F(MujocoTest, ResolvePluginMissingInstanceThrowsError) {
 
   mjModel* model = mj_compile(spec, nullptr);
   EXPECT_THAT(model, IsNull());
- 
+
   std::string error_msg = mjs_getError(spec);
-  EXPECT_THAT(error_msg, HasSubstr("unrecognized name 'pid_config' for plugin instance")); 
-  
+  EXPECT_THAT(error_msg, HasSubstr("unrecognized name 'pid_config' for plugin instance"));
+
   if (model) mj_deleteModel(model);
   mj_deleteSpec(spec);
-}
+}commit
 
 // ----------------------------- test modeldir  --------------------------------
 

--- a/test/user/user_model_test.cc
+++ b/test/user/user_model_test.cc
@@ -907,7 +907,7 @@ TEST_F(MujocoTest, ResolvePluginMissingInstanceThrowsError) {
 
   if (model) mj_deleteModel(model);
   mj_deleteSpec(spec);
-}commit
+}
 
 // ----------------------------- test modeldir  --------------------------------
 


### PR DESCRIPTION
When looking up a plugin instance name that does not exist, 
```
<plugin plugin="mujoco.pid">
  <instance name="my_pid_config" /> 
</plugin>
...
<actuator>
  <plugin instance="pid_config" ... /> <!-- wrong name -->
</actuator>
```
there is a null check in `mjCModel::RegisterPlugin` for throwing an error if the instance can't be found,
```
void mjCModel::ResolvePlugin(..., mjCPlugin** plugin_instance) {
    ...
    (*plugin_instance)->plugin_slot = plugin_slot;
    if (!*plugin_instance) {
```
but the pointer is dereferenced before the the null check. Moving the plugin slot assignment to after this check fixes it. The added test fails due to a segfault before the change, but passes afterwards. 