### PR TITLE
Fix #3104: include file-referenced assets in MjSpec.to_zip

### DIFF
--- a/python/mujoco/__init__.py
+++ b/python/mujoco/__init__.py
@@ -112,11 +112,43 @@ def to_zip(spec: _specs.MjSpec, file: Union[str, IO[bytes]]) -> None:
     spec: The mjSpec to save to a file.
     file: The path to the file to save to or the file object to write to.
   """
-  files_to_zip = spec.assets
+  # Copy to avoid mutating spec.assets.
+  files_to_zip = dict(spec.assets)
+
+  # Collect assets referenced by file path in spec elements that were not
+  # explicitly added to spec.assets (e.g. loaded from disk via XML).
+  modelfiledir = spec.modelfiledir or ''
+
+  def _maybe_add_file(filepath: str) -> None:
+    if not filepath or filepath in files_to_zip:
+      return
+    full_path = (
+        filepath if os.path.isabs(filepath)
+        else os.path.join(modelfiledir, filepath) if modelfiledir
+        else filepath
+    )
+    try:
+      with open(full_path, 'rb') as f:
+        files_to_zip[filepath] = f.read()
+    except OSError:
+      pass
+
+  for mesh in spec.meshes:
+    _maybe_add_file(mesh.file)
+  for hfield in spec.hfields:
+    _maybe_add_file(hfield.file)
+  for skin in spec.skins:
+    _maybe_add_file(skin.file)
+  for texture in spec.textures:
+    _maybe_add_file(texture.file)
+    for cubefile in texture.cubefiles:
+      _maybe_add_file(cubefile)
+
   files_to_zip[spec.modelname + '.xml'] = spec.to_xml()
   if isinstance(file, str):
     directory = os.path.dirname(file)
-    os.makedirs(directory, exist_ok=True)
+    if directory:
+      os.makedirs(directory, exist_ok=True)
     file = open(file, 'wb')
   with zipfile.ZipFile(file, 'w') as zip_file:
     for filename, contents in files_to_zip.items():

--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -16,6 +16,7 @@
 
 import gc
 import inspect
+import io
 import math
 import os
 import textwrap
@@ -1913,6 +1914,45 @@ class SpecsTest(absltest.TestCase):
         string_spec = mujoco.MjSpec.from_string(xml_string, assets=assets)
         string_spec.compile()
         self.assertEqual(spec.to_xml(), string_spec.to_xml())
+
+  def test_to_zip_includes_file_assets(self):
+    """Tests that to_zip includes assets referenced by file path in spec elements.
+
+    Regression test for https://github.com/google-deepmind/mujoco/issues/3104.
+    When a spec is loaded from an XML file with external asset references (e.g.
+    <mesh file="..."/>), those referenced files should be included in the zip
+    even if they were not explicitly added to spec.assets.
+    """
+    msh_xml_path = (
+        epath.resource_path('mujoco') / 'testdata' / 'msh.xml'
+    ).as_posix()
+    spec = mujoco.MjSpec.from_file(msh_xml_path)
+
+    # The mesh is loaded from disk; it should not be in spec.assets yet.
+    self.assertNotIn('abdomen_1_body.msh', spec.assets)
+
+    buf = io.BytesIO()
+    mujoco.to_zip(spec, buf)
+    buf.seek(0)
+
+    with zipfile.ZipFile(buf, 'r') as zf:
+      names = zf.namelist()
+
+    self.assertIn('abdomen_1_body.msh', names)
+
+    # Round-trip: the zip should produce a compilable spec.
+    buf.seek(0)
+    spec2 = mujoco.from_zip(buf)
+    self.assertIsNotNone(spec2.compile())
+
+  def test_to_zip_does_not_mutate_assets(self):
+    """Tests that to_zip does not add the serialized XML to spec.assets."""
+    spec = mujoco.MjSpec()
+    spec.modelname = 'test'
+    assets_before = dict(spec.assets)
+    buf = io.BytesIO()
+    mujoco.to_zip(spec, buf)
+    self.assertEqual(dict(spec.assets), assets_before)
 
   def test_rangefinder_sensor(self):
     """Test rangefinder sensor with mjSpec, iterative model building."""


### PR DESCRIPTION
## Problem

`MjSpec.to_zip` only serializes assets present in the Python-side `spec.assets` dict. Assets referenced via XML file attributes — e.g. `<mesh file="cube.obj"/>`, `<texture file="tex.png"/>` — are loaded by the C layer from disk but are never added to `spec.assets`, so they are silently omitted from the zip. The resulting zip cannot be reloaded.

Fixes #3104.

## Changes

**`python/mujoco/__init__.py`**
- After copying `spec.assets`, walk all spec elements that can carry `file` references: `meshes`, `hfields`, `skins`, and `textures` (including `cubefiles`).
- For each referenced file not already present in the dict, resolve the path against `spec.modelfiledir` and read it from disk. Files not found on disk are silently skipped (in-memory assets already in `spec.assets` take precedence).
- Two secondary bugs also fixed:
  - `spec.assets` was mutated in-place (`files_to_zip = spec.assets` then items were added to it); now a copy is made first so the caller's dict is untouched.
  - `os.makedirs(directory, ...)` was called even when `directory` is `''` (e.g. saving to current directory), which raises `FileNotFoundError`; now guarded with `if directory`.

**`python/mujoco/specs_test.py`**
- `test_to_zip_includes_file_assets`: loads `testdata/msh.xml` (which references `abdomen_1_body.msh` by file path), calls `to_zip`, and asserts the mesh file is present in the zip. Also verifies the zip round-trips to a compilable spec.
- `test_to_zip_does_not_mutate_assets`: asserts `spec.assets` content is unchanged after `to_zip`.

## Reproducer

```python
import io
import mujoco

spec = mujoco.MjSpec.from_file("model_with_mesh.xml")
buf = io.BytesIO()
mujoco.to_zip(spec, buf)
buf.seek(0)
spec2 = mujoco.from_zip(buf)
model = spec2.compile()  # previously raised -- now works
```
