### PR TITLE
Fix #2904: add MUJOCO_ENABLE_LTO option to make LTO configurable

### DIFF
--- a/cmake/MujocoOptions.cmake
+++ b/cmake/MujocoOptions.cmake
@@ -108,13 +108,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang
   endif()
 endif()
 
-# Enable interprocedural optimization (LTO) by default for non-Debug builds, but
-# only when the caller has not made an explicit choice. Checking the value (rather
-# than whether it is DEFINED) meant an explicit `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`
-# was silently overridden back to ON, e.g. in CI where LTO is disabled to cut
-# build time.
-if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION AND (CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug"))
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+# Provide a user-facing option to control Link-Time Optimization (LTO/IPO).
+# When ON (the default), LTO is enabled for non-Debug builds unless the caller
+# has already set CMAKE_INTERPROCEDURAL_OPTIMIZATION explicitly.
+# Users can disable LTO entirely with -DMUJOCO_ENABLE_LTO=OFF.
+option(MUJOCO_ENABLE_LTO "Enable Link-Time Optimization (LTO) for non-Debug builds." ON)
+
+if(MUJOCO_ENABLE_LTO)
+  if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION AND (CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug"))
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  endif()
 endif()
 
 include(MujocoHarden)


### PR DESCRIPTION
## Problem

`CMAKE_INTERPROCEDURAL_OPTIMIZATION` was set unconditionally for non-Debug builds whenever `DEFINED` was not set. There was no user-facing CMake option to disable LTO without resorting to undocumented internal variable manipulation.

An explicit `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF` could also be silently overridden in certain CMake configurations, as discussed in the issue.

Fixes #2904.

## Changes

**`cmake/MujocoOptions.cmake`**

- Introduces a new `MUJOCO_ENABLE_LTO` option (default `ON`) that gives users a clean, documented way to disable LTO: `-DMUJOCO_ENABLE_LTO=OFF`.
- The existing `CMAKE_INTERPROCEDURAL_OPTIMIZATION` logic is preserved inside the `if(MUJOCO_ENABLE_LTO)` guard, so the default behaviour (LTO on for non-Debug, off for Debug) is unchanged.

```cmake
# Clean user-facing disable:
cmake -DMUJOCO_ENABLE_LTO=OFF ..
```
