### PR TITLE
Add opt-in MJX solver scan loop

### DIFF
--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -270,6 +270,7 @@ def _put_option(
     implicitfast = o.integrator == mujoco.mjtIntegrator.mjINT_IMPLICITFAST
     if implicitfast and has_fluid_params:
       raise NotImplementedError('implicitfast not implemented for fluid drag.')
+    impl_fields['solver_scan'] = bool(impl_fields.get('solver_scan', False))
     impl_fields['has_fluid_params'] = has_fluid_params
     return types.Option(**fields, _impl=types.OptionJAX(**impl_fields))
 

--- a/mjx/mujoco/mjx/_src/solver.py
+++ b/mjx/mujoco/mjx/_src/solver.py
@@ -598,6 +598,10 @@ def solve(m: Model, d: Data) -> Data:
   ctx = Context.create(m, d)
   if m.opt.iterations == 1:
     ctx = body(ctx)
+  elif m.opt._impl.solver_scan:
+    # Opt-in scan-based loop for reverse-mode autodiff. The default remains
+    # `while_loop` to avoid changing solver performance characteristics.
+    ctx = _while_loop_scan(cond, body, ctx, m.opt.iterations)
   else:
     ctx = jax.lax.while_loop(cond, body, ctx)
 

--- a/mjx/mujoco/mjx/_src/solver_test.py
+++ b/mjx/mujoco/mjx/_src/solver_test.py
@@ -164,6 +164,34 @@ class SolverTest(parameterized.TestCase):
     m.opt.cone = cone
     solver.solve(mjx.put_model(m), mjx.put_data(m, mujoco.MjData(m)))
 
+  def test_solver_reverse_mode_grad(self):
+    """Reverse-mode autodiff works with the scan solver loop enabled."""
+    m = mujoco.MjModel.from_xml_string("""
+       <mujoco>
+          <worldbody>
+            <geom size="0 0 1e-5" type="plane" condim="1"/>
+            <body pos="0 0 0.09">
+              <freejoint/>
+              <geom size="0.1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+    """)
+    # iterations > 1 exercises the outer loop that blocks reverse-mode autodiff.
+    m.opt.iterations = 4
+    m.opt.ls_iterations = 4
+    mx = mjx.put_model(m).tree_replace({'opt._impl.solver_scan': True})
+    dx = mjx.put_data(m, mujoco.MjData(m))
+
+    def loss(qvel):
+      d = dx.replace(qvel=qvel)
+      d = mjx.solve(mx, d)
+      return (d.qacc ** 2).sum()
+
+    grad = jax.jit(jax.grad(loss))(dx.qvel)
+    self.assertEqual(grad.shape, dx.qvel.shape)
+    self.assertTrue(np.all(np.isfinite(grad)))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -485,6 +485,7 @@ class OptionJAX(PyTreeNode):
   o_friction: jax.Array
   disableactuator: int
   sdf_initpoints: int
+  solver_scan: bool
   has_fluid_params: bool
 
 
@@ -1213,4 +1214,3 @@ def tree_path_to_attr_str(path: jax.tree_util.KeyPath) -> str:
   assert all(isinstance(p, jax.tree_util.GetAttrKey) for p in path)
   path = [p for p in path if p.name != '_impl']
   return '__'.join(p.name for p in path)
-


### PR DESCRIPTION
Draft follow-up for #3264 / #2259, based on the original reverse-mode autodiff fix from @ingyukoh.

The maintainer review concern on #3264 was avoiding a default solver performance change. This version keeps the scan loop opt-in through `OptionJAX.solver_scan` and leaves the existing `jax.lax.while_loop` path as the default.

Changes:
- adds `OptionJAX.solver_scan`, defaulting to `False` in `_put_option`
- uses `_while_loop_scan` for the outer solver loop only when opted in
- adds a reverse-mode gradient regression test that enables the flag explicitly

Local validation:
- `python3 -m py_compile mjx/mujoco/mjx/_src/types.py mjx/mujoco/mjx/_src/io.py mjx/mujoco/mjx/_src/solver.py mjx/mujoco/mjx/_src/solver_test.py`
- `git diff --check`

Could not run the focused MJX runtime test locally because this base Python is missing `jax`, `jaxlib`, `absl-py`, and `mujoco`.

Opening as draft to avoid superseding the existing approved PR unless maintainers prefer this rebased/tested version.
