### PR TITLE
Add OpenUSD MuJoCo setup scripts and wrapper examples

### DIFF
--- a/docs/openusd/README.md
+++ b/docs/openusd/README.md
@@ -1,0 +1,59 @@
+# MuJoCo + OpenUSD Setup Notes
+
+This documents the current OpenUSD-enabled MuJoCo setup used for USD asset/environment import testing.
+
+## Current Purpose
+
+This work is focused on the OpenUSD -> MuJoCo import path.
+
+It is not policy training yet. The goal is to make MuJoCo able to load and visualize USD-based assets/environments so they can later be tested with Seahorse, RoboJudo, and ProtoMotion workflows.
+
+## Build Flow
+
+1. Clone stable MuJoCo.
+2. Build OpenUSD using MuJoCo's helper:
+
+   `cmake/third_party_deps/openusd`
+
+3. Configure MuJoCo with OpenUSD enabled:
+
+   `-DMUJOCO_WITH_USD=True`
+
+4. Build MuJoCo.
+5. Verify that `build/bin/simulate` exists.
+6. Launch MuJoCo using the runtime helper script:
+
+   `scripts/openusd/run_mujoco_usd.sh`
+
+## Runtime Helper
+
+The runtime helper script sets the paths needed for MuJoCo to find the USD decoder plugin and OpenUSD libraries.
+
+It handles:
+
+- `libusd_decoder_plugin.so`
+- `LD_LIBRARY_PATH`
+- `PXR_PLUGINPATH_NAME`
+- WSL graphics settings using `llvmpipe`
+
+## XML Wrapper Testing
+
+USD assets are loaded through MJCF XML wrapper files.
+
+The important MJCF line is:
+
+    <model name="asset_name" file="/path/to/file.usd" content_type="text/usd"/>
+
+The wrapper gives MuJoCo simulation context such as:
+
+- asset path
+- worldbody
+- lighting
+- floor
+- attach point
+
+## Current Limitation
+
+This does not automatically convert a full Isaac Sim task into a MuJoCo training environment.
+
+Physics, contacts, joints, actuators, rewards, and policy training still need separate validation.

--- a/examples/openusd_wrappers/README.md
+++ b/examples/openusd_wrappers/README.md
@@ -1,0 +1,32 @@
+# OpenUSD MJCF Wrapper Examples
+
+These XML files are examples for loading USD assets into MuJoCo using MJCF wrappers.
+
+## Purpose
+
+The wrappers provide a controlled way to test USD asset loading in MuJoCo after building MuJoCo with OpenUSD enabled.
+
+## Current Examples
+
+- `load_pallet_usd.xml`
+- `load_rack_usd.xml`
+
+## Key MJCF Concept
+
+The wrapper uses:
+
+    <model name="asset_name" file="/path/to/file.usd" content_type="text/usd"/>
+
+Then the asset is attached into the MuJoCo world using:
+
+    <attach model="asset_name" prefix="asset_"/>
+
+## Notes
+
+These files may contain local asset paths from the development machine. During Seahorse integration, update the USD file paths to point to the Seahorse/G1 assets.
+
+## Current Scope
+
+These wrappers are for asset/environment import testing.
+
+They are not full training environments yet.

--- a/examples/openusd_wrappers/load_pallet_usd.xml
+++ b/examples/openusd_wrappers/load_pallet_usd.xml
@@ -1,0 +1,13 @@
+<mujoco model="load_pallet_usd">
+  <asset>
+    <model name="pallet_asset" file="/mnt/c/Users/David/Hard_Documents/mujoco/usd_tests/Industrial_NVD_10012/Assets/ArchVis/Industrial/Pallets/Pallet_A1.usd" content_type="text/usd"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 5"/>
+    <geom name="floor" type="plane" size="5 5 0.1"/>
+    <body name="pallet_holder" pos="0 0 0">
+      <attach model="pallet_asset" prefix="pallet_"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/examples/openusd_wrappers/load_rack_usd.xml
+++ b/examples/openusd_wrappers/load_rack_usd.xml
@@ -1,0 +1,13 @@
+<mujoco model="load_rack_usd">
+  <asset>
+    <model name="rack_asset" file="/home/david/usd_tests/Industrial_NVD@10012_extracted/Assets/ArchVis/Industrial/Shelves/RackSmallEmpty_A1.usd" content_type="text/usd"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 6"/>
+    <geom name="floor" type="plane" size="8 8 0.1"/>
+    <body name="rack_holder" pos="0 0 0">
+      <attach model="rack_asset" prefix="rack_"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/scripts/openusd/run_mujoco_usd.sh
+++ b/scripts/openusd/run_mujoco_usd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$HOME/mujoco"
+
+mkdir -p build/bin/mujoco_plugin
+
+if [ -f build/lib/libusd_decoder_plugin.so ]; then
+  cp -f build/lib/libusd_decoder_plugin.so build/bin/mujoco_plugin/
+fi
+
+export LD_LIBRARY_PATH="$HOME/mujoco/build/lib:$HOME/mujoco/build/_deps/openusd-build/lib:$LD_LIBRARY_PATH"
+export PXR_PLUGINPATH_NAME="$HOME/mujoco/build/lib/mujoco-usd-resources:$PXR_PLUGINPATH_NAME"
+
+LIBGL_ALWAYS_SOFTWARE=1 MESA_LOADER_DRIVER_OVERRIDE=llvmpipe ./build/bin/simulate "$@"


### PR DESCRIPTION
This adds the initial OpenUSD/MuJoCo setup files for testing USD asset imports.

Included:
- Runtime helper script for launching MuJoCo with USD plugin paths
- OpenUSD setup notes
- MJCF XML wrapper examples for loading USD assets

Scope:
- This is for USD asset/environment import testing.
- This does not include build artifacts, downloaded assets, or training code.
- Next step is to test Seahorse/G1 warehouse assets through the OpenUSD -> MuJoCo wrapper pipeline.