### PR TITLE
Fix #3368: clip hfield grid indices before int cast in MJX collision

### DIFF
--- a/mjx/mujoco/mjx/_src/collision_convex.py
+++ b/mjx/mujoco/mjx/_src/collision_convex.py
@@ -963,9 +963,9 @@ def _hfield_collision(
   xmin = obj_pos[0] - obj_rbound
   ymin = obj_pos[1] - obj_rbound
   cmin = jp.floor((xmin + h.size[0]) / (2 * h.size[0]) * (h.ncol - 1))
-  cmin = cmin.astype(int)
+  cmin = jp.clip(cmin, -(h.ncol - 1), h.ncol - 1).astype(int)
   rmin = jp.floor((ymin + h.size[1]) / (2 * h.size[1]) * (h.nrow - 1))
-  rmin = rmin.astype(int)
+  rmin = jp.clip(rmin, -(h.nrow - 1), h.nrow - 1).astype(int)
 
   # compute real-valued grid step
   dx = 2.0 * h.size[0] / (h.ncol - 1)


### PR DESCRIPTION
## Problem

In `_hfield_collision`, the computed grid indices `cmin` and `rmin` are float values that may be very large (e.g. `+inf` or beyond int32 range) when the colliding object is far outside the height field. Calling `.astype(int)` directly on such values produces an integer overflow, which generates a JAX/XLA warning and results in undefined behaviour on GPU targets.

Note: PR #3369 fixes a related overflow in the `_box_box` and `_convex_convex` paths. This PR addresses the remaining overflow in the hfield path.

Fixes #3368.

## Changes

**`mjx/mujoco/mjx/_src/collision_convex.py`**

Clip `cmin` and `rmin` to a valid range before calling `.astype(int)`:

```python
# Before
cmin = jp.floor(...).astype(int)
rmin = jp.floor(...).astype(int)

# After
cmin = jp.clip(jp.floor(...), -(h.ncol - 1), h.ncol - 1).astype(int)
rmin = jp.clip(jp.floor(...), -(h.nrow - 1), h.nrow - 1).astype(int)
```

The clip bounds match the existing clamps inside `make_prisms` (`jp.clip(ri, 0, h.nrow - 2)` / `jp.clip(ci, 0, h.ncol - 2)`), so the observable collision result is unchanged for in-bounds objects. For out-of-bounds objects the prisms simply land on the nearest valid row/column, which is the correct fallback behaviour.
