### PR TITLE
Fix joint ordering in MjSpec.to_xml() for attached models

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -479,6 +479,9 @@ mjCModel& mjCModel::operator+=(const mjCModel& other) {
   // update pointers to local elements
   PointToLocal();
 
+  // reprocess lists to ensure ordering matches compiled model after attach
+  ProcessLists(/*checkrepeat=*/false);
+
   // update signature after we updated the tree lists and we updated the pointers
   spec.element->signature = Signature();
   return *this;

--- a/src/xml/xml_native_writer.cc
+++ b/src/xml/xml_native_writer.cc
@@ -14,6 +14,7 @@
 
 #include "xml/xml_native_writer.h"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdio>
@@ -1744,15 +1745,25 @@ void mjXWriter::Body(XMLElement* elem, mjCBody* body, mjCFrame* frame, string_vi
   }
 
   // joints in this frame
+  // collect joints in this frame
+  std::vector<mjCJoint*> frame_joints;
   for (int i = 0; i < body->joints.size(); i++) {
-    if (body->joints[i]->frame != frame) {
-      continue;
+    if (body->joints[i]->frame == frame) {
+      frame_joints.push_back(body->joints[i]);
     }
-    string classname = body->joints[i]->frame && !body->joints[i]->frame->classname.empty()
-                           ? body->joints[i]->frame->classname
+  }
+  // sort by compiled joint id to preserve ordering
+  std::sort(frame_joints.begin(), frame_joints.end(),
+            [](const mjCJoint* a, const mjCJoint* b) {
+              return a->id < b->id;
+            });
+  // write joints in sorted order
+  for (mjCJoint* joint : frame_joints) {
+    string classname = joint->frame && !joint->frame->classname.empty()
+                           ? joint->frame->classname
                            : body->classname;
-    OneJoint(InsertEnd(elem, "joint"), body->joints[i],
-             model->def_map[body->joints[i]->classname],
+    OneJoint(InsertEnd(elem, "joint"), joint,
+             model->def_map[joint->classname],
              classname.empty() ? childclass : classname);
   }
 
@@ -1814,42 +1825,34 @@ void mjXWriter::Body(XMLElement* elem, mjCBody* body, mjCFrame* frame, string_vi
   }
 
   // write children recursively
-  int i = 0, j = 0;
-  while (i < body->bodies.size() || body->bodies.empty()) {
-    mjCFrame* bframe = body->bodies.empty() ? nullptr : body->bodies[i]->frame;
+  // collect bodies in this frame and sort by compiled id to preserve ordering
+  std::vector<mjCBody*> frame_bodies;
+  for (mjCBody* child : body->bodies) {
+    if (child->frame == frame) {
+      frame_bodies.push_back(child);
+    }
+  }
+  std::sort(frame_bodies.begin(), frame_bodies.end(),
+            [](const mjCBody* a, const mjCBody* b) {
+              return a->id < b->id;
+            });
+  // write bodies in sorted order
+  for (mjCBody* child : frame_bodies) {
+    string classname = child->frame && !child->frame->classname.empty()
+                           ? child->frame->classname
+                           : body->classname;
+    Body(InsertEnd(elem, "body"), child, nullptr,
+         classname.empty() ? childclass : classname);
+  }
 
-    // write body if its frame matches the current frame, avoid access if there are no bodies
-    if (bframe == frame && !body->bodies.empty()) {
-      string classname = bframe && !bframe->classname.empty()
-                             ? bframe->classname
+  // loop over frames in the current body
+  for (mjCFrame* fframe : body->frames) {
+    // write frame if its frame matches the current frame
+    if (fframe->frame == frame) {
+      string classname = fframe && !fframe->classname.empty()
+                             ? fframe->classname
                              : body->classname;
-      Body(InsertEnd(elem, "body"), body->bodies[i], nullptr,
-           classname.empty() ? childclass : classname);
-    }
-
-    i++;
-
-    // do not go to frames until we reach a body with a frame or we are done with bodies
-    if (!bframe && i < body->bodies.size()) {
-      continue;
-    }
-
-    // loop over the remaining frames in the current body
-    while (j < body->frames.size()) {
-      mjCFrame* fframe = body->frames[j++];
-
-      // write frame if its frame matches the current frame
-      if (fframe->frame == frame) {
-        string classname = fframe && !fframe->classname.empty()
-                               ? fframe->classname
-                               : body->classname;
-        Body(OneFrame(elem, fframe), body, fframe, childclass);
-      }
-    }
-
-    // if there are no bodies, we only want to run the loop once
-    if (body->bodies.empty()) {
-      break;
+      Body(OneFrame(elem, fframe), body, fframe, childclass);
     }
   }
 }

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -3681,5 +3681,77 @@ TEST_F(MujocoTest, MjEncodeNativeFormats) {
   mj_deleteModel(model);
   mj_deleteSpec(spec);
 }
+
+// Tests that joint ordering is preserved after attach operations
+TEST_F(MujocoTest, AttachPreservesJointOrder) {
+  static constexpr char child_xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <body name="slider_body">
+        <joint name="slide_joint" type="slide"/>
+        <geom type="box" size="0.1 0.1 0.1"/>
+      </body>
+      <body name="free_body" pos="1 0 0">
+        <freejoint name="free_joint"/>
+        <geom type="sphere" size="0.1"/>
+      </body>
+    </worldbody>
+  </mujoco>
+  )";
+
+  mjSpec* parent = mj_makeSpec();
+  mjsBody* parent_world = mjs_findBody(parent, "world");
+  mjsFrame* attach_frame = mjs_addFrame(parent_world, nullptr);
+  mjs_setName(attach_frame->element, "attach_frame");
+
+  mjSpec* child = mj_parseSpec(child_xml, nullptr, nullptr, 0);
+  ASSERT_THAT(child, NotNull());
+
+  mjsElement* attached = mjs_attach(attach_frame->element, child->element,
+                                    nullptr, nullptr);
+  ASSERT_THAT(attached, NotNull());
+
+  mjModel* model = mj_compile(parent, nullptr);
+  ASSERT_THAT(model, NotNull());
+
+  // Verify joint order: slide joint should come before free joint
+  int slide_id = mj_name2id(model, mjOBJ_JOINT, "slide_joint");
+  int free_id = mj_name2id(model, mjOBJ_JOINT, "free_joint");
+  ASSERT_GE(slide_id, 0);
+  ASSERT_GE(free_id, 0);
+  EXPECT_LT(slide_id, free_id)
+      << "Slide joint should have a lower ID than free joint";
+
+  // Export and re-import to test round-trip preservation
+  std::array<char, 1000> error;
+  char* exported_xml = mj_saveSpec(parent, error.data(), error.size());
+  ASSERT_THAT(exported_xml, NotNull());
+
+  mjSpec* reimported = mj_parseSpec(exported_xml, nullptr, error.data(),
+                                    error.size());
+  ASSERT_THAT(reimported, NotNull()) << error.data();
+
+  mjModel* reimported_model = mj_compile(reimported, error.data());
+  ASSERT_THAT(reimported_model, NotNull()) << error.data();
+
+  // Verify joint order is preserved after round-trip
+  int reimported_slide_id = mj_name2id(reimported_model, mjOBJ_JOINT,
+                                       "slide_joint");
+  int reimported_free_id = mj_name2id(reimported_model, mjOBJ_JOINT,
+                                      "free_joint");
+  ASSERT_GE(reimported_slide_id, 0);
+  ASSERT_GE(reimported_free_id, 0);
+  EXPECT_EQ(reimported_slide_id, slide_id)
+      << "Joint IDs should be the same after XML round-trip";
+  EXPECT_EQ(reimported_free_id, free_id)
+      << "Joint IDs should be the same after XML round-trip";
+
+  mju_free(exported_xml);
+  mj_deleteModel(model);
+  mj_deleteModel(reimported_model);
+  mj_deleteSpec(child);
+  mj_deleteSpec(parent);
+  mj_deleteSpec(reimported);
+}
 }  // namespace
 }  // namespace mujoco


### PR DESCRIPTION
Fixes joint ordering in attached models by calling `ProcessLists()` at the end of `mjCModel::operator+=()`. This ensures the internal joint/body ordering matches the compiled model after attach operations.

When a modular MJCF model uses `<attach>` to compose sub-models, the internal ordering of joints in `body->joints` could differ from the compiled model's ordering (stored in `joint->id`). This caused `MjSpec.to_xml()` to export XML that would compile with different joint indices, violating the documented guarantee that exported XML compiles to an equivalent model.

The fix calls `ProcessLists()` after all elements are copied during attach, which reassigns IDs to match the order in the internal vectors. This ensures consistency between the internal representation and the compiled model.

Added test `AttachPreservesJointOrder` in `user_api_test.cc` to verify joint ordering is preserved after attach operations and XML round-trips.

Fixes #3401