### PR TITLE
Support pinned flex vertices with bending

### DIFF
--- a/src/engine/engine_passive.c
+++ b/src/engine/engine_passive.c
@@ -481,10 +481,15 @@ static void mj_flexPassiveBend(const mjModel* m, mjData* d, int f,
     frc[0][1] = -(frc[1][1] + frc[2][1] + frc[3][1]);
     frc[0][2] = -(frc[1][2] + frc[2][2] + frc[3][2]);
 
-    // velocities
-    mjtNum* vel[4];
+    // velocities. A PINNED vertex is welded to a parent body (not a free 3-slide flex vertex): its bending
+    // reaction is absorbed by the pin, so treat its velocity as zero (exact for a static pin) and (below) apply
+    // no force to it. isfree[i] distinguishes the two -- a free flex vertex's body has exactly 3 (slide) dofs.
+    static const mjtNum zero3[3] = {0, 0, 0};
+    const mjtNum* vel[4]; int isfree[4];
     for (int i = 0; i < 4; i++) {
-      vel[i] = d->qvel + m->body_dofadr[bodyid[v[i]]];
+      int bid = bodyid[v[i]];
+      isfree[i] = (m->body_dofnum[bid] == 3);
+      vel[i] = isfree[i] ? (d->qvel + m->body_dofadr[bid]) : zero3;
     }
 
     // force
@@ -506,12 +511,13 @@ static void mj_flexPassiveBend(const mjModel* m, mjData* d, int f,
       }
     }
 
-    // insert into global force
+    // insert into global force (free flex vertices only: 3 translational dofs, no moment arm). A pinned vertex has
+    // no free flex dof -- its bending reaction is carried by the pin -- so it is skipped (its POSITION still enters
+    // every neighbor's force via the xpos sum above, which is what the pin constrains).
     for (int i = 0; i < 4; i++) {
-      int bid = bodyid[v[i]];
-      int body_dofnum = m->body_dofnum[bid];
-      int body_dofadr = m->body_dofadr[bid];
-      for (int x = 0; x < body_dofnum; x++) {
+      if (!isfree[i]) continue;
+      int body_dofadr = m->body_dofadr[bodyid[v[i]]];
+      for (int x = 0; x < 3; x++) {
         if (enbl_spring) d->qfrc_spring[body_dofadr+x] -= spring[3*i+x];
         if (enbl_damper) d->qfrc_damper[body_dofadr+x] -= damper[3*i+x] * m->flex_damping[f];
       }

--- a/src/user/user_mesh.cc
+++ b/src/user/user_mesh.cc
@@ -4280,11 +4280,9 @@ void mjCFlex::ResolveReferences(const mjCModel* m) {
     mjCBody* pbody = static_cast<mjCBody*>(m->FindObject(mjOBJ_BODY, vertbody));
     if (pbody) {
       vertbodyid.push_back(pbody->id);
-      if (pbody->joints.size() != 3 && dim == 2 &&
-          (elastic2d == 1 || elastic2d == 3) && !interpolated) {
-        // TODO(quaglino): add support for pins
-        throw mjCError(this, "pins are not supported for bending");
-      }
+      // pinned vertices (body without 3 free slide dofs) ARE supported for bending now: mj_flexPassiveBend skips
+      // applying the bending force to them (the reaction is carried by the pin) while still using their position
+      // in every neighbor's force; the IPC integrator's bending does the same. So no restriction here.
     } else {
       throw mjCError(this, "unknown body '%s' in flex", vertbody.c_str());
     }


### PR DESCRIPTION
The flexcomp compiler previously rejected pins on dim-2 flexes with bending (elastic2d bend/both). Allow them: mj_flexPassiveBend treats a pinned vertex (body without 3 free slide dofs) as static -- zero velocity, and no bending force applied to it (the reaction is carried by the pin) -- while its position still enters every neighbor's bending force, which is exactly what the pin constrains.