### PR TITLE
Fix MJX x64 int dtypes

### DIFF
--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -670,7 +670,7 @@ def _make_data_jax(
   efc_address = constraint.make_efc_address(m, dim, efc_type)
 
   float_ = jp.zeros(1, float).dtype
-  int_ = np.int32
+  int_ = jp.zeros(1, int).dtype
   contact = _make_data_contact_jax(dim, efc_address)
 
   if m.opt.cone == types.ConeType.ELLIPTIC and np.any(contact.dim == 1):
@@ -679,12 +679,12 @@ def _make_data_jax(
     )
 
   zero_impl_fields = {
-      'solver_niter': (int_,),
+      'solver_niter': (np.int32,),
       'cinert': (m.nbody, 10, float_),
-      'ten_wrapadr': (m.ntendon, np.int32),
-      'ten_wrapnum': (m.ntendon, np.int32),
+      'ten_wrapadr': (m.ntendon, int_),
+      'ten_wrapnum': (m.ntendon, int_),
       'ten_J': (m.ntendon, m.nv, float_),
-      'wrap_obj': (m.nwrap, 2, np.int32),
+      'wrap_obj': (m.nwrap, 2, int_),
       'wrap_xpos': (m.nwrap, 6, float_),
       'actuator_moment': (m.nu, m.nv, float_),
       'crb': (m.nbody, 10, float_),
@@ -920,6 +920,9 @@ def _put_contact(
   """Converts mujoco.structs._MjContactList into mjx.Contact."""
   fields = {f.name: getattr(c, f.name) for f in types.Contact.fields()}
   fields['frame'] = fields['frame'].reshape((-1, 3, 3))
+  int_ = jp.zeros(1, int).dtype
+  for fname in ('geom1', 'geom2', 'geom'):
+    fields[fname] = fields[fname].astype(int_)
   # reorder contacts so that their condims match those specified in dim.
   # if we have fewer Contacts for a condim range, pad the range with zeros
 
@@ -991,6 +994,10 @@ def _put_data_jax(
   }
   # MJX does not support islanding, so only transfer the first solver_niter
   impl_fields['solver_niter'] = impl_fields['solver_niter'][0]
+
+  int_ = jp.zeros(1, int).dtype
+  for fname in ('ten_wrapadr', 'ten_wrapnum', 'wrap_obj'):
+    impl_fields[fname] = impl_fields[fname].astype(int_)
 
   # convert sparse actuator_moment to dense matrix
   moment = np.zeros((m.nu, m.nv))

--- a/mjx/mujoco/mjx/_src/io_test.py
+++ b/mjx/mujoco/mjx/_src/io_test.py
@@ -899,7 +899,11 @@ class DataIOTest(parameterized.TestCase):
     d = mujoco.MjData(m)
     mujoco.mj_step(m, d, 2)
 
-    with jax.enable_x64(True):
+    enable_x64 = getattr(jax, 'enable_x64', None)
+    if enable_x64 is None:
+      from jax.experimental import enable_x64  # pylint: disable=g-import-not-at-top
+
+    with enable_x64(True):
       mx = mjx.put_model(m, impl='jax')
       dx = mjx.put_data(m, d, impl='jax')
 

--- a/mjx/mujoco/mjx/_src/io_test.py
+++ b/mjx/mujoco/mjx/_src/io_test.py
@@ -893,6 +893,28 @@ class DataIOTest(parameterized.TestCase):
     # calling make_data.  they should be interchangeable for jax functions:
     step_fn_jit(mjx.make_data(m, impl=impl))
 
+  def test_make_matches_put_x64(self):
+    """Test that put_data matches make_data and step dtypes under x64."""
+    m = mujoco.MjModel.from_xml_string(_MULTIPLE_CONSTRAINTS)
+    d = mujoco.MjData(m)
+    mujoco.mj_step(m, d, 2)
+
+    with jax.enable_x64(True):
+      mx = mjx.put_model(m, impl='jax')
+      dx = mjx.put_data(m, d, impl='jax')
+
+      int_ = jp.zeros(1, int).dtype
+      self.assertEqual(dx._impl.contact.geom1.dtype, int_)
+      self.assertEqual(dx._impl.contact.geom2.dtype, int_)
+      self.assertEqual(dx._impl.contact.geom.dtype, int_)
+      self.assertEqual(dx._impl.ten_wrapadr.dtype, int_)
+      self.assertEqual(dx._impl.ten_wrapnum.dtype, int_)
+      self.assertEqual(dx._impl.wrap_obj.dtype, int_)
+
+      step_fn = jax.jit(mjx.step).lower(mx, dx).compile()
+      step_fn(mx, mjx.make_data(m, impl='jax'))
+      step_fn(mx, step_fn(mx, dx))
+
   def test_contact_elliptic_condim1(self):
     """Test that condim=1 with ConeType.ELLIPTIC is not implemented."""
     m = mujoco.MjModel.from_xml_string("""


### PR DESCRIPTION
Draft follow-up for #3334 / #2565, based on the original x64 dtype fix from @discobot.

Under `jax_enable_x64`, compiled MJX functions can produce canonical JAX int dtypes for contact geom indices and tendon wrap indices, while `put_data` / `make_data` still supplied `int32` in a few places. This aligns those fields with the canonical JAX int dtype and adds an AOT-style regression test.

Changes:
- uses canonical JAX int dtype for `ten_wrapadr`, `ten_wrapnum`, and `wrap_obj` in `make_data` / `put_data`
- casts contact `geom1`, `geom2`, and `geom` in `_put_contact`
- keeps `solver_niter` as `int32`
- adds an x64 `make_data` / `put_data` / compiled `mjx.step` interchangeability test

Local validation:
- `python3 -m py_compile mjx/mujoco/mjx/_src/io.py mjx/mujoco/mjx/_src/io_test.py`
- `git diff --check`

Could not run the focused MJX runtime test locally because this base Python is missing `jax`, `jaxlib`, `absl-py`, and `mujoco`.

Opening as draft to avoid duplicating the existing open PR unless maintainers want this rebased version.
