### PR TITLE
Preserve inertial semantics when decoding USD

### DIFF
--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -877,11 +877,15 @@ void ParseUsdPhysicsScene(mjSpec* spec,
 
 void ParseUsdPhysicsMassAPIForBody(mjsBody* body,
                                    const pxr::UsdPhysicsMassAPI& mass_api) {
+  bool has_mass = false;
+  bool has_diagonal_inertia = false;
+
   auto mass_attr = mass_api.GetMassAttr();
   if (mass_attr.HasAuthoredValue()) {
     float mass;
     mass_attr.Get(&mass);
     body->mass = mass;
+    has_mass = true;
   }
 
   auto com_attr = mass_api.GetCenterOfMassAttr();
@@ -903,6 +907,11 @@ void ParseUsdPhysicsMassAPIForBody(mjsBody* body,
     pxr::GfVec3f diag_inertia;
     diag_inertia_attr.Get(&diag_inertia);
     SetDoubleArrFromGfVec3d(body->inertia, diag_inertia);
+    has_diagonal_inertia = true;
+  }
+
+  if (has_mass && has_diagonal_inertia) {
+    body->explicitinertial = true;
   }
 }
 

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -1894,6 +1894,10 @@ void ParseUsdGeomGprim(mjSpec* spec, const pxr::UsdPrim& gprim,
     }
   }
 
+  if (gprim.HasAPI<pxr::UsdPhysicsMassAPI>()) {
+    ParseUsdPhysicsMassAPIForGeom(geom, pxr::UsdPhysicsMassAPI(gprim));
+  }
+
   if (gprim.HasAPI<pxr::MjcPhysicsImageableAPI>()) {
     auto imageable_api = pxr::MjcPhysicsImageableAPI(gprim);
     auto group_attr = imageable_api.GetGroupAttr();

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -932,6 +932,21 @@ void ParseUsdPhysicsMassAPIForGeom(mjsGeom* geom,
   }
 }
 
+bool HasAuthoredMassOrDensity(const pxr::UsdPhysicsMassAPI& mass_api) {
+  return mass_api.GetMassAttr().HasAuthoredValue() ||
+         mass_api.GetDensityAttr().HasAuthoredValue();
+}
+
+bool IsMasslessMjcImageable(const pxr::UsdPrim& prim) {
+  if (!prim.HasAPI<pxr::MjcPhysicsImageableAPI>()) {
+    return false;
+  }
+  if (!prim.HasAPI<pxr::UsdPhysicsMassAPI>()) {
+    return true;
+  }
+  return !HasAuthoredMassOrDensity(pxr::UsdPhysicsMassAPI(prim));
+}
+
 void ParseMjcPhysicsCollisionAPI(
     mjsGeom* geom, const pxr::MjcPhysicsCollisionAPI& collision_api) {
   auto shell_inertia_attr = collision_api.GetShellInertiaAttr();
@@ -1892,6 +1907,13 @@ void ParseUsdGeomGprim(mjSpec* spec, const pxr::UsdPrim& gprim,
     if (material) {
       mjs_setString(geom->material, mjs_getName(material->element)->c_str());
     }
+  }
+
+  if (IsMasslessMjcImageable(gprim)) {
+    // MjcImageableAPI marks MuJoCo visual-only geoms. If they do not carry
+    // explicit mass or density, keep them from inheriting MuJoCo's default
+    // geom density and affecting inferred body inertias.
+    geom->density = 0;
   }
 
   if (gprim.HasAPI<pxr::UsdPhysicsMassAPI>()) {

--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -932,21 +932,6 @@ void ParseUsdPhysicsMassAPIForGeom(mjsGeom* geom,
   }
 }
 
-bool HasAuthoredMassOrDensity(const pxr::UsdPhysicsMassAPI& mass_api) {
-  return mass_api.GetMassAttr().HasAuthoredValue() ||
-         mass_api.GetDensityAttr().HasAuthoredValue();
-}
-
-bool IsMasslessMjcImageable(const pxr::UsdPrim& prim) {
-  if (!prim.HasAPI<pxr::MjcPhysicsImageableAPI>()) {
-    return false;
-  }
-  if (!prim.HasAPI<pxr::UsdPhysicsMassAPI>()) {
-    return true;
-  }
-  return !HasAuthoredMassOrDensity(pxr::UsdPhysicsMassAPI(prim));
-}
-
 void ParseMjcPhysicsCollisionAPI(
     mjsGeom* geom, const pxr::MjcPhysicsCollisionAPI& collision_api) {
   auto shell_inertia_attr = collision_api.GetShellInertiaAttr();
@@ -1909,15 +1894,20 @@ void ParseUsdGeomGprim(mjSpec* spec, const pxr::UsdPrim& gprim,
     }
   }
 
-  if (IsMasslessMjcImageable(gprim)) {
-    // MjcImageableAPI marks MuJoCo visual-only geoms. If they do not carry
-    // explicit mass or density, keep them from inheriting MuJoCo's default
-    // geom density and affecting inferred body inertias.
-    geom->density = 0;
+  bool has_authored_mass_properties = false;
+  if (gprim.HasAPI<pxr::UsdPhysicsMassAPI>()) {
+    auto mass_api = pxr::UsdPhysicsMassAPI(gprim);
+    has_authored_mass_properties =
+        mass_api.GetMassAttr().HasAuthoredValue() ||
+        mass_api.GetDensityAttr().HasAuthoredValue();
+    ParseUsdPhysicsMassAPIForGeom(geom, mass_api);
   }
 
-  if (gprim.HasAPI<pxr::UsdPhysicsMassAPI>()) {
-    ParseUsdPhysicsMassAPIForGeom(geom, pxr::UsdPhysicsMassAPI(gprim));
+  if (gprim.HasAPI<pxr::MjcPhysicsImageableAPI>() &&
+      !has_authored_mass_properties) {
+    // This non-collider GPrim has MuJoCo visual metadata but no explicit mass
+    // properties. Keep it from inheriting MuJoCo's default geom density.
+    geom->density = 0;
   }
 
   if (gprim.HasAPI<pxr::MjcPhysicsImageableAPI>()) {


### PR DESCRIPTION
## Summary

This PR preserves MuJoCo inertial semantics during USD decode:

- If `UsdPhysicsMassAPI` authors both mass and diagonal inertia on a body, mark the decoded body inertial as explicit.
- Decode `UsdPhysicsMassAPI` mass/density on visual `UsdGeomGprim` geoms as well as colliders.
- Treat visual-only `MjcImageableAPI` geoms with no authored mass or density as `density=0`, so they do not inherit MuJoCo default density and alter inferred body inertias.

Fixes #3399

## Why

MuJoCo roundtrip validation showed that visual-only meshes could accidentally gain mass during USD import, and explicit inertials could be lost during compilation. Both affect sampled dynamics.

## USD / non-USD impact

The change is contained to `plugin/usd_decoder`, which is only built when `MUJOCO_WITH_USD=ON`.

## Validation
Roundtrip evidence:

- Franka hand/finger mass and inertia match after preserving explicit inertials.
- UMI gripper no longer gains mass from visual-only mesh geoms after defaulting massless `MjcImageableAPI` geoms to `density=0`.