### PR TITLE
Check physics-purpose material bindings in USD decoder for contact properties

### DIFF
--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -110,10 +110,14 @@ struct UsdCaches {
   pxr::UsdGeomXformCache xform_cache;
   pxr::UsdShadeMaterialBindingAPI::BindingsCache bindings_cache;
   pxr::UsdShadeMaterialBindingAPI::CollectionQueryCache collection_query_cache;
+  pxr::UsdShadeMaterialBindingAPI::BindingsCache physics_bindings_cache;
+  pxr::UsdShadeMaterialBindingAPI::CollectionQueryCache
+      physics_collection_query_cache;
   std::map<pxr::SdfPath, mjsMaterial*> parsed_materials;
 };
 
 constexpr const char* kUsdPrimPathKey = "usd_primpath";
+const pxr::TfToken kPhysicsMaterialPurpose("physics");
 
 void SetUsdPrimPathUserValue(mjsElement* element,
                              const pxr::SdfPath& prim_path) {
@@ -1816,6 +1820,26 @@ void ParseMjcPhysicsMaterialAPI(
   }
 }
 
+bool ParsePhysicsMaterialAPIsIfAuthored(
+    mjsGeom* geom, const pxr::UsdPrim& material_prim) {
+  bool parsed = false;
+  if (material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>()) {
+    ParseUsdPhysicsMaterialAPI(
+        geom, pxr::UsdPhysicsMaterialAPI(material_prim));
+    parsed = true;
+  }
+  if (material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>()) {
+    ParseMjcPhysicsMaterialAPI(
+        geom, material_prim, pxr::MjcPhysicsMaterialAPI(material_prim));
+    parsed = true;
+  } else if (material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI)) {
+    ParseMjcPhysicsMaterialAPI(
+        geom, material_prim, pxr::MjcPhysicsMaterialAPI(material_prim));
+    parsed = true;
+  }
+  return parsed;
+}
+
 void ParseDisplayColorAndOpacity(const pxr::UsdPrim& prim, mjsGeom* geom) {
   // Convert displayColor and displayOpacity to rgba.
   // We want to support primvar inheritance, hence FindPrimvarWithInheritance.
@@ -1919,41 +1943,26 @@ void ParseUsdPhysicsCollider(mjSpec* spec,
     ParseMjcPhysicsCollisionAPI(geom, pxr::MjcPhysicsCollisionAPI(prim));
   }
 
-  // Check for physics-purpose material binding first (for contact properties)
-  pxr::TfToken physics_purpose("physics");
+  pxr::UsdShadeMaterialBindingAPI material_binding_api(prim);
   pxr::UsdShadeMaterial physics_material =
-      pxr::UsdShadeMaterialBindingAPI(prim).ComputeBoundMaterial(
-          physics_purpose, &caches.bindings_cache, &caches.collection_query_cache);
+      material_binding_api.ComputeBoundMaterial(
+          &caches.physics_bindings_cache, &caches.physics_collection_query_cache,
+          kPhysicsMaterialPurpose);
+  bool parsed_physics_material = false;
   if (physics_material) {
-    pxr::UsdPrim physics_material_prim = physics_material.GetPrim();
-    if (physics_material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>() ||
-        physics_material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>() ||
-        physics_material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI)) {
-      ParseUsdPhysicsMaterialAPI(
-          geom, pxr::UsdPhysicsMaterialAPI(physics_material_prim));
-      ParseMjcPhysicsMaterialAPI(
-          geom, physics_material_prim,
-          pxr::MjcPhysicsMaterialAPI(physics_material_prim));
-    }
+    parsed_physics_material =
+        ParsePhysicsMaterialAPIsIfAuthored(geom, physics_material.GetPrim());
   }
 
-  // Check for default/all-purpose material binding (for visual properties)
   pxr::UsdShadeMaterial bound_material =
-      pxr::UsdShadeMaterialBindingAPI(prim).ComputeBoundMaterial(
+      material_binding_api.ComputeBoundMaterial(
           &caches.bindings_cache, &caches.collection_query_cache);
   if (bound_material) {
     pxr::UsdPrim bound_material_prim = bound_material.GetPrim();
-    // If no physics-purpose binding was found, check default binding for physics APIs
-    if (!physics_material &&
-        (bound_material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>() ||
-         bound_material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>() ||
-         bound_material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI))) {
-      ParseUsdPhysicsMaterialAPI(
-          geom, pxr::UsdPhysicsMaterialAPI(bound_material_prim));
-      ParseMjcPhysicsMaterialAPI(
-          geom, bound_material_prim,
-          pxr::MjcPhysicsMaterialAPI(bound_material_prim));
+    if (!parsed_physics_material) {
+      ParsePhysicsMaterialAPIsIfAuthored(geom, bound_material_prim);
     }
+
     pxr::SdfPath material_path = bound_material_prim.GetPath();
     mjsMaterial* material = nullptr;
     if (auto iter = caches.parsed_materials.find(material_path);

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -1919,14 +1919,35 @@ void ParseUsdPhysicsCollider(mjSpec* spec,
     ParseMjcPhysicsCollisionAPI(geom, pxr::MjcPhysicsCollisionAPI(prim));
   }
 
+  // Check for physics-purpose material binding first (for contact properties)
+  pxr::TfToken physics_purpose("physics");
+  pxr::UsdShadeMaterial physics_material =
+      pxr::UsdShadeMaterialBindingAPI(prim).ComputeBoundMaterial(
+          physics_purpose, &caches.bindings_cache, &caches.collection_query_cache);
+  if (physics_material) {
+    pxr::UsdPrim physics_material_prim = physics_material.GetPrim();
+    if (physics_material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>() ||
+        physics_material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>() ||
+        physics_material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI)) {
+      ParseUsdPhysicsMaterialAPI(
+          geom, pxr::UsdPhysicsMaterialAPI(physics_material_prim));
+      ParseMjcPhysicsMaterialAPI(
+          geom, physics_material_prim,
+          pxr::MjcPhysicsMaterialAPI(physics_material_prim));
+    }
+  }
+
+  // Check for default/all-purpose material binding (for visual properties)
   pxr::UsdShadeMaterial bound_material =
       pxr::UsdShadeMaterialBindingAPI(prim).ComputeBoundMaterial(
           &caches.bindings_cache, &caches.collection_query_cache);
   if (bound_material) {
     pxr::UsdPrim bound_material_prim = bound_material.GetPrim();
-    if (bound_material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>() ||
-        bound_material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>() ||
-        bound_material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI)) {
+    // If no physics-purpose binding was found, check default binding for physics APIs
+    if (!physics_material &&
+        (bound_material_prim.HasAPI<pxr::UsdPhysicsMaterialAPI>() ||
+         bound_material_prim.HasAPI<pxr::MjcPhysicsMaterialAPI>() ||
+         bound_material_prim.HasAPI(kNewtonTokens->NewtonMaterialAPI))) {
       ParseUsdPhysicsMaterialAPI(
           geom, pxr::UsdPhysicsMaterialAPI(bound_material_prim));
       ParseMjcPhysicsMaterialAPI(


### PR DESCRIPTION
The USD decoder previously only checked default/all-purpose material bindings when importing colliders, missing physics-purpose material bindings that carry contact properties like friction, solref, solimp, margin, and gap. In USD, a collider can bind one material for visual appearance (default purpose) and a separate material for physics simulation (physics purpose).

The fix modifies `ParseUsdPhysicsCollider` in `plugin/usd_decoder/usd_decoder.cc` to query physics-purpose material bindings before falling back to default bindings. When a physics-purpose binding exists with physics material APIs, the decoder now correctly extracts contact properties from that material. The default binding continues to provide visual material assignment. This ensures MJCF→USD→MJCF roundtrips preserve authored contact properties.

Fixes #3393
