### PR TITLE
Fix overflow cast in MJX collisions for box-box and convex-convex

### DIFF
--- a/mjx/mujoco/mjx/_src/collision_convex.py
+++ b/mjx/mujoco/mjx/_src/collision_convex.py
@@ -714,7 +714,7 @@ def _box_box(b1: ConvexInfo, b2: ConvexInfo) -> Collision:
   # Go back to world frame.
   pos = b2.pos + pos @ b2.mat.T
   n = normal @ b2.mat.T
-  dist = jp.where(jp.isinf(dist), jp.finfo(float).max, dist)
+  dist = jp.where(jp.isinf(dist), jp.finfo(dist.dtype).max, dist)
 
   return dist, pos, n
 
@@ -927,7 +927,7 @@ def _convex_convex(c1: ConvexInfo, c2: ConvexInfo) -> Collision:
   pos = c2.pos + pos @ c2.mat.T
   n = normal @ c2.mat.T
   n = -n if swapped else n
-  dist = jp.where(jp.isinf(dist), jp.finfo(float).max, dist)
+  dist = jp.where(jp.isinf(dist), jp.finfo(dist.dtype).max, dist)
 
   return dist, pos, n
 

--- a/mjx/mujoco/mjx/_src/collision_driver_test.py
+++ b/mjx/mujoco/mjx/_src/collision_driver_test.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 from typing import Dict, Optional, Tuple
+import warnings
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -796,6 +797,19 @@ class ConvexTest(absltest.TestCase):
     )
     c = dx._impl.contact
     self.assertTrue((c.dist > 0).all())
+
+  def test_no_overflow_warning_f32(self):
+    """Tests box-box and convex-convex don't overflow finfo.max in float32."""
+    directory = epath.resource_path('mujoco.mjx')
+    assets = {
+        'meshes/dodecahedron.stl': (
+            directory / 'test_data' / 'meshes/dodecahedron.stl'
+        ).read_bytes(),
+    }
+    with warnings.catch_warnings():
+      warnings.simplefilter('error', RuntimeWarning)
+      _collide(self._BOX_BOX, keyframe=0)
+      _collide(self._CONVEX_CONVEX, assets=assets)
 
 
 class HFieldTest(absltest.TestCase):

--- a/mjx/mujoco/mjx/_src/collision_driver_test.py
+++ b/mjx/mujoco/mjx/_src/collision_driver_test.py
@@ -806,8 +806,9 @@ class ConvexTest(absltest.TestCase):
             directory / 'test_data' / 'meshes/dodecahedron.stl'
         ).read_bytes(),
     }
-    with warnings.catch_warnings():
+    with warnings.catch_warnings():  # Regression test for #3368
       warnings.simplefilter('error', RuntimeWarning)
+      jax.clear_caches()  # force a re-trace so the cast (and warning) re-runs
       _collide(self._BOX_BOX, keyframe=0)
       _collide(self._CONVEX_CONVEX, assets=assets)
 


### PR DESCRIPTION
Fixes the overflow cast in MJX collisions encountered in #3368 and possibly #2226.

To repeat the central part of #3368: The current implementation of MJX throws a warning for box-box and convex-convex collisions. The exact warning is lax_numpy.py:2799: RuntimeWarning: overflow encountered in cast.

The reason is that the collision checking functions for box-box and convex-convex collisions use a `jp.where` selection to set infinite values to the maximum possible float value instead. This is done via `jp.where(jp.isinf(dist), jp.finfo(float).max, dist)`. jax uses float32 by default, and so `dist` is a float32 array.  `jp.finfo(float)` uses float64 however, because jax treats Python's float built-in as double precision. The dtype mismatch then results in the overflow error, because we are setting elements of a float32 array to float64 (or at least attempt it). The fix is to replace the `jp.finfo` with `jp.finfo(dist.dtype)`. This PR adds a minimal test and fixes the error in the two affected functions.