### PR TITLE
Preserve small MuJoCo semantics in USD decoder

### DIFF
--- a/plugin/usd_decoder/kinematic_tree.cc
+++ b/plugin/usd_decoder/kinematic_tree.cc
@@ -139,7 +139,9 @@ ExtractedPrims ExtractPrims(pxr::UsdStageRefPtr stage) {
       root->physics_scene = prim_path;
     }
 
-    if (prim.IsA<pxr::UsdGeomGprim>()) {
+    bool is_site = prim.HasAPI<pxr::MjcPhysicsSiteAPI>();
+
+    if (prim.IsA<pxr::UsdGeomGprim>() && !is_site) {
       bool has_collision_api = prim.HasAPI<pxr::UsdPhysicsCollisionAPI>();
       if (has_collision_api) {
         bool collision_enabled = false;
@@ -155,7 +157,7 @@ ExtractedPrims ExtractPrims(pxr::UsdStageRefPtr stage) {
       }
     }
 
-    if (prim.HasAPI<pxr::MjcPhysicsSiteAPI>()) {
+    if (is_site) {
       current_node->sites.push_back(prim_path);
       // Sites should not have children.
       it.PruneChildren();

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -50,6 +50,7 @@
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/types.h>
+#include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/common.h>
 #include <pxr/usd/usd/prim.h>
@@ -114,6 +115,41 @@ struct UsdCaches {
 };
 
 constexpr const char* kUsdPrimPathKey = "usd_primpath";
+
+std::string StripExtension(std::string filename) {
+  const std::size_t slash = filename.find_last_of("/\\");
+  if (slash != std::string::npos) {
+    filename = filename.substr(slash + 1);
+  }
+  const std::size_t dot = filename.find_last_of('.');
+  if (dot != std::string::npos) {
+    filename.erase(dot);
+  }
+  return filename;
+}
+
+std::string GetStageModelName(const pxr::UsdStageRefPtr& stage) {
+  pxr::UsdPrim default_prim = stage->GetDefaultPrim();
+  if (default_prim) {
+    std::string display_name = default_prim.GetDisplayName();
+    if (!display_name.empty()) {
+      return display_name;
+    }
+    std::string prim_name = default_prim.GetName().GetString();
+    if (!prim_name.empty()) {
+      return prim_name;
+    }
+  }
+
+  if (pxr::SdfLayerHandle root_layer = stage->GetRootLayer()) {
+    std::string layer_stem = StripExtension(root_layer->GetDisplayName());
+    if (!layer_stem.empty()) {
+      return layer_stem;
+    }
+  }
+
+  return "";
+}
 
 void SetUsdPrimPathUserValue(mjsElement* element,
                              const pxr::SdfPath& prim_path) {
@@ -2589,6 +2625,10 @@ void PopulateSpecFromTree(pxr::UsdStageRefPtr stage, mjSpec* spec,
 
 mjSpec* ParseStage(const pxr::UsdStageRefPtr stage) {
   mjSpec* spec = mj_makeSpec();
+  std::string model_name = GetStageModelName(stage);
+  if (!model_name.empty()) {
+    mjs_setString(spec->modelname, model_name.c_str());
+  }
 
   std::unique_ptr<Node> root = BuildKinematicTree(stage);
 

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -1921,6 +1921,10 @@ void ParseUsdGeomGprim(mjSpec* spec, const pxr::UsdPrim& gprim,
     }
   }
 
+  if (gprim.HasAPI<pxr::MjcPhysicsCollisionAPI>()) {
+    ParseMjcPhysicsCollisionAPI(geom, pxr::MjcPhysicsCollisionAPI(gprim));
+  }
+
   if (gprim.HasAPI<pxr::MjcPhysicsImageableAPI>()) {
     auto imageable_api = pxr::MjcPhysicsImageableAPI(gprim);
     auto group_attr = imageable_api.GetGroupAttr();

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -2348,9 +2348,12 @@ void ParseUsdPhysicsJoint(mjSpec* spec, const pxr::UsdPrim& prim, mjsBody* body,
       mj_joint->axis[2] = 1;
     }
 
+    pxr::UsdAttribute lower_attr = revolute.GetLowerLimitAttr();
+    pxr::UsdAttribute upper_attr = revolute.GetUpperLimitAttr();
     float lower, upper;
-    if (revolute.GetLowerLimitAttr().Get(&lower) &&
-        revolute.GetUpperLimitAttr().Get(&upper)) {
+    if (lower_attr.HasAuthoredValue() && upper_attr.HasAuthoredValue() &&
+        lower_attr.Get(&lower) && upper_attr.Get(&upper) &&
+        !(std::isinf(lower) && lower < 0 && std::isinf(upper) && upper > 0)) {
       mj_joint->limited = mjLIMITED_TRUE;
       if (spec->compiler.degree) {
         mj_joint->range[0] = lower;
@@ -2377,9 +2380,12 @@ void ParseUsdPhysicsJoint(mjSpec* spec, const pxr::UsdPrim& prim, mjsBody* body,
       mj_joint->axis[1] = 0;
       mj_joint->axis[2] = 1;
     }
+    pxr::UsdAttribute lower_attr = prismatic.GetLowerLimitAttr();
+    pxr::UsdAttribute upper_attr = prismatic.GetUpperLimitAttr();
     float lower, upper;
-    if (prismatic.GetLowerLimitAttr().Get(&lower) &&
-        prismatic.GetUpperLimitAttr().Get(&upper)) {
+    if (lower_attr.HasAuthoredValue() && upper_attr.HasAuthoredValue() &&
+        lower_attr.Get(&lower) && upper_attr.Get(&upper) &&
+        !(std::isinf(lower) && lower < 0 && std::isinf(upper) && upper > 0)) {
       mj_joint->limited = mjLIMITED_TRUE;
       mj_joint->range[0] = lower;
       mj_joint->range[1] = upper;

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -48,6 +48,7 @@
 #include <pxr/base/gf/vec3d.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/staticTokens.h>
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/types.h>
 #include <pxr/usd/sdf/layer.h>
@@ -116,18 +117,6 @@ struct UsdCaches {
 
 constexpr const char* kUsdPrimPathKey = "usd_primpath";
 
-std::string StripExtension(std::string filename) {
-  const std::size_t slash = filename.find_last_of("/\\");
-  if (slash != std::string::npos) {
-    filename = filename.substr(slash + 1);
-  }
-  const std::size_t dot = filename.find_last_of('.');
-  if (dot != std::string::npos) {
-    filename.erase(dot);
-  }
-  return filename;
-}
-
 std::string GetStageModelName(const pxr::UsdStageRefPtr& stage) {
   pxr::UsdPrim default_prim = stage->GetDefaultPrim();
   if (default_prim) {
@@ -142,7 +131,8 @@ std::string GetStageModelName(const pxr::UsdStageRefPtr& stage) {
   }
 
   if (pxr::SdfLayerHandle root_layer = stage->GetRootLayer()) {
-    std::string layer_stem = StripExtension(root_layer->GetDisplayName());
+    std::string layer_stem =
+        pxr::TfStringGetBeforeSuffix(root_layer->GetDisplayName());
     if (!layer_stem.empty()) {
       return layer_stem;
     }

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -2352,11 +2352,9 @@ void ParseUsdPhysicsJoint(mjSpec* spec, const pxr::UsdPrim& prim, mjsBody* body,
       mj_joint->axis[2] = 1;
     }
 
-    pxr::UsdAttribute lower_attr = revolute.GetLowerLimitAttr();
-    pxr::UsdAttribute upper_attr = revolute.GetUpperLimitAttr();
     float lower, upper;
-    if (lower_attr.HasAuthoredValue() && upper_attr.HasAuthoredValue() &&
-        lower_attr.Get(&lower) && upper_attr.Get(&upper) &&
+    if (revolute.GetLowerLimitAttr().Get(&lower) &&
+        revolute.GetUpperLimitAttr().Get(&upper) &&
         !(std::isinf(lower) && lower < 0 && std::isinf(upper) && upper > 0)) {
       mj_joint->limited = mjLIMITED_TRUE;
       if (spec->compiler.degree) {
@@ -2384,11 +2382,9 @@ void ParseUsdPhysicsJoint(mjSpec* spec, const pxr::UsdPrim& prim, mjsBody* body,
       mj_joint->axis[1] = 0;
       mj_joint->axis[2] = 1;
     }
-    pxr::UsdAttribute lower_attr = prismatic.GetLowerLimitAttr();
-    pxr::UsdAttribute upper_attr = prismatic.GetUpperLimitAttr();
     float lower, upper;
-    if (lower_attr.HasAuthoredValue() && upper_attr.HasAuthoredValue() &&
-        lower_attr.Get(&lower) && upper_attr.Get(&upper) &&
+    if (prismatic.GetLowerLimitAttr().Get(&lower) &&
+        prismatic.GetUpperLimitAttr().Get(&upper) &&
         !(std::isinf(lower) && lower < 0 && std::isinf(upper) && upper > 0)) {
       mj_joint->limited = mjLIMITED_TRUE;
       mj_joint->range[0] = lower;


### PR DESCRIPTION
## Summary

This PR combines four small USD decoder preservation fixes:

- Treat `MjcSiteAPI` prims as sites only, not both sites and visual geoms.
- Initialize `mjSpec::modelname` from the USD stage/default prim when possible.
- Only mark revolute/prismatic joints as MuJoCo-limited when finite lower/upper limits are authored.
- Parse `MjcCollisionAPI` metadata on disabled colliders that are imported through the visual-geom path.

Fixes #3391
## Why

These are narrow roundtrip-fidelity issues. They do not introduce new schema or change the broad USD import architecture, but they remove noisy and sometimes physics-relevant differences in compiled MuJoCo models.

## Details

### Sites

`MjcSiteAPI` prims can also be `UsdGeomGprim`s for guide/visual purposes. The decoder should route them to the site list and avoid also treating them as visual geoms.

### Model Name

The decoder now tries, in order:

1. default prim display name
2. default prim name
3. root layer display name without extension

If none are available, the existing MuJoCo default remains unchanged.

### Unlimited Joint Limits

The decoder now enables MuJoCo joint limits only when both lower and upper USD limit attributes are authored and not the unbounded fallback pair `[-inf, inf]`.

### Disabled Collider Metadata

If a disabled collider is routed through the visual path, it remains contact-disabled, but MuJoCo-specific metadata such as `group` is still decoded from `MjcCollisionAPI`.

## USD / non-USD impact

The changes are contained to `plugin/usd_decoder`, which is only built when `MUJOCO_WITH_USD=ON`.

## Validation

Each source branch built locally with:

```bash
cmake --build ./mujoco/build --target usd_decoder_plugin --parallel 8
```

Roundtrip fixture/model evidence from this repo:

- Site double-decode count warnings disappear for models that author guide/site prims.
- Root model names no longer become `"MuJoCo Model"` when a better USD name exists.
- `fixtures/unlimited_joint_limits.xml` stops reporting `limited: False != True`.
- Lite6 narrow's disabled `gripper_lite_body.group` metadata is preserved in the direct USD-imported MJB comparison.
````