### PR TITLE
Fix #3139: support UTF-8 file paths on Windows via mju_fopen

### DIFF
--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -37,6 +37,7 @@
 #include "engine/engine_util_blas.h"
 #include "engine/engine_util_errmem.h"
 #include "engine/engine_util_misc.h"
+#include "engine/engine_util_file.h"
 
 #ifdef ADDRESS_SANITIZER
   #include <sanitizer/asan_interface.h>
@@ -511,7 +512,7 @@ void mj_saveModel(const mjModel* m, const char* filename, void* buffer, int buff
 
   // open file for writing if no buffer
   if (!buffer) {
-    fp = fopen(filename, "wb");
+    fp = mju_fopen(filename, "wb");
     if (!fp) {
       mju_warning("Could not open file '%s'", filename);
       return;

--- a/src/engine/engine_print.c
+++ b/src/engine/engine_print.c
@@ -34,6 +34,7 @@
 #include "engine/engine_support.h"
 #include "engine/engine_util_errmem.h"
 #include "engine/engine_util_misc.h"
+#include "engine/engine_util_file.h"
 #include "engine/engine_vis_init.h"
 
 #ifdef MEMORY_SANITIZER
@@ -542,7 +543,7 @@ void mj_printFormattedModel(const mjModel* m, const char* filename, const char* 
   // get file
   FILE* fp;
   if (filename) {
-    fp = fopen(filename, "wt");
+    fp = mju_fopen(filename, "wt");
   } else {
     fp = stdout;
   }
@@ -1230,7 +1231,7 @@ void mj_printFormattedData(const mjModel* m, const mjData* d, const char* filena
   // get file
   FILE* fp;
   if (filename) {
-    fp = fopen(filename, "wt");
+    fp = mju_fopen(filename, "wt");
   } else {
     fp = stdout;
   }
@@ -1751,7 +1752,7 @@ void mj_printFormattedScene(const mjvScene* s, const char* filename, const char*
   // get file
   FILE* fp;
   if (filename) {
-    fp = fopen(filename, "wt");
+    fp = mju_fopen(filename, "wt");
   } else {
     fp = stdout;
   }

--- a/src/engine/engine_util_errmem.c
+++ b/src/engine/engine_util_errmem.c
@@ -27,6 +27,7 @@
 
 #include "engine/engine_crossplatform.h"  // IWYU pragma: keep
 #include "engine/engine_macro.h"
+#include "engine/engine_util_file.h"
 
 //------------------------- cross-platform aligned malloc/free -------------------------------------
 
@@ -262,7 +263,7 @@ static void mju_defaultLogHandler(const mjLogMessage* msg) {
   }
 
   if (cfg->logto_file && cfg->logfile[0]) {
-    FILE* fp = fopen(cfg->logfile, "a+t");
+    FILE* fp = mju_fopen(cfg->logfile, "a+t");
     if (fp) {
       mju_fprint_message(fp, timestr, msg);
       fclose(fp);
@@ -348,7 +349,7 @@ void mju_writeLog(const char* type, const char* msg) {
   char timestr[64];
   mju_localTimeStr(timestr, sizeof(timestr));
 
-  FILE* fp = fopen("MUJOCO_LOG.TXT", "a+t");
+  FILE* fp = mju_fopen("MUJOCO_LOG.TXT", "a+t");
   if (fp) {
     fprintf(fp, "%s\n%s: %s\n\n", timestr, type, msg);
     fclose(fp);

--- a/src/engine/engine_util_file.h
+++ b/src/engine/engine_util_file.h
@@ -1,0 +1,58 @@
+// Copyright 2024 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_SRC_ENGINE_ENGINE_UTIL_FILE_H_
+#define MUJOCO_SRC_ENGINE_ENGINE_UTIL_FILE_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+// Platform-aware fopen that supports UTF-8 encoded file paths on Windows.
+// On non-Windows platforms, this is equivalent to fopen.
+static inline FILE* mju_fopen(const char* filename, const char* mode) {
+#ifdef _WIN32
+  // Convert UTF-8 filename to wide string
+  int wlen = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+  if (wlen <= 0) {
+    return fopen(filename, mode);  // fallback
+  }
+  wchar_t* wfilename = (wchar_t*)malloc(wlen * sizeof(wchar_t));
+  if (!wfilename) {
+    return fopen(filename, mode);  // fallback
+  }
+  MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, wlen);
+
+  // Convert mode to wide string
+  int wmlen = MultiByteToWideChar(CP_UTF8, 0, mode, -1, NULL, 0);
+  wchar_t* wmode = (wchar_t*)malloc(wmlen * sizeof(wchar_t));
+  if (!wmode) {
+    free(wfilename);
+    return fopen(filename, mode);  // fallback
+  }
+  MultiByteToWideChar(CP_UTF8, 0, mode, -1, wmode, wmlen);
+
+  FILE* fp = _wfopen(wfilename, wmode);
+  free(wfilename);
+  free(wmode);
+  return fp;
+#else
+  return fopen(filename, mode);
+#endif
+}
+
+#endif  // MUJOCO_SRC_ENGINE_ENGINE_UTIL_FILE_H_

--- a/src/user/user_api.cc
+++ b/src/user/user_api.cc
@@ -43,6 +43,7 @@
 #include "user/user_resolver.h"
 #include "user/user_resource.h"
 #include "user/user_util.h"
+#include "engine/engine_util_file.h"
 
 namespace {
 
@@ -261,7 +262,7 @@ mjtSize mj_encode(const mjSpec* s, const mjModel* m, const char* filename,
     return -1;
   }
 
-  FILE* fp = fopen(filename, "wb");
+  FILE* fp = mju_fopen(filename, "wb");
   if (!fp) {
     std::free(resource.data);
     if (error) {

--- a/src/user/user_util.cc
+++ b/src/user/user_util.cc
@@ -33,6 +33,7 @@
 
 #include <mujoco/mujoco.h>
 #include "engine/engine_crossplatform.h"
+#include "engine/engine_util_file.h"
 
 
 // workaround with locale bug on some MacOS machines
@@ -1194,7 +1195,7 @@ std::string FilePath::StrLower() const {
 
 // read file into memory buffer
 std::vector<uint8_t> FileToMemory(const char* filename) {
-  FILE* fp = fopen(filename, "rb");
+  FILE* fp = mju_fopen(filename, "rb");
   if (!fp) {
     return {};
   }

--- a/src/xml/xml_api.cc
+++ b/src/xml/xml_api.cc
@@ -31,6 +31,7 @@
 #include "xml/xml_global.h"
 #include "xml/xml_native_reader.h"
 #include "xml/xml_util.h"
+#include "engine/engine_util_file.h"
 
 //---------------------------------- Functions -----------------------------------------------------
 
@@ -84,7 +85,7 @@ mjModel* mj_loadXML(const char* filename, const mjVFS* vfs,
 int mj_saveLastXML(const char* filename, const mjModel* m, char* error, int error_sz) {
   FILE *fp = stdout;
   if (filename != nullptr && filename[0] != '\0') {
-    fp = fopen(filename, "w");
+    fp = mju_fopen(filename, "w");
     if (!fp) {
       mjCopyError(error, "File not found", error_sz);
       return 0;


### PR DESCRIPTION
## Problem

On Windows, MuJoCo uses `fopen` throughout its C/C++ layer. `fopen` on Windows uses the system ANSI code page, which means file paths containing UTF-8 characters (non-ASCII) fail to open even though the paths are valid.

Fixes #3139.

## Changes

**`src/engine/engine_util_file.h`** (new file)

Introduces `mju_fopen`, a thin wrapper around `fopen`:
- On Windows: converts the UTF-8 `filename` and `mode` strings to wide (`wchar_t`) using `MultiByteToWideChar(CP_UTF8, ...)` and calls `_wfopen`. Falls back to `fopen` on allocation failure.
- On all other platforms: directly calls `fopen` with zero overhead.

The function is `static inline` in a header so it requires no new compile unit and has no ABI impact.

**Callers updated** to use `mju_fopen` instead of `fopen`:
- `src/engine/engine_io.c` — `mj_saveModel`
- `src/engine/engine_print.c` — `mj_printFormattedModel`, `mj_printFormattedData`, `mj_printFormattedScene`
- `src/engine/engine_util_errmem.c` — log-to-file handler, `mju_writeLog`
- `src/user/user_api.cc` — `mj_encode`
- `src/user/user_util.cc` — `FileToMemory`
- `src/xml/xml_api.cc` — `mj_saveLastXML`
