### PR TITLE
Resolve OpenGL backend lazily

### DIFF
--- a/python/mujoco/gl_context_test.py
+++ b/python/mujoco/gl_context_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for lazy OpenGL backend resolution in gl_context."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from mujoco.rendering.classic import gl_context
+
+
+@absltest.skipUnless(
+    hasattr(gl_context, 'GLContext'), 'rendering is disabled (MUJOCO_GL=disable)'
+)
+class GLContextTest(absltest.TestCase):
+
+  def test_construction_delegates_to_resolved_backend(self):
+    created = {}
+
+    class _FakeBackend:
+
+      def __init__(self, width, height):
+        created['size'] = (width, height)
+
+    with mock.patch.object(
+        gl_context, '_resolve_gl_context', return_value=_FakeBackend
+    ):
+      ctx = gl_context.GLContext(640, 480)
+
+    self.assertIsInstance(ctx, _FakeBackend)
+    self.assertEqual(created['size'], (640, 480))
+
+  def test_missing_native_libraries_raise_importerror_on_construction(self):
+    native_error = AttributeError(
+        "'NoneType' object has no attribute 'glGetError'"
+    )
+    with mock.patch.object(
+        gl_context, '_resolve_gl_context', side_effect=native_error
+    ):
+      with self.assertRaises(ImportError) as cm:
+        gl_context.GLContext(640, 480)
+    self.assertIs(cm.exception.__cause__, native_error)
+
+  def test_missing_python_packages_raise_importerror_on_construction(self):
+    import_error = ImportError("No module named 'OpenGL'")
+    with mock.patch.object(
+        gl_context, '_resolve_gl_context', side_effect=import_error
+    ):
+      with self.assertRaises(ImportError) as cm:
+        gl_context.GLContext(640, 480)
+    self.assertIs(cm.exception.__cause__, import_error)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/python/mujoco/rendering/classic/gl_context.py
+++ b/python/mujoco/rendering/classic/gl_context.py
@@ -34,15 +34,29 @@ if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
     raise RuntimeError(
         f'invalid value for environment variable MUJOCO_GL: {_MUJOCO_GL}')
 
-  if _SYSTEM == 'Linux' and _MUJOCO_GL == 'osmesa':
-    from mujoco.osmesa import GLContext as _GLContext
-    GLContext = _GLContext
-  elif _SYSTEM == 'Linux' and _MUJOCO_GL == 'egl':
-    from mujoco.egl import GLContext as _GLContext
-    GLContext = _GLContext
-  elif _SYSTEM == 'Darwin':
-    from mujoco.cgl import GLContext as _GLContext
-    GLContext = _GLContext
-  else:
-    from mujoco.glfw import GLContext as _GLContext
-    GLContext = _GLContext
+  def _resolve_gl_context():
+    """Imports and returns the configured backend's GLContext class."""
+    if _SYSTEM == 'Linux' and _MUJOCO_GL == 'osmesa':
+      from mujoco.osmesa import GLContext as _GLContext
+    elif _SYSTEM == 'Linux' and _MUJOCO_GL == 'egl':
+      from mujoco.egl import GLContext as _GLContext
+    elif _SYSTEM == 'Darwin':
+      from mujoco.cgl import GLContext as _GLContext
+    else:
+      from mujoco.glfw import GLContext as _GLContext
+    return _GLContext
+
+  class GLContext:
+    """Configured OpenGL backend, resolved lazily on construction."""
+
+    def __new__(cls, *args, **kwargs):
+      try:
+        backend = _resolve_gl_context()
+      except (ImportError, AttributeError) as exc:
+        raise ImportError(
+            f'Could not initialize the OpenGL backend for '
+            f'MUJOCO_GL={_MUJOCO_GL!r}. Rendering is unavailable; the required '
+            'OpenGL libraries may not be installed. Set MUJOCO_GL=disable to '
+            'skip GL initialization entirely.'
+        ) from exc
+      return backend(*args, **kwargs)


### PR DESCRIPTION
Draft follow-up for #3366, based on the original lazy-backend import fix from @kevinzakka.

This keeps `MUJOCO_GL` validation at import time but defers importing the selected backend until a `GLContext` is constructed. That lets `import mujoco` work on systems that never render and do not have OpenGL libraries available.

Local validation:
- `python3 -m py_compile python/mujoco/rendering/classic/gl_context.py python/mujoco/gl_context_test.py`
- direct importlib/mocked validation for backend delegation, native `AttributeError` conversion, and backend `ImportError` conversion
- `git diff --check`

Could not run `python/mujoco/gl_context_test.py` directly in this local Python because `absl-py` is not installed in the base environment.

Opening as draft to avoid duplicating the existing approved PR unless maintainers want this rebased version.
