### PR TITLE
Defer material instance destruction in the Filament renderer.

### DIFF
--- a/src/render/filament/core/material_manager.cc
+++ b/src/render/filament/core/material_manager.cc
@@ -79,6 +79,9 @@ MaterialManager::MaterialManager(ObjectManager* object_mgr)
     : object_mgr_(object_mgr) {}
 
 MaterialManager::~MaterialManager() {
+  for (filament::MaterialInstance* instance : graveyard_) {
+    object_mgr_->GetEngine()->destroy(instance);
+  }
   for (auto& [key, instance] : instances_) {
     object_mgr_->GetEngine()->destroy(instance);
   }
@@ -87,12 +90,20 @@ MaterialManager::~MaterialManager() {
 void MaterialManager::PrepareToRender() { used_keys_.clear(); }
 
 void MaterialManager::RemoveUnusedMaterials() {
+  // Destroy instances swept on the previous frame. By now, every renderable
+  // that was drawn has been re-bound to a current instance, so the swept
+  // instances are no longer referenced by any live entity.
+  for (filament::MaterialInstance* instance : graveyard_) {
+    object_mgr_->GetEngine()->destroy(instance);
+  }
+  graveyard_.clear();
+
   if (instances_.size() == used_keys_.size()) {
     return;
   }
   for (auto it = instances_.begin(); it != instances_.end();) {
     if (!used_keys_.contains(it->first)) {
-      object_mgr_->GetEngine()->destroy(it->second);
+      graveyard_.push_back(it->second);
       it = instances_.erase(it);
     } else {
       ++it;

--- a/src/render/filament/core/material_manager.h
+++ b/src/render/filament/core/material_manager.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include <filament/Engine.h>
 #include <filament/MaterialInstance.h>
@@ -83,6 +84,11 @@ class MaterialManager {
   ObjectManager* object_mgr_;
   std::unordered_map<MaterialKey, filament::MaterialInstance*> instances_;
   std::unordered_set<MaterialKey> used_keys_;
+
+  // Instances swept by RemoveUnusedMaterials, destroyed one frame later:
+  // renderable entities may still be bound to a swept instance until they are
+  // re-bound during rendering, and destroying a bound instance is an error.
+  std::vector<filament::MaterialInstance*> graveyard_;
 };
 }  // namespace mujoco
 


### PR DESCRIPTION
MaterialManager::RemoveUnusedMaterials destroyed unused material instances before renderables were re-bound to their current instances (binding happens later in the frame, in SceneView::Render). Any renderable whose material key changes between frames therefore left its entity bound to an instance being destroyed, tripping Filament's precondition that a material instance may not be destroyed while referenced by a live entity. Swept instances are now moved to a graveyard and destroyed one frame later, after every drawn renderable has been re-bound.
