### PR TITLE
docs: add full keyboard and mouse shortcut reference for simulate

### DIFF
--- a/doc/programming/samples.rst
+++ b/doc/programming/samples.rst
@@ -122,7 +122,253 @@ Interaction is done with the mouse; built-in help with a summary of available co
 ``F1`` key. Briefly, an object is selected by left-double-click. The user can then apply forces and torques on the
 selected object by holding Ctrl and dragging the mouse. Dragging the mouse alone (without Ctrl) moves the camera. There
 are keyboard shortcuts for pausing the simulation, resetting, and re-loading the model file. The latter functionality is
-very useful while editing the model in an XML editor.
+very useful while editing the model in an XML editor. The complete set of shortcuts is given in
+:ref:`saSimulateShortcuts` below.
+
+.. _saSimulateShortcuts:
+
+simulate shortcuts
+^^^^^^^^^^^^^^^^^^
+
+The ``F1`` help overlay lists the most common commands. The tables below are the complete reference, and also apply to
+the Python viewer launched with :ref:`mujoco.viewer<PyViewer>`, which is built on the same ``Simulate`` UI. Shortcuts
+that step or pause the simulation have no effect in passive mode, where stepping is driven by user code.
+
+In addition to the shortcuts listed here, every UI control shows its own shortcut when the right mouse button is held
+over the UI panel.
+
+Simulation and camera
+"""""""""""""""""""""
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3
+   :header-rows: 1
+
+   * - Key
+     - Action
+   * - ``Space``
+     - Play / pause
+   * - ``Right arrow``
+     - Step forward
+   * - ``Left arrow``
+     - Step backward, through the history buffer
+   * - ``=``
+     - Speed up
+   * - ``-``
+     - Slow down
+   * - ``Backspace``
+     - Reset
+   * - ``Ctrl C``
+     - Copy state to clipboard
+   * - ``Ctrl L``
+     - Reload the model
+   * - ``Ctrl A``
+     - Align the free camera
+   * - ``Esc``
+     - Switch to the free camera
+   * - ``[`` / ``]``
+     - Cycle down / up through the fixed cameras defined in the model
+   * - ``Page Up``
+     - Select the parent of the currently selected body
+   * - ``Tab`` / ``Shift Tab``
+     - Toggle the left / right UI panel
+
+.. note::
+   Speed up is bound to ``=``, not ``+``, and both speed shortcuts are ignored while ``Shift`` is held. On a US
+   keyboard ``+`` is ``Shift`` ``=``, so pressing ``+`` does *not* speed up the simulation, despite what the ``F1``
+   overlay suggests.
+
+Panels and files
+""""""""""""""""
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3
+   :header-rows: 1
+
+   * - Key
+     - Action
+   * - ``F1``
+     - Toggle the help overlay
+   * - ``F2``
+     - Toggle the info overlay
+   * - ``F3``
+     - Toggle the profiler
+   * - ``F4``
+     - Toggle the sensor plots
+   * - ``F5``
+     - Toggle fullscreen
+   * - ``F6``
+     - Cycle the frame visualization
+   * - ``F7``
+     - Cycle the label visualization
+   * - ``Ctrl M``
+     - Print the model to ``MJMODEL.TXT``
+   * - ``Ctrl D``
+     - Print the data to ``MJDATA.TXT``
+   * - ``Ctrl P``
+     - Save a screenshot
+   * - ``Ctrl Q``
+     - Quit
+   * - ``Alt`` + letter
+     - Expand / collapse a UI section: ``F`` File, ``O`` Option, ``S`` Simulation, ``W`` Watch, ``P`` Physics,
+       ``R`` Rendering, ``V`` Visualization, ``G`` Group enable, ``L`` Logging, ``J`` Joint, ``C`` Control,
+       ``E`` Equality
+
+Visibility groups
+"""""""""""""""""
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3
+   :header-rows: 1
+
+   * - Key
+     - Action
+   * - ``0`` … ``5``
+     - Toggle visibility of geom group 0 … 5
+   * - ``Shift 0`` … ``Shift 5``
+     - Toggle visibility of site group 0 … 5
+
+Visualization flags
+"""""""""""""""""""
+
+These toggle the abstract visualization flags in the Rendering section, and correspond to the shortcuts declared in
+``mjVISSTRING``. Flags with no shortcut assigned (Select Point, the Flex flags and SDF iters) are omitted.
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3 1 3
+   :header-rows: 1
+
+   * - Key
+     - Flag
+     - Key
+     - Flag
+   * - ``H``
+     - Convex Hull
+     - ``X``
+     - Texture
+   * - ``J``
+     - Joint
+     - ``Q``
+     - Camera
+   * - ``U``
+     - Actuator
+     - ``,``
+     - Activation
+   * - ``Z``
+     - Light
+     - ``V``
+     - Tendon
+   * - ``Y``
+     - Range Finder
+     - ``E``
+     - Equality
+   * - ``I``
+     - Inertia
+     - ``'``
+     - Scale Inertia
+   * - ``B``
+     - Perturb Force
+     - ``O``
+     - Perturb Object
+   * - ``C``
+     - Contact Point
+     - ``N``
+     - Island
+   * - ``F``
+     - Contact Force
+     - ``P``
+     - Contact Split
+   * - ``T``
+     - Transparent
+     - ``A``
+     - Auto Connect
+   * - ``M``
+     - Center of Mass
+     - ``D``
+     - Static Body
+   * - ``;``
+     - Skin
+     - :literal:`\``
+     - Body Tree
+   * - ``\``
+     - Mesh Tree
+     -
+     -
+
+Rendering flags
+"""""""""""""""
+
+These toggle the OpenGL effects in the Rendering section, and correspond to the shortcuts declared in ``mjRNDSTRING``.
+Flags with no shortcut assigned (Depth, Id Color and Cull Face) are omitted. Segment is also omitted: it declares
+``,``, but that key is already claimed by the Activation visualization flag, which is registered first and therefore
+wins.
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3 1 3
+   :header-rows: 1
+
+   * - Key
+     - Flag
+     - Key
+     - Flag
+   * - ``S``
+     - Shadow
+     - ``W``
+     - Wireframe
+   * - ``R``
+     - Reflection
+     - ``L``
+     - Additive
+   * - ``K``
+     - Skybox
+     - ``G``
+     - Fog
+   * - ``/``
+     - Haze
+     -
+     -
+
+Mouse
+"""""
+
+.. list-table::
+   :width: 95%
+   :align: left
+   :widths: 1 3
+   :header-rows: 1
+
+   * - Action
+     - Effect
+   * - Left drag
+     - Orbit the camera
+   * - ``Shift`` right drag
+     - Pan the camera
+   * - Scroll, or middle drag
+     - Zoom
+   * - Double-click
+     - Select an object
+   * - Right double-click
+     - Center the camera on the clicked point
+   * - ``Ctrl`` right double-click
+     - Track the selected body
+   * - ``Ctrl`` [``Shift``] drag
+     - Rotate the selected object
+   * - ``Ctrl`` [``Shift``] right drag
+     - Translate the selected object
+   * - Right-button hold over the UI
+     - Show the shortcut of each UI control
+   * - Double-click a UI section title
+     - Expand / collapse all sections
 
 The code is long yet reasonably commented, so it is best to just read it. Here we provide a high-level overview.
 The ``main()`` function initializes both MuJoCo and GLFW, opens a window, and install GLFW callbacks for mouse and


### PR DESCRIPTION
Fixes #3306. Thanks to @scotgopal for the initial list in the issue.

## Summary
- Add a complete shortcut reference to the `simulate` section of the docs: simulation/camera, panels/files, visibility groups, visualization flags, rendering flags, and mouse. The `F1` overlay only covers the common commands.
- Tables are derived from the shortcut declarations in `simulate.cc`, `simulate.h`, `mjVISSTRING` and `mjRNDSTRING` rather than from observed behavior, so the less discoverable ones are included (`F1`-`F5`, `Backspace`, `Ctrl+L`, `Ctrl+A`, `Ctrl+C` are declared in `simulate.h`; `F6`/`F7` are absent from the overlay).
- Document speed-up as `=`, not `+`. The handler skips the key when Shift is held (`!state->shift`), so `+` (Shift+`=` on a US layout) does nothing, despite what the overlay shows.

## Validation
- `sphinx-build` of `doc/`: builds clean, no new warnings vs `main` (the two `autodoc` warnings for `mujoco_warp`/`mjx` are pre-existing).
- pre-commit passes.

## Notes
- `Segment` (`mjRNDSTRING`) declares `,`, but so does `Activation` (`mjVISSTRING`). Both are added to `ui0` with the vis flags first, so `matchshortcut` finds `Activation` and `Segment`'s shortcut never fires. The docs describe current behavior and omit `Segment`. Happy to file a separate issue or send a fix if you want one.