### PR TITLE
Fix attached tendon wrap model pointers

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -6451,8 +6451,9 @@ void mjCTendon::CopyFromSpec() {
   material_ = spec_material_;
   userdata_ = spec_userdata_;
 
-  // clear precompiled
+  // propagate model pointer to wraps and clear precompiled
   for (int i=0; i < path.size(); i++) {
+    path[i]->model = model;
     if (path[i]->Type() == mjWRAP_CYLINDER) {
       path[i]->spec.type = mjWRAP_SPHERE;
     }

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -1283,6 +1283,20 @@ TEST_F(MujocoTest, AttachSpatialTendonWithoutSidesite) {
       mjs_findElement(parent, mjOBJ_TENDON, "tendon_without_sidesite_child"),
       NotNull());
 
+  mjsTendon* tendon = mjs_asTendon(
+      mjs_findElement(parent, mjOBJ_TENDON, "tendon_with_sidesite_child"));
+  ASSERT_THAT(tendon, NotNull());
+  ASSERT_EQ(mjs_getWrapNum(tendon), 3);
+
+  EXPECT_EQ(mjs_getWrapTarget(mjs_getWrap(tendon, 0)),
+            mjs_findElement(parent, mjOBJ_SITE, "site_A_child"));
+  EXPECT_EQ(mjs_getWrapTarget(mjs_getWrap(tendon, 1)),
+            mjs_findElement(parent, mjOBJ_GEOM, "wrap_geom_child"));
+  EXPECT_EQ(mjs_getWrapTarget(mjs_getWrap(tendon, 2)),
+            mjs_findElement(parent, mjOBJ_SITE, "site_B_child"));
+  EXPECT_EQ(mjs_getWrapSideSite(mjs_getWrap(tendon, 1)),
+            mjs_asSite(mjs_findElement(parent, mjOBJ_SITE, "side_site_child")));
+
   mjModel* model = mj_compile(parent, nullptr);
   ASSERT_THAT(model, NotNull()) << mjs_getError(parent);
   EXPECT_EQ(model->ntendon, 2);


### PR DESCRIPTION
Draft follow-up for #3157 / #3152, based on the original fix from @mar-yan24.

This keeps the change narrow:
- propagates the parent model pointer to tendon wraps during `mjCTendon::CopyFromSpec()`
- extends the attach spatial-tendon test so attached wrap targets and sidesites are resolved before compile

Local validation:
- `git diff --check`
- `cmake -S . -B /tmp/mujoco-pr3157-build -DMUJOCO_BUILD_TESTS=ON -DMUJOCO_TEST_PYTHON_UTIL=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/mujoco-pr3157-build --target user_api_test -j2`
- `/tmp/mujoco-pr3157-build/bin/user_api_test --gtest_filter='MujocoTest.AttachSpatialTendonWithoutSidesite'`

Opening as draft to avoid superseding the existing approved PR unless maintainers prefer this rebased/test-extended version.
