### PR TITLE
Add height field support to mjx.ray

### DIFF
--- a/doc/mjx.rst
+++ b/doc/mjx.rst
@@ -510,7 +510,7 @@ The following table compares feature support between MJX-Warp and MJX-JAX compar
      - Positions and directions
    * - Ray
      - All, BVH for meshes, hfield, and flex
-     - Slow for meshes, hfield and flex unimplemented
+     - Slow for meshes and hfield, flex unimplemented
 
 
 .. [1] Differentiability is `mostly supported <https://github.com/google-deepmind/mujoco/issues/2259>`__ in MJX-JAX but is

--- a/mjx/mujoco/mjx/_src/ray.py
+++ b/mjx/mujoco/mjx/_src/ray.py
@@ -15,6 +15,7 @@
 """Functions for ray interesection testing."""
 
 from typing import Sequence, Tuple
+import warnings
 
 import jax
 from jax import numpy as jp
@@ -220,8 +221,88 @@ def _ray_mesh(
   return dist, id_
 
 
+def _ray_hfield(
+    m: Model,
+    geom_id: np.ndarray,
+    unused_size: jax.Array,
+    pnt: jax.Array,
+    vec: jax.Array,
+) -> Tuple[jax.Array, np.ndarray]:
+  """Returns the distance at which rays intersect with height fields.
+
+  Follows mj_rayHfield (engine_ray.c): the hfield is the union of the base box
+  (spanning z in [-size[3], 0] in local frame), the terrain surface triangles
+  (two per grid cell), and the four prism sides below the terrain edge. Like
+  _ray_mesh, triangles are tested by brute force with no pruning.
+  """
+  data_id = m.geom_dataid[geom_id]
+
+  ray_basis = lambda x: jp.array(math.orthogonals(math.normalize(x))).T
+  basis = jax.vmap(ray_basis)(vec)
+
+  dists = []
+  for i, hid in enumerate(data_id):
+    nrow, ncol = int(m.hfield_nrow[hid]), int(m.hfield_ncol[hid])
+    size = m.hfield_size[hid]
+    adr = int(m.hfield_adr[hid])
+    data = m.hfield_data[adr : adr + nrow * ncol].reshape(nrow, ncol)
+    p, v = pnt[i], vec[i]
+
+    # base box, centered at z = -size[3]/2 in the local frame
+    base_size = jp.array([size[0], size[1], 0.5 * size[3]])
+    x = _ray_box(base_size, p + jp.array([0.0, 0.0, 0.5 * size[3]]), v)
+
+    # terrain surface: two triangles per grid cell
+    xg = jp.array(np.linspace(-size[0], size[0], ncol))
+    yg = jp.array(np.linspace(-size[1], size[1], nrow))
+    vert = jp.stack(
+        [
+            jp.broadcast_to(xg[None, :], (nrow, ncol)),
+            jp.broadcast_to(yg[:, None], (nrow, ncol)),
+            data * size[2],
+        ],
+        axis=-1,
+    )
+    v00, v10 = vert[:-1, :-1], vert[:-1, 1:]
+    v01, v11 = vert[1:, :-1], vert[1:, 1:]
+    tri = jp.concatenate([
+        jp.stack([v00, v10, v11], axis=2).reshape(-1, 3, 3),
+        jp.stack([v00, v11, v01], axis=2).reshape(-1, 3, 3),
+    ])
+    dist = jax.vmap(_ray_triangle, in_axes=(0, None, None, None))(
+        tri, p, v, basis[i]
+    )
+    x = jp.minimum(x, jp.min(dist))
+
+    # prism sides (z in [0, size[2]]): a side hit counts if the hit point lies
+    # below the terrain edge, interpolated between neighboring data points
+    dx = 2 * size[0] / (ncol - 1)
+    dy = 2 * size[1] / (nrow - 1)
+    for axis, sgn, edge, cell in (
+        (0, -1, data[:, 0], dy),
+        (0, 1, data[:, ncol - 1], dy),
+        (1, -1, data[0, :], dx),
+        (1, 1, data[nrow - 1, :], dx),
+    ):
+      t = math.safe_div(sgn * size[axis] - p[axis], v[axis])
+      hit = p + t * v
+      valid = (jp.abs(v[axis]) > mujoco.mjMINVAL) & (t >= 0)
+      valid &= jp.abs(hit[1 - axis]) <= size[1 - axis]
+      valid &= (hit[2] >= 0) & (hit[2] <= size[2])
+      y = (hit[1 - axis] + size[1 - axis]) / cell
+      y0 = jp.clip(jp.floor(y), 0, edge.shape[0] - 2)
+      z0, z1 = edge[y0.astype(int)], edge[y0.astype(int) + 1]
+      valid &= hit[2] / size[2] < z0 * (y0 + 1 - y) + z1 * (y - y0)
+      x = jp.minimum(x, jp.where(valid, t, jp.inf))
+
+    dists.append(x)
+
+  return jp.stack(dists), geom_id
+
+
 _RAY_FUNC = {
     GeomType.PLANE: _ray_plane,
+    GeomType.HFIELD: _ray_hfield,
     GeomType.SPHERE: _ray_sphere,
     GeomType.CAPSULE: _ray_capsule,
     GeomType.ELLIPSOID: _ray_ellipsoid,
@@ -270,6 +351,15 @@ def ray(
   geom_pnts = jax.vmap(lambda x, y: x.T @ (pnt - y))(d.geom_xmat, d.geom_xpos)
   geom_vecs = jax.vmap(lambda x: x.T @ vec)(d.geom_xmat)
 
+  # warn about candidate geoms whose type has no ray intersection function:
+  # they are invisible to rays (silently reported as a miss)
+  unsupported = set(m.geom_type[geom_filter].tolist()) - set(_RAY_FUNC)
+  if unsupported:
+    names = ', '.join(GeomType(t).name for t in sorted(unsupported))
+    warnings.warn(
+        f'mjx.ray: unsupported geom types treated as invisible: {names}'
+    )
+
   geom_filter_dyn = (m.geom_matid != -1) | (m.geom_rgba[:, 3] != 0)
   geom_filter_dyn &= (m.geom_matid == -1) | (m.mat_rgba[m.geom_matid, 3] != 0)
   for geom_type, fn in _RAY_FUNC.items():
@@ -280,7 +370,7 @@ def ray(
 
     args = m.geom_size[id_], geom_pnts[id_], geom_vecs[id_]
 
-    if geom_type == GeomType.MESH:
+    if geom_type in (GeomType.MESH, GeomType.HFIELD):
       dist, id_ = fn(m, id_, *args)
     else:
       dist = jax.vmap(fn)(*args)

--- a/mjx/mujoco/mjx/_src/ray_test.py
+++ b/mjx/mujoco/mjx/_src/ray_test.py
@@ -240,6 +240,88 @@ class RayTest(parameterized.TestCase):
     _assert_eq(geomid, -1, 'geom_id')
     _assert_eq(dist, -1, 'dist')
 
+  def test_ray_hfield(self):
+    """Tests MJX ray<>hfield matches MuJoCo.
+
+    Before HFIELD was added to _RAY_FUNC, the dispatch loop silently skipped
+    height field geoms: every one of the surface/side/base rays below returned
+    (dist=-1, geomid=-1), i.e. terrain was invisible to mjx.ray while the same
+    rays hit with mujoco.mj_ray.
+    """
+    xml = """
+    <mujoco>
+      <asset>
+        <hfield name="terrain" nrow="9" ncol="11" size="1.0 0.8 0.5 0.1"/>
+        <material name="mat0" rgba="1 1 1 1"/>
+      </asset>
+      <worldbody>
+        <geom name="hf" type="hfield" hfield="terrain" pos="0.05 -0.02 0.03"/>
+        <geom name="ball" type="sphere" size="0.1" pos="0.3 0.2 1.2"
+              material="mat0"/>
+      </worldbody>
+    </mujoco>
+    """
+    m = mujoco.MjModel.from_xml_string(xml)
+    # deterministic bumpy terrain, normalized heights in [0, 1]
+    rr, cc = np.meshgrid(np.arange(9), np.arange(11), indexing='ij')
+    m.hfield_data[:] = (0.5 + 0.5 * np.sin(0.9 * rr) * np.cos(0.7 * cc)).ravel()
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+    mx, dx = mjx.put_model(m), mjx.put_data(m, d)
+
+    rays = [
+        # straight down onto the terrain surface
+        ([0.12, -0.23, 2.0], [0.0, 0.0, -1.0]),
+        ([-0.5, 0.4, 2.0], [0.0, 0.0, -1.0]),
+        # oblique onto the surface
+        ([1.5, 0.8, 1.5], [-0.6, -0.35, -1.0]),
+        # from the side, hitting a prism side face below the terrain edge
+        ([2.0, 0.1, 0.1], [-1.0, 0.0, 0.0]),
+        ([0.0, -2.0, 0.2], [0.05, 1.0, 0.0]),
+        # from below, hitting the bottom of the base box
+        ([0.0, 0.0, -1.0], [0.0, 0.0, 1.0]),
+        # hits the sphere above the terrain
+        ([0.3, 0.2, 2.5], [0.0, 0.0, -1.0]),
+        # misses
+        ([3.0, 3.0, 2.0], [0.0, 0.0, -1.0]),
+        ([-2.0, 0.0, 0.55], [1.0, 0.0, 0.0]),
+    ]
+    ray_fn = jax.jit(mjx.ray)
+    for pnt, vec in rays:
+      pnt, vec = np.array(pnt), np.array(vec)
+      vec /= np.linalg.norm(vec)
+      geomid_mj = np.zeros(1, dtype=np.int32)
+      dist_mj = mujoco.mj_ray(m, d, pnt, vec, None, 1, -1, geomid_mj)
+      dist, geomid = ray_fn(mx, dx, jp.array(pnt), jp.array(vec))
+      _assert_eq(dist, dist_mj, f'dist pnt={pnt} vec={vec}')
+      _assert_eq(geomid, geomid_mj[0], f'geom_id pnt={pnt} vec={vec}')
+
+  def test_ray_unsupported_geom_warning(self):
+    """Tests that ray warns about geom types it cannot intersect."""
+    xml = """
+    <mujoco>
+      <asset>
+        <material name="mat0" rgba="1 1 1 1"/>
+      </asset>
+      <worldbody>
+        <geom name="cyl" type="cylinder" size="0.1 0.3" pos="0 0 1"
+              material="mat0"/>
+        <geom name="ball" type="sphere" size="0.1" pos="1 0 1" material="mat0"/>
+      </worldbody>
+    </mujoco>
+    """
+    m = mujoco.MjModel.from_xml_string(xml)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+    mx, dx = mjx.put_model(m), mjx.put_data(m, d)
+
+    pnt, vec = jp.array([0, 0, 3.0]), jp.array([0, 0, -1.0])
+    with self.assertWarnsRegex(UserWarning, 'CYLINDER'):
+      dist, geomid = mjx.ray(mx, dx, pnt, vec)
+    # the cylinder is invisible to the ray: it reports a miss
+    _assert_eq(geomid, -1, 'geom_id')
+    _assert_eq(dist, -1, 'dist')
+
   def test_ray_invisible(self):
     """Tests ray doesn't hit transparent geoms."""
     m = test_util.load_test_file('ray.xml')


### PR DESCRIPTION
`mjx.ray` has no intersection function for `HFIELD` geoms, so the dispatch loop silently skips height fields: every ray that should hit terrain instead returns `(dist=-1, geomid=-1)` while the same ray hits with `mujoco.mj_ray`. Issue #2155 tracked this and was closed once the Warp backend gained hfield rays, but the JAX backend still lacks it.

This adds `_ray_hfield`, a port of `mj_rayHfield`: the base box, the two surface triangles per grid cell, and the four prism side faces, where a side hit only counts if the hit point lies below the terrain edge interpolated between the neighboring data points. It also makes `ray` warn when a candidate geom has a type with no registered ray function, instead of silently treating it as a miss, and updates the one-line MJX feature-support entry.

I want to be upfront that there is an open in-flight PR for the same feature, #2804, which I only found after writing this. I'm posting this as complementary rather than competing. The overlap is the core port; what this adds on top is the silent-miss warning for unsupported geom types, an exact-parity test battery (9 rays checked bitwise against `mj_ray`: straight-down and oblique surface hits, side-face hits below the terrain edge, the base box from below, occlusion by a sphere above the terrain, and misses), and the doc-table line. The implementations differ in shape: this one composes per-face candidate distances with a running `minimum` and a per-face validity mask, whereas #2804 uses a compiled-for-fixed-size early-out. I'm happy to converge on whichever implementation the maintainers prefer, drop mine in favor of #2804's, or fold these tests and the warning onto #2804; the tests are implementation-agnostic and should transfer either way.

Separately, while testing I hit a pre-existing crash unrelated to this change: `mjx.ray` raises when the model has no materials (`nmat == 0`), because the visibility filter indexes `mat_rgba[geom_matid]` with `geom_matid == -1` into an empty array. All the tests here put a material on every geom to avoid it. I'm happy to send a follow-up that guards that filter if useful.

I prepared this change with AI assistance (Claude); I have not added it as a commit co-author, since it cannot sign the CLA, and I've reviewed the change and take responsibility for it.
