### PR TITLE
Fix MJCF XSD schema metadata gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,10 +126,15 @@ regenerate it:
 ```bash
 cmake --build build --target xmlschema
 ./build/bin/xmlschema /tmp/raw.xsd
-python3 doc/mjcf_schema_enrich.py \
+./doc/mjcf_schema_enrich.py \
     --in /tmp/raw.xsd --rst doc/XMLreference.rst --out doc/mjcf.xsd \
     --strict --report
 ```
+
+`doc/mjcf_schema_enrich.py` is a [uv](https://docs.astral.sh/uv/) PEP 723
+script; its shebang provisions a matching Python interpreter, so the only
+prerequisite is `uv` on `PATH`. Run it as `./doc/mjcf_schema_enrich.py ...`
+or `uv run doc/mjcf_schema_enrich.py ...`.
 
 `--strict` exits non-zero on drift between the parser, the attribute table
 (`src/xml/xml_native_schema.cc`), and the RST — fix warnings before

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,24 @@ Thanks for improving MuJoCo!
 
 This project follows Google's
 [Open Source Community Guidelines](https://opensource.google/conduct/).
+
+
+## Regenerating the MJCF XSD
+
+The MJCF XSD shipped with releases lives at `doc/mjcf.xsd` and is
+auto-generated from `src/xml/` and `doc/XMLreference.rst`. If your change
+touches MJCF parsing, adds an attribute, or edits the reference docs,
+regenerate it:
+
+```bash
+cmake --build build --target xmlschema
+./build/bin/xmlschema /tmp/raw.xsd
+python3 doc/mjcf_schema_enrich.py \
+    --in /tmp/raw.xsd --rst doc/XMLreference.rst --out doc/mjcf.xsd \
+    --strict --report
+```
+
+`--strict` exits non-zero on drift between the parser, the attribute table
+(`src/xml/xml_native_schema.cc`), and the RST — fix warnings before
+committing. See the header comment in `xml_native_schema.cc` for which files
+to edit when adding a new attribute.

--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -7,6 +7,31 @@ Introduction
 
 This chapter is the reference manual for the MJCF modeling language used in MuJoCo.
 
+.. _XSDSchema:
+
+Editor integration (XSD)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MJCF grammar is also published as an `XSD <https://www.w3.org/XML/Schema>`_
+schema, generated directly from the parser source and the prose below. Pointing
+your editor at it gives you autocompletion, inline documentation, and validation
+while writing MJCF.
+
+For VS Code, install the
+`Red Hat XML extension <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>`_
+and reference the schema from the root element:
+
+.. code-block:: xml
+
+   <mujoco xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/google-deepmind/mujoco/main/doc/mjcf.xsd">
+     ...
+   </mujoco>
+
+Other editors with XSD support (IntelliJ, Eclipse, Emacs ``nxml-mode``) work the
+same way. The schema is regenerated on every release -- see
+``CONTRIBUTING.md`` if you are contributing changes to MJCF.
+
 
 .. _CSchema:
 

--- a/doc/mjcf_schema_enrich.py
+++ b/doc/mjcf_schema_enrich.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
 # Copyright 2026 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +27,13 @@ doc/XMLreference.rst for human-facing `:at:` blocks and patches each
 
 Typical usage (release workflow):
     ./build/bin/xmlschema /tmp/raw.xsd
-    python3 doc/mjcf_schema_enrich.py \
+    ./doc/mjcf_schema_enrich.py \
         --in /tmp/raw.xsd \
         --rst doc/XMLreference.rst \
         --out doc/mjcf.xsd
+
+The shebang invokes `uv run --script`, which provisions a matching
+Python interpreter from the PEP 723 metadata block above.
 
 The script fails soft: attrs with no matching RST block keep their
 auto-generated type but lose the doc annotation. A --report flag prints

--- a/doc/mjcf_schema_enrich.py
+++ b/doc/mjcf_schema_enrich.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Enrich an auto-generated MJCF XSD with docs and defaults mined from RST.
+
+The C++ generator (sample/xmlschema.cc) emits type info. This script mines
+doc/XMLreference.rst for human-facing `:at:` blocks and patches each
+<xs:attribute> with:
+  * `default="..."` when the RST :at-val: contains a quoted default
+  * <xs:annotation><xs:documentation>...</xs:documentation></xs:annotation>
+
+Typical usage (release workflow):
+    ./build/bin/xmlschema /tmp/raw.xsd
+    python3 doc/mjcf_schema_enrich.py \
+        --in /tmp/raw.xsd \
+        --rst doc/XMLreference.rst \
+        --out doc/mjcf.xsd
+
+The script fails soft: attrs with no matching RST block keep their
+auto-generated type but lose the doc annotation. A --report flag prints
+the drift list.
+"""
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DocEntry:
+    """One parsed `:at:` block from the RST."""
+    element: str              # element the attr belongs to (last anchor segment -1)
+    attr: str                 # attribute name
+    type_str: str = ""        # RST type annotation, e.g. "real(3)", "[a,b], \"a\""
+    default: Optional[str] = None
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# RST parser
+# ---------------------------------------------------------------------------
+
+# Example matched lines:
+#   .. _option-timestep:
+#   .. _body-joint-solreflimit:
+ANCHOR_RE = re.compile(r"^\.\. _([a-zA-Z0-9_-]+):\s*$")
+
+# Example matched lines:
+#   :at:`angle`: :at-val:`[radian, degree], "degree"`
+#   :at:`o_solref`, :at:`o_solimp`, :at:`o_friction`
+#   :at:`gridlayout`: :at-val:`string, "............"`
+#
+# The line starts with :at: and contains one or more backtick-wrapped attr
+# names, optionally followed by a :at-val:`...` block.
+AT_LINE_RE = re.compile(r"^:at:`")
+AT_NAME_RE = re.compile(r":at:`([^`]+)`")
+AT_VAL_RE = re.compile(r":at-val:`([^`]*)`")
+
+# Inside :at-val:`TYPE, "DEFAULT"` or :at-val:`TYPE, required` or
+# :at-val:`TYPE, optional`. TYPE may contain a comma, e.g.
+# "[rgb, depth, normal], \"rgb\"" -- so we split on the LAST top-level comma.
+# Easier: try to match the quoted default first; fall back to a status word.
+DEFAULT_RE = re.compile(r'"([^"]*)"\s*$')
+STATUS_RE = re.compile(r"(required|optional)\s*$", re.IGNORECASE)
+
+
+def _split_type_and_default(at_val: str) -> tuple[str, Optional[str]]:
+    """Split an :at-val: body into (type_str, default_or_None).
+
+    at_val looks like:
+      'real, "0.002"'            -> ('real', '0.002')
+      '[Euler, RK4, implicit, implicitfast], "Euler"' -> (list, 'Euler')
+      'int, required'            -> ('int', None)
+      'string, optional'         -> ('string', None)
+    """
+    s = at_val.strip()
+    m = DEFAULT_RE.search(s)
+    if m:
+        default = m.group(1)
+        type_part = s[: m.start()].rstrip(", \t")
+        return type_part, default
+    m = STATUS_RE.search(s)
+    if m:
+        type_part = s[: m.start()].rstrip(", \t")
+        return type_part, None
+    return s, None
+
+
+def _parse_at_line(at_line: str) -> list[tuple[str, str, Optional[str]]]:
+    """Return a list of (attr_name, type_str, default_or_None) from an :at: line.
+
+    Grouped lines share the same (type, default). When no :at-val: is present,
+    the type/default are empty/None.
+    """
+    names = AT_NAME_RE.findall(at_line)
+    val_m = AT_VAL_RE.search(at_line)
+    type_str, default = ("", None)
+    if val_m:
+        type_str, default = _split_type_and_default(val_m.group(1))
+    return [(n, type_str, default) for n in names]
+
+
+def _anchor_to_element_attr(anchor: str) -> tuple[str, str]:
+    """Split a hyphenated anchor like 'body-joint-pos' into (element, attr).
+
+    Rule: the attr is the LAST segment, the element is the second-to-last.
+    For single-segment anchors like 'option' (section anchor), the element
+    is the whole anchor and attr is empty -- caller should filter those.
+    """
+    parts = anchor.split("-")
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[-2], parts[-1]
+
+
+def parse_rst(rst_path: str) -> dict[tuple[str, str], DocEntry]:
+    """Build a (element, attr) -> DocEntry dict from the RST."""
+    with open(rst_path, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    entries: dict[tuple[str, str], DocEntry] = {}
+    pending_anchors: list[str] = []  # anchors accumulated since last :at: line
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        m = ANCHOR_RE.match(line)
+        if m:
+            pending_anchors.append(m.group(1))
+            i += 1
+            continue
+
+        if stripped.startswith(":at:`"):
+            # Parse the :at: line (which may continue on next line for grouped
+            # attrs, but mostly doesn't in practice).
+            at_line = stripped
+            parsed = _parse_at_line(at_line)
+
+            # Skim the description: all lines indented by >=3 spaces until a
+            # blank-line-then-unindented sentinel or another anchor/at block.
+            desc_lines: list[str] = []
+            j = i + 1
+            while j < n:
+                lj = lines[j]
+                sj = lj.strip()
+                if not sj:
+                    # Blank line: peek ahead; if next non-blank is indented-
+                    # continuation or blank, keep collecting.
+                    k = j + 1
+                    while k < n and not lines[k].strip():
+                        k += 1
+                    if k >= n:
+                        break
+                    lk = lines[k]
+                    if (not lk.startswith((" ", "\t"))) or \
+                       ANCHOR_RE.match(lk) or \
+                       lk.strip().startswith(":at:`"):
+                        break
+                    desc_lines.append("")
+                    j = k
+                    continue
+                if lj.startswith((" ", "\t")):
+                    desc_lines.append(lj.rstrip())
+                    j += 1
+                else:
+                    break
+
+            description = "\n".join(desc_lines).rstrip()
+
+            # Build DocEntry per attr. If grouped attrs share anchors, match
+            # them by position; otherwise fall back to the last section anchor.
+            # The common case is: N anchors immediately preceding, one per attr
+            # in order.
+            attr_anchors = [a for a in pending_anchors if "-" in a]
+            if len(attr_anchors) == len(parsed):
+                pairs = [(_anchor_to_element_attr(a), p)
+                         for a, p in zip(attr_anchors, parsed)]
+            else:
+                # Fallback: use the last anchor's element prefix for all attrs.
+                last = attr_anchors[-1] if attr_anchors else \
+                       (pending_anchors[-1] if pending_anchors else "")
+                element_prefix = (
+                    _anchor_to_element_attr(last)[0]
+                    if "-" in last else last
+                )
+                pairs = [((element_prefix, p[0]), p) for p in parsed]
+
+            for (element, _anchor_attr), (attr_name, type_str, default) in pairs:
+                key = (element, attr_name)
+                # Only set if empty (first occurrence wins). Duplicate
+                # element-attr anchors are rare.
+                if key not in entries:
+                    entries[key] = DocEntry(
+                        element=element,
+                        attr=attr_name,
+                        type_str=type_str,
+                        default=default,
+                        description=description,
+                    )
+
+            pending_anchors.clear()
+            i = j
+            continue
+
+        # Any non-anchor, non-at line flushes the pending anchor buffer
+        # unless it's blank.
+        if stripped:
+            pending_anchors.clear()
+        i += 1
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Sphinx markup cleanup
+# ---------------------------------------------------------------------------
+
+# Handle the common inline-role forms; we drop the role marker and keep text.
+# :ref:`display text <target>`    -> display text
+# :ref:`target`                    -> target
+# :at:`name`                       -> name
+# :math:`a + b`                    -> a + b
+# :at-val:`real, "0"`              -> real, "0"
+# ``inline code``                  -> inline code
+# |br|, |nbsp|, |*|, etc.          -> removed / replaced
+
+ROLE_WITH_TEXT_RE = re.compile(r":[a-zA-Z-]+:`([^`<]*?)\s*<[^`>]*>`")
+ROLE_BARE_RE = re.compile(r":[a-zA-Z-]+:`([^`]*)`")
+DOUBLE_BACKTICK_RE = re.compile(r"``([^`]+)``")
+SUBSTITUTION_RE = re.compile(r"\|([a-zA-Z0-9_]+)\|")
+DIRECTIVE_BLOCK_RE = re.compile(r"\.\. [a-zA-Z-]+::.*", re.MULTILINE)
+
+SUBSTITUTIONS = {
+    "br": "\n",
+    "nbsp": " ",
+    "*": "*",
+    "!": "",
+    "?": "",
+    "@": "",
+    "-": "-",
+    "minus": "-",
+}
+
+
+def clean_rst_markup(text: str) -> str:
+    text = ROLE_WITH_TEXT_RE.sub(r"\1", text)
+    text = ROLE_BARE_RE.sub(r"\1", text)
+    text = DOUBLE_BACKTICK_RE.sub(r"\1", text)
+    text = SUBSTITUTION_RE.sub(
+        lambda m: SUBSTITUTIONS.get(m.group(1), ""), text)
+    # Strip Sphinx directive markers like ".. raw:: html" on their own lines.
+    text = DIRECTIVE_BLOCK_RE.sub("", text)
+    # Dedent consistently by stripping leading indentation from every line.
+    lines = [ln.lstrip() for ln in text.splitlines()]
+    # Collapse >=2 blank lines to a single blank line.
+    out: list[str] = []
+    prev_blank = False
+    for ln in lines:
+        blank = not ln.strip()
+        if blank and prev_blank:
+            continue
+        out.append(ln)
+        prev_blank = blank
+    return "\n".join(out).strip()
+
+
+# ---------------------------------------------------------------------------
+# XSD patcher
+# ---------------------------------------------------------------------------
+
+XS = "http://www.w3.org/2001/XMLSchema"
+ET.register_namespace("xs", XS)
+NS = {"xs": XS}
+
+
+# Defaults in RST sometimes use `...` as a "pad with zeros" convention
+# (e.g. `"0 0 ..."` for `user` attrs). These aren't valid XSD defaults.
+_DOTS_RE = re.compile(r"\.\.\.")
+
+
+def _default_invalid_reason(value: str, xsd_type: str) -> Optional[str]:
+    """Return a reason string if this RST default is not XSD-compatible,
+    or None if it's fine."""
+    is_numeric_list = xsd_type and (
+        xsd_type.startswith("list_") or
+        xsd_type.startswith("uptolist_") or
+        xsd_type.startswith("vec_"))
+    is_numeric_scalar = xsd_type in ("xs:int", "xs:double")
+
+    if (is_numeric_list or is_numeric_scalar) and _DOTS_RE.search(value):
+        return "ellipsis in numeric default"
+    if is_numeric_list:
+        tokens = value.split()
+        if not tokens:
+            return "empty list default"
+        item_kind = "real" if "real" in xsd_type else "int"
+        for t in tokens:
+            try:
+                float(t) if item_kind == "real" else int(t)
+            except ValueError:
+                return f"non-numeric token '{t}' in {item_kind} list"
+    elif xsd_type == "xs:int":
+        try:
+            int(value)
+        except ValueError:
+            return f"non-integer value '{value}' for xs:int"
+    elif xsd_type == "xs:double":
+        try:
+            float(value)
+        except ValueError:
+            return f"non-double value '{value}' for xs:double"
+    return None
+
+
+def _find_containing_element(xs_root: ET.Element,
+                             attr_node: ET.Element,
+                             parents: dict[ET.Element, ET.Element]) -> str:
+    """Return the 'name' of the nearest ancestor <xs:element>, or "" if none."""
+    node = parents.get(attr_node)
+    while node is not None:
+        if node.tag == f"{{{XS}}}element":
+            name = node.get("name")
+            if name:
+                return name
+        node = parents.get(node)
+    return ""
+
+
+# Fallback elements when the direct (element, attr) lookup misses.
+# Actuator shortcuts all inherit the bulk of their attrs from <general>; the
+# RST documents the shared attrs once under actuator-general-*. Same story for
+# <spatial>/<fixed> (which share <tendon>'s attrs).
+ELEMENT_ALIASES: dict[str, list[str]] = {
+    "motor":       ["general"],
+    "position":    ["general"],
+    "velocity":    ["general"],
+    "intvelocity": ["general"],
+    "damper":      ["general"],
+    "cylinder":    ["general"],
+    "muscle":      ["general"],
+    "adhesion":    ["general"],
+    "dcmotor":     ["general"],
+    "plugin":      ["general"],
+    "spatial":     ["tendon"],
+    "fixed":       ["tendon"],
+}
+
+
+def _lookup_doc(docs: dict[tuple[str, str], DocEntry],
+                element: str, attr: str) -> Optional[DocEntry]:
+    doc = docs.get((element, attr))
+    if doc:
+        return doc
+    for alias in ELEMENT_ALIASES.get(element, ()):
+        doc = docs.get((alias, attr))
+        if doc:
+            return doc
+    return None
+
+
+@dataclass
+class EnrichmentReport:
+    """Summary + per-category drift info."""
+    matched: int = 0                                        # attrs found in RST
+    total: int = 0                                          # total xs:attributes
+    no_doc: list[tuple[str, str]] = field(default_factory=list)        # (element, attr)
+    bad_default: list[tuple[str, str, str, str]] = field(default_factory=list)  # (element, attr, raw_value, reason)
+    unused_rst: list[tuple[str, str]] = field(default_factory=list)    # RST entry -> no XSD match
+
+
+def patch_xsd(xsd_path: str,
+              docs: dict[tuple[str, str], DocEntry],
+              out_path: str,
+              add_defaults: bool = True,
+              add_annotations: bool = True,
+              ) -> EnrichmentReport:
+    """Patch the XSD in place. Returns an EnrichmentReport."""
+    tree = ET.parse(xsd_path)
+    root = tree.getroot()
+
+    parents: dict[ET.Element, Optional[ET.Element]] = {
+        child: parent for parent in root.iter() for child in parent}
+    parents[root] = None
+
+    used_keys: set[tuple[str, str]] = set()
+    report = EnrichmentReport()
+
+    for attr_node in root.iter(f"{{{XS}}}attribute"):
+        attr_name = attr_node.get("name")
+        if not attr_name:
+            continue
+        report.total += 1
+
+        # Resolve the containing element name. Falls through to named
+        # complexType for body_type / default_type.
+        element_name = _find_containing_element(root, attr_node, parents)
+        if not element_name:
+            anc = parents.get(attr_node)
+            while anc is not None:
+                if anc.tag == f"{{{XS}}}complexType":
+                    tname = anc.get("name", "")
+                    if tname.endswith("_type"):
+                        element_name = tname[:-len("_type")]
+                        break
+                anc = parents.get(anc)
+        if not element_name:
+            continue
+
+        doc = _lookup_doc(docs, element_name, attr_name)
+        if doc is None:
+            report.no_doc.append((element_name, attr_name))
+            continue
+        used_keys.add((doc.element, attr_name))
+        report.matched += 1
+
+        if add_defaults and doc.default is not None \
+                and "default" not in attr_node.attrib:
+            xsd_type = attr_node.get("type", "")
+            reason = _default_invalid_reason(doc.default, xsd_type)
+            if reason is None:
+                attr_node.set("default", doc.default)
+            else:
+                report.bad_default.append(
+                    (element_name, attr_name, doc.default, reason))
+
+        if add_annotations and doc.description:
+            cleaned = clean_rst_markup(doc.description)
+            if cleaned:
+                # Remove any existing annotation we previously injected.
+                for existing in list(
+                    attr_node.findall(f"{{{XS}}}annotation")
+                ):
+                    attr_node.remove(existing)
+                ann = ET.SubElement(attr_node, f"{{{XS}}}annotation")
+                docnode = ET.SubElement(ann, f"{{{XS}}}documentation")
+                docnode.text = cleaned
+
+    _indent(root)
+    tree.write(out_path, encoding="utf-8", xml_declaration=True)
+    report.unused_rst = sorted(set(docs.keys()) - used_keys)
+    return report
+
+
+def _indent(elem: ET.Element, level: int = 0) -> None:
+    """In-place pretty-print (Python 3.9+ has ET.indent, but we reimplement
+    here to stay compatible with older interpreters)."""
+    pad = "\n" + "  " * level
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = pad + "  "
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = pad
+        for child in elem:
+            _indent(child, level + 1)
+        if not elem[-1].tail or not elem[-1].tail.strip():
+            elem[-1].tail = pad
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = pad
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(r: EnrichmentReport, out_path: str) -> None:
+    pct = (100.0 * r.matched / r.total) if r.total else 0.0
+    print(f"\nEnrichment summary for {out_path}:", file=sys.stderr)
+    print(f"  matched       {r.matched}/{r.total}  ({pct:.1f}%) "
+          "xs:attributes have RST docs",
+          file=sys.stderr)
+    if r.no_doc:
+        print(f"  warn          {len(r.no_doc)} xs:attributes have no "
+              "RST documentation (RST may need updating)",
+              file=sys.stderr)
+    if r.bad_default:
+        print(f"  warn          {len(r.bad_default)} RST defaults rejected "
+              "(not XSD-compatible; RST may need updating)",
+              file=sys.stderr)
+    if r.unused_rst:
+        print(f"  warn          {len(r.unused_rst)} RST entries have no "
+              "matching xs:attribute (possible renamed/removed attrs)",
+              file=sys.stderr)
+    if r.no_doc or r.bad_default or r.unused_rst:
+        print("  (run with --report for per-item details)", file=sys.stderr)
+
+
+def _print_report(r: EnrichmentReport) -> None:
+    if r.no_doc:
+        by_element: dict[str, list[str]] = defaultdict(list)
+        for (e, a) in sorted(r.no_doc):
+            by_element[e].append(a)
+        print(f"\n=== xs:attributes with NO RST docs ({len(r.no_doc)}) ===",
+              file=sys.stderr)
+        for e, attrs in sorted(by_element.items()):
+            print(f"  <{e or '?'}>: {', '.join(attrs)}", file=sys.stderr)
+
+    if r.bad_default:
+        print(f"\n=== RST defaults rejected ({len(r.bad_default)}) ===",
+              file=sys.stderr)
+        print("  (fix by rewording the :at-val:`...` in the RST)",
+              file=sys.stderr)
+        for (e, a, v, reason) in r.bad_default:
+            print(f"  <{e}>/{a}: default={v!r}  ({reason})", file=sys.stderr)
+
+    if r.unused_rst:
+        by_element = defaultdict(list)
+        for (e, a) in r.unused_rst:
+            by_element[e].append(a)
+        print(f"\n=== RST entries with no matching xs:attribute "
+              f"({len(r.unused_rst)}) ===",
+              file=sys.stderr)
+        print("  (possible stale RST: attr renamed or removed in the C++ "
+              "table, or element aliasing missing in ELEMENT_ALIASES)",
+              file=sys.stderr)
+        for e, attrs in sorted(by_element.items()):
+            print(f"  <{e or '?'}>: {', '.join(attrs)}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    ap.add_argument("--in", dest="in_path", required=True,
+                    help="input XSD (from bin/xmlschema)")
+    ap.add_argument("--rst", dest="rst_path", required=True,
+                    help="path to doc/XMLreference.rst")
+    ap.add_argument("--out", dest="out_path", required=True,
+                    help="output enriched XSD")
+    ap.add_argument("--no-defaults", action="store_true",
+                    help="skip injecting default=... from RST")
+    ap.add_argument("--no-annotations", action="store_true",
+                    help="skip injecting xs:annotation prose")
+    ap.add_argument("--report", action="store_true",
+                    help="print per-item drift details")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero if any drift warnings are emitted "
+                         "(for CI gating)")
+    args = ap.parse_args(argv)
+
+    print(f"Parsing {args.rst_path} ...", file=sys.stderr)
+    docs = parse_rst(args.rst_path)
+    print(f"Extracted {len(docs)} (element, attr) doc entries from RST.",
+          file=sys.stderr)
+
+    report = patch_xsd(
+        args.in_path, docs, args.out_path,
+        add_defaults=not args.no_defaults,
+        add_annotations=not args.no_annotations,
+    )
+    print(f"Wrote {args.out_path}.", file=sys.stderr)
+    _print_summary(report, args.out_path)
+    if args.report:
+        _print_report(report)
+
+    has_warnings = bool(report.no_doc or report.bad_default or report.unused_rst)
+    return 1 if (args.strict and has_warnings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/include/mujoco/mujoco.h
+++ b/include/mujoco/mujoco.h
@@ -343,6 +343,9 @@ MJAPI void mju_printMatSparse(const mjtNum* mat, int nr,
 MJAPI int mj_printSchema(const char* filename, char* buffer, int buffer_sz,
                          int flg_html, int flg_pad);
 
+// Print internal XML schema as an XSD (XML Schema Definition) document.
+MJAPI int mj_printSchemaXSD(const char* filename, char* buffer, int buffer_sz);
+
 // Print scene to text file.
 MJAPI void mj_printScene(const mjvScene* s, const char* filename);
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -87,9 +87,15 @@ target_compile_options(testspeed PUBLIC ${MUJOCO_SAMPLE_COMPILE_OPTIONS})
 target_link_libraries(testspeed Threads::Threads)
 target_link_options(testspeed PRIVATE ${MUJOCO_SAMPLE_LINK_OPTIONS})
 
+add_executable(xmlschema xmlschema.cc)
+target_compile_options(xmlschema PUBLIC ${MUJOCO_SAMPLE_COMPILE_OPTIONS})
+target_link_libraries(xmlschema Threads::Threads)
+target_link_options(xmlschema PRIVATE ${MUJOCO_SAMPLE_LINK_OPTIONS})
+
 target_link_libraries(compile mujoco::mujoco)
 target_link_libraries(dependencies mujoco::mujoco)
 target_link_libraries(testspeed mujoco::mujoco)
+target_link_libraries(xmlschema mujoco::mujoco)
 
 # Build samples that require GLFW.
 

--- a/sample/xmlschema.cc
+++ b/sample/xmlschema.cc
@@ -1,0 +1,50 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Release-time helper: emit the auto-generated MJCF XSD to a file or stdout.
+//
+// Usage:
+//   xmlschema                    # write raw XSD to stdout
+//   xmlschema raw.xsd            # write raw XSD to file
+//
+// The emitted document is the "raw" schema (structure + types + enums only);
+// release builds post-process it through doc/mjcf_schema_enrich.py to inject
+// defaults and prose from doc/XMLreference.rst, producing doc/mjcf.xsd.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <mujoco/mujoco.h>
+
+int main(int argc, char** argv) {
+  const char* out = (argc >= 2) ? argv[1] : nullptr;
+
+  if (!out) {
+    // stdout path: ask for the size, allocate, print.
+    const int n = mj_printSchemaXSD(nullptr, nullptr, 0) + 1;
+    char* buf = static_cast<char*>(std::malloc(n));
+    if (!buf) {
+      std::fprintf(stderr, "out of memory\n");
+      return EXIT_FAILURE;
+    }
+    mj_printSchemaXSD(nullptr, buf, n);
+    std::fputs(buf, stdout);
+    std::free(buf);
+  } else {
+    mj_printSchemaXSD(out, nullptr, 0);
+    std::fprintf(stderr, "wrote %s\n", out);
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -23,6 +23,8 @@ set(MUJOCO_XML_SRCS
     xml.h
     xml_native_reader.cc
     xml_native_reader.h
+    xml_native_schema.cc
+    xml_native_schema.h
     xml_numeric_format.cc
     xml_numeric_format.h
     xml_native_writer.cc

--- a/src/xml/xml_api.cc
+++ b/src/xml/xml_api.cc
@@ -30,6 +30,7 @@
 #include "xml/xml.h"
 #include "xml/xml_global.h"
 #include "xml/xml_native_reader.h"
+#include "xml/xml_native_schema.h"
 #include "xml/xml_util.h"
 
 //---------------------------------- Functions -----------------------------------------------------
@@ -135,6 +136,28 @@ int mj_printSchema(const char* filename, char* buffer, int buffer_sz, int flg_ht
   }
 
   // return string length
+  return str.str().size();
+}
+
+
+
+// print internal XML schema as an XSD (XML Schema Definition) document
+int mj_printSchemaXSD(const char* filename, char* buffer, int buffer_sz) {
+  std::stringstream str;
+  mujoco::PrintSchemaXSD(str);
+
+  if (filename) {
+    std::ofstream file;
+    file.open(filename);
+    file << str.str();
+    file.close();
+  }
+
+  if (buffer && buffer_sz) {
+    strncpy(buffer, str.str().c_str(), buffer_sz);
+    buffer[buffer_sz-1] = 0;
+  }
+
   return str.str().size();
 }
 

--- a/src/xml/xml_api.h
+++ b/src/xml/xml_api.h
@@ -40,6 +40,9 @@ MJAPI void mj_freeLastXML(void);
 MJAPI int mj_printSchema(const char* filename, char* buffer, int buffer_sz,
                          int flg_html, int flg_pad);
 
+// print internal XML schema as an XSD (XML Schema Definition) document
+MJAPI int mj_printSchemaXSD(const char* filename, char* buffer, int buffer_sz);
+
 // load model from binary MJB file
 // if vfs is not NULL, look up file in vfs before reading from disk
 MJAPI mjModel* mj_loadModel(const char* filename, const mjVFS* vfs);

--- a/src/xml/xml_native_reader.cc
+++ b/src/xml/xml_native_reader.cc
@@ -602,42 +602,42 @@ std::vector<const char*> MJCF[nMJCF] = {
 //---------------------------------- MJCF keywords used in attributes ------------------------------
 
 // coordinate type
-extern const mjMap coordinate_map[2] = {
+const mjMap coordinate_map[2] = {
   {"local",   0},
   {"global",  1}
 };
 
 
 // angle type
-extern const mjMap angle_map[2] = {
+const mjMap angle_map[2] = {
   {"radian",  0},
   {"degree",  1}
 };
 
 
 // bool type
-extern const mjMap bool_map[2] = {
+const mjMap bool_map[2] = {
   {"false",   0},
   {"true",    1}
 };
 
 
 // fluidshape type
-extern const mjMap fluid_map[2] = {
+const mjMap fluid_map[2] = {
   {"none",      0},
   {"ellipsoid", 1}
 };
 
 
 // enable type
-extern const mjMap enable_map[2] = {
+const mjMap enable_map[2] = {
   {"disable", 0},
   {"enable",  1}
 };
 
 
 // TFAuto type
-extern const mjMap TFAuto_map[3] = {
+const mjMap TFAuto_map[3] = {
   {"false",   0},
   {"true",    1},
   {"auto",    2}
@@ -652,8 +652,8 @@ const mjMap FAuto_map[2] = {
 
 
 // body sleep type
-extern const int bodysleep_sz = 4;
-extern const mjMap bodysleep_map[bodysleep_sz] = {
+const int bodysleep_sz = 4;
+const mjMap bodysleep_map[bodysleep_sz] = {
   {"auto",          mjSLEEP_AUTO},
   {"never",         mjSLEEP_NEVER},
   {"allowed",       mjSLEEP_ALLOWED},
@@ -661,8 +661,8 @@ extern const mjMap bodysleep_map[bodysleep_sz] = {
 };
 
 // joint type
-extern const int joint_sz = 4;
-extern const mjMap joint_map[joint_sz] = {
+const int joint_sz = 4;
+const mjMap joint_map[joint_sz] = {
   {"free",          mjJNT_FREE},
   {"ball",          mjJNT_BALL},
   {"slide",         mjJNT_SLIDE},
@@ -671,7 +671,7 @@ extern const mjMap joint_map[joint_sz] = {
 
 
 // geom type
-extern const mjMap geom_map[mjNGEOMTYPES] = {
+const mjMap geom_map[mjNGEOMTYPES] = {
   {"plane",         mjGEOM_PLANE},
   {"hfield",        mjGEOM_HFIELD},
   {"sphere",        mjGEOM_SPHERE},
@@ -685,15 +685,15 @@ extern const mjMap geom_map[mjNGEOMTYPES] = {
 
 
 // projection type
-extern const int projection_sz = 2;
-extern const mjMap projection_map[projection_sz] = {
+const int projection_sz = 2;
+const mjMap projection_map[projection_sz] = {
   {"perspective",   mjPROJ_PERSPECTIVE},
   {"orthographic",  mjPROJ_ORTHOGRAPHIC}
 };
 
 // camlight type
-extern const int camlight_sz = 5;
-extern const mjMap camlight_map[camlight_sz] = {
+const int camlight_sz = 5;
+const mjMap camlight_map[camlight_sz] = {
   {"fixed",         mjCAMLIGHT_FIXED},
   {"track",         mjCAMLIGHT_TRACK},
   {"trackcom",      mjCAMLIGHT_TRACKCOM},
@@ -703,8 +703,8 @@ extern const mjMap camlight_map[camlight_sz] = {
 
 
 // light type
-extern const int lighttype_sz = 4;
-extern const mjMap lighttype_map[lighttype_sz] = {
+const int lighttype_sz = 4;
+const mjMap lighttype_map[lighttype_sz] = {
   {"spot",          mjLIGHT_SPOT},
   {"directional",   mjLIGHT_DIRECTIONAL},
   {"point",         mjLIGHT_POINT},
@@ -713,8 +713,8 @@ extern const mjMap lighttype_map[lighttype_sz] = {
 
 
 // texmat role type
-extern const int texrole_sz = mjNTEXROLE - 1;
-extern const mjMap texrole_map[texrole_sz] = {
+const int texrole_sz = mjNTEXROLE - 1;
+const mjMap texrole_map[texrole_sz] = {
   {"rgb",           mjTEXROLE_RGB},
   {"occlusion",     mjTEXROLE_OCCLUSION},
   {"roughness",     mjTEXROLE_ROUGHNESS},
@@ -728,8 +728,8 @@ extern const mjMap texrole_map[texrole_sz] = {
 
 
 // integrator type
-extern const int integrator_sz = 4;
-extern const mjMap integrator_map[integrator_sz] = {
+const int integrator_sz = 4;
+const mjMap integrator_map[integrator_sz] = {
   {"Euler",         mjINT_EULER},
   {"RK4",           mjINT_RK4},
   {"implicit",      mjINT_IMPLICIT},
@@ -738,16 +738,16 @@ extern const mjMap integrator_map[integrator_sz] = {
 
 
 // cone type
-extern const int cone_sz = 2;
-extern const mjMap cone_map[cone_sz] = {
+const int cone_sz = 2;
+const mjMap cone_map[cone_sz] = {
   {"pyramidal",     mjCONE_PYRAMIDAL},
   {"elliptic",      mjCONE_ELLIPTIC}
 };
 
 
 // Jacobian type
-extern const int jac_sz = 3;
-extern const mjMap jac_map[jac_sz] = {
+const int jac_sz = 3;
+const mjMap jac_map[jac_sz] = {
   {"dense",         mjJAC_DENSE},
   {"sparse",        mjJAC_SPARSE},
   {"auto",          mjJAC_AUTO}
@@ -755,8 +755,8 @@ extern const mjMap jac_map[jac_sz] = {
 
 
 // solver type
-extern const int solver_sz = 3;
-extern const mjMap solver_map[solver_sz] = {
+const int solver_sz = 3;
+const mjMap solver_map[solver_sz] = {
   {"PGS",           mjSOL_PGS},
   {"CG",            mjSOL_CG},
   {"Newton",        mjSOL_NEWTON}
@@ -764,8 +764,8 @@ extern const mjMap solver_map[solver_sz] = {
 
 
 // constraint type
-extern const int equality_sz = 8;
-extern const mjMap equality_map[equality_sz] = {
+const int equality_sz = 8;
+const mjMap equality_map[equality_sz] = {
   {"connect",       mjEQ_CONNECT},
   {"weld",          mjEQ_WELD},
   {"joint",         mjEQ_JOINT},
@@ -778,8 +778,8 @@ extern const mjMap equality_map[equality_sz] = {
 
 
 // type for texture
-extern const int texture_sz = 3;
-extern const mjMap texture_map[texture_sz] = {
+const int texture_sz = 3;
+const mjMap texture_map[texture_sz] = {
   {"2d",            mjTEXTURE_2D},
   {"cube",          mjTEXTURE_CUBE},
   {"skybox",        mjTEXTURE_SKYBOX}
@@ -787,8 +787,8 @@ extern const mjMap texture_map[texture_sz] = {
 
 
 // colorspace for texture
-extern const int colorspace_sz = 3;
-extern const mjMap colorspace_map[colorspace_sz] = {
+const int colorspace_sz = 3;
+const mjMap colorspace_map[colorspace_sz] = {
   {"auto",          mjCOLORSPACE_AUTO},
   {"linear",        mjCOLORSPACE_LINEAR},
   {"sRGB",          mjCOLORSPACE_SRGB}
@@ -796,8 +796,8 @@ extern const mjMap colorspace_map[colorspace_sz] = {
 
 
 // builtin type for texture
-extern const int builtin_sz = 4;
-extern const mjMap builtin_map[builtin_sz] = {
+const int builtin_sz = 4;
+const mjMap builtin_map[builtin_sz] = {
   {"none",          mjBUILTIN_NONE},
   {"gradient",      mjBUILTIN_GRADIENT},
   {"checker",       mjBUILTIN_CHECKER},
@@ -806,8 +806,8 @@ extern const mjMap builtin_map[builtin_sz] = {
 
 
 // mark type for texture
-extern const int mark_sz = 4;
-extern const mjMap mark_map[mark_sz] = {
+const int mark_sz = 4;
+const mjMap mark_map[mark_sz] = {
   {"none",          mjMARK_NONE},
   {"edge",          mjMARK_EDGE},
   {"cross",         mjMARK_CROSS},
@@ -816,8 +816,8 @@ extern const mjMap mark_map[mark_sz] = {
 
 
 // dyn type
-extern const int dyn_sz = 7;
-extern const mjMap dyn_map[dyn_sz] = {
+const int dyn_sz = 7;
+const mjMap dyn_map[dyn_sz] = {
   {"none",          mjDYN_NONE},
   {"integrator",    mjDYN_INTEGRATOR},
   {"filter",        mjDYN_FILTER},
@@ -829,8 +829,8 @@ extern const mjMap dyn_map[dyn_sz] = {
 
 
 // dcmotor controller input mode
-extern const int dcmotorinput_sz = 3;
-extern const mjMap dcmotorinput_map[dcmotorinput_sz] = {
+const int dcmotorinput_sz = 3;
+const mjMap dcmotorinput_map[dcmotorinput_sz] = {
   {"voltage",       0},
   {"position",      1},
   {"velocity",      2}
@@ -838,8 +838,8 @@ extern const mjMap dcmotorinput_map[dcmotorinput_sz] = {
 
 
 // gain type
-extern const int gain_sz = 5;
-extern const mjMap gain_map[gain_sz] = {
+const int gain_sz = 5;
+const mjMap gain_map[gain_sz] = {
   {"fixed",         mjGAIN_FIXED},
   {"affine",        mjGAIN_AFFINE},
   {"muscle",        mjGAIN_MUSCLE},
@@ -849,8 +849,8 @@ extern const mjMap gain_map[gain_sz] = {
 
 
 // bias type
-extern const int bias_sz = 5;
-extern const mjMap bias_map[bias_sz] = {
+const int bias_sz = 5;
+const mjMap bias_map[bias_sz] = {
   {"none",          mjBIAS_NONE},
   {"affine",        mjBIAS_AFFINE},
   {"muscle",        mjBIAS_MUSCLE},
@@ -860,8 +860,8 @@ extern const mjMap bias_map[bias_sz] = {
 
 
 // interpolation type
-extern const int interp_sz = 3;
-extern const mjMap interp_map[interp_sz] = {
+const int interp_sz = 3;
+const mjMap interp_map[interp_sz] = {
   {"zoh",           0},
   {"linear",        1},
   {"cubic",         2}
@@ -869,8 +869,8 @@ extern const mjMap interp_map[interp_sz] = {
 
 
 // stage type
-extern const int stage_sz = 4;
-extern const mjMap stage_map[stage_sz] = {
+const int stage_sz = 4;
+const mjMap stage_map[stage_sz] = {
   {"none",          mjSTAGE_NONE},
   {"pos",           mjSTAGE_POS},
   {"vel",           mjSTAGE_VEL},
@@ -879,8 +879,8 @@ extern const mjMap stage_map[stage_sz] = {
 
 
 // data type
-extern const int datatype_sz = 4;
-extern const mjMap datatype_map[datatype_sz] = {
+const int datatype_sz = 4;
+const mjMap datatype_map[datatype_sz] = {
   {"real",          mjDATATYPE_REAL},
   {"positive",      mjDATATYPE_POSITIVE},
   {"axis",          mjDATATYPE_AXIS},
@@ -889,7 +889,7 @@ extern const mjMap datatype_map[datatype_sz] = {
 
 
 // contact data type
-extern const mjMap condata_map[mjNCONDATA] = {
+const mjMap condata_map[mjNCONDATA] = {
   {"found",         mjCONDATA_FOUND},
   {"force",         mjCONDATA_FORCE},
   {"torque",        mjCONDATA_TORQUE},
@@ -901,7 +901,7 @@ extern const mjMap condata_map[mjNCONDATA] = {
 
 
 // rangefinder data type
-extern const mjMap raydata_map[mjNRAYDATA] = {
+const mjMap raydata_map[mjNRAYDATA] = {
   {"dist",          mjRAYDATA_DIST},
   {"dir",           mjRAYDATA_DIR},
   {"origin",        mjRAYDATA_ORIGIN},
@@ -911,16 +911,16 @@ extern const mjMap raydata_map[mjNRAYDATA] = {
 };
 
 // camera output type
-extern const int camout_sz = mjNCAMOUT;
-extern const mjMap camout_map[mjNCAMOUT] = {{"rgb", mjCAMOUT_RGB},
+const int camout_sz = mjNCAMOUT;
+const mjMap camout_map[mjNCAMOUT] = {{"rgb", mjCAMOUT_RGB},
                                      {"depth", mjCAMOUT_DEPTH},
                                      {"distance", mjCAMOUT_DIST},
                                      {"normal", mjCAMOUT_NORMAL},
                                      {"segmentation", mjCAMOUT_SEG}};
 
 // contact reduction type
-extern const int reduce_sz = 4;
-extern const mjMap reduce_map[reduce_sz] = {
+const int reduce_sz = 4;
+const mjMap reduce_map[reduce_sz] = {
   {"none",          0},
   {"mindist",       1},
   {"maxforce",      2},
@@ -934,8 +934,8 @@ const mjMap conflict_map[conflict_sz] = {{"warning", mjCONFLICT_WARNING},
                                          {"error", mjCONFLICT_ERROR}};
 
 // LR mode
-extern const int lrmode_sz = 4;
-extern const mjMap lrmode_map[lrmode_sz] = {
+const int lrmode_sz = 4;
+const mjMap lrmode_map[lrmode_sz] = {
   {"none",          mjLRMODE_NONE},
   {"muscle",        mjLRMODE_MUSCLE},
   {"muscleuser",    mjLRMODE_MUSCLEUSER},
@@ -944,7 +944,7 @@ extern const mjMap lrmode_map[lrmode_sz] = {
 
 
 // composite type
-extern const mjMap comp_map[mjNCOMPTYPES] = {
+const mjMap comp_map[mjNCOMPTYPES] = {
   {"particle",      mjCOMPTYPE_PARTICLE},
   {"grid",          mjCOMPTYPE_GRID},
   {"rope",          mjCOMPTYPE_ROPE},
@@ -955,13 +955,13 @@ extern const mjMap comp_map[mjNCOMPTYPES] = {
 
 
 // composite joint kind
-extern const mjMap jkind_map[1] = {
+const mjMap jkind_map[1] = {
   {"main",          mjCOMPKIND_JOINT}
 };
 
 
 // composite rope shape
-extern const mjMap shape_map[mjNCOMPSHAPES] = {
+const mjMap shape_map[mjNCOMPSHAPES] = {
   {"s",             mjCOMPSHAPE_LINE},
   {"cos(s)",        mjCOMPSHAPE_COS},
   {"sin(s)",        mjCOMPSHAPE_SIN},
@@ -970,14 +970,14 @@ extern const mjMap shape_map[mjNCOMPSHAPES] = {
 
 
 // mesh type
-extern const mjMap meshtype_map[2] = {
+const mjMap meshtype_map[2] = {
   {"false",         mjINERTIA_VOLUME},
   {"true",          mjINERTIA_SHELL},
 };
 
 
 // mesh inertia type
-extern const mjMap meshinertia_map[4] = {
+const mjMap meshinertia_map[4] = {
   {"convex",        mjMESH_INERTIA_CONVEX},
   {"legacy",        mjMESH_INERTIA_LEGACY},
   {"exact",         mjMESH_INERTIA_EXACT},
@@ -986,8 +986,8 @@ extern const mjMap meshinertia_map[4] = {
 
 
 // mesh builtin type
-extern const int meshbuiltin_sz = 8;
-extern const mjMap meshbuiltin_map[meshbuiltin_sz] = {
+const int meshbuiltin_sz = 8;
+const mjMap meshbuiltin_map[meshbuiltin_sz] = {
   {"none",          mjMESH_BUILTIN_NONE},
   {"sphere",        mjMESH_BUILTIN_SPHERE},
   {"hemisphere",    mjMESH_BUILTIN_HEMISPHERE},
@@ -1000,7 +1000,7 @@ extern const mjMap meshbuiltin_map[meshbuiltin_sz] = {
 
 
 // flexcomp type
-extern const mjMap fcomp_map[mjNFCOMPTYPES] = {
+const mjMap fcomp_map[mjNFCOMPTYPES] = {
   {"grid",          mjFCOMPTYPE_GRID},
   {"box",           mjFCOMPTYPE_BOX},
   {"cylinder",      mjFCOMPTYPE_CYLINDER},
@@ -1015,7 +1015,7 @@ extern const mjMap fcomp_map[mjNFCOMPTYPES] = {
 
 
 // flexcomp dof type
-extern const mjMap fdof_map[mjNFCOMPDOFS] = {
+const mjMap fdof_map[mjNFCOMPDOFS] = {
   {"full",          mjFCOMPDOF_FULL},
   {"radial",        mjFCOMPDOF_RADIAL},
   {"trilinear",     mjFCOMPDOF_TRILINEAR},
@@ -1025,7 +1025,7 @@ extern const mjMap fdof_map[mjNFCOMPDOFS] = {
 
 
 // flex selfcollide type
-extern const mjMap flexself_map[5] = {
+const mjMap flexself_map[5] = {
   {"none",          mjFLEXSELF_NONE},
   {"narrow",        mjFLEXSELF_NARROW},
   {"bvh",           mjFLEXSELF_BVH},
@@ -1035,7 +1035,7 @@ extern const mjMap flexself_map[5] = {
 
 
 // flex elastic 2d type
-extern const mjMap elastic2d_map[5] = {
+const mjMap elastic2d_map[5] = {
   {"none",          0},
   {"bend",          1},
   {"stretch",       2},
@@ -1044,13 +1044,1041 @@ extern const mjMap elastic2d_map[5] = {
 
 
 // flex equality type
-extern const mjMap flexeq_map[4] = {
+const mjMap flexeq_map[4] = {
   {"false",         0},
   {"true",          1},
   {"vert",          2},
   {"strain",        3},
 };
 
+
+//---------------------------------- Attribute type table ------------------------------------------
+// Typed mirror of the ReadAttr*/MapValue calls in the OneX() parsers below.
+// Consumed by the XSD generator in xml_native_schema.cc.
+//
+// MAINTENANCE: if you add/rename an attribute in OneX() or MJCF[], add the
+// matching row here too (one per (element, attr) pair).
+
+// clang-format off
+const mjXAttr kMjXAttrTable[] = {
+
+  //-------------------------------- <mujoco> ------------------------------------------------------
+  {"mujoco", "model", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <compiler> ----------------------------------------------------
+  {"compiler", "autolimits",        kMjXEnum,   0, bool_map,        2},
+  {"compiler", "boundmass",         kMjXReal,   0, nullptr,         0},
+  {"compiler", "boundinertia",      kMjXReal,   0, nullptr,         0},
+  {"compiler", "settotalmass",      kMjXReal,   0, nullptr,         0},
+  {"compiler", "balanceinertia",    kMjXEnum,   0, bool_map,        2},
+  {"compiler", "strippath",         kMjXEnum,   0, bool_map,        2},
+  {"compiler", "coordinate",        kMjXEnum,   0, coordinate_map,  2},
+  {"compiler", "angle",             kMjXEnum,   0, angle_map,       2},
+  {"compiler", "fitaabb",           kMjXEnum,   0, bool_map,        2},
+  {"compiler", "eulerseq",          kMjXString, 0, nullptr,         0},
+  {"compiler", "meshdir",           kMjXString, 0, nullptr,         0},
+  {"compiler", "texturedir",        kMjXString, 0, nullptr,         0},
+  {"compiler", "discardvisual",     kMjXEnum,   0, bool_map,        2},
+  {"compiler", "usethread",         kMjXEnum,   0, bool_map,        2},
+  {"compiler", "fusestatic",        kMjXEnum,   0, bool_map,        2},
+  {"compiler", "inertiafromgeom",   kMjXEnum,   0, TFAuto_map,      3},
+  {"compiler", "inertiagrouprange", kMjXIntN,   2, nullptr,         0},
+  {"compiler", "saveinertial",      kMjXEnum,   0, bool_map,        2},
+  {"compiler", "assetdir",          kMjXString, 0, nullptr,         0},
+  {"compiler", "alignfree",         kMjXEnum,   0, bool_map,        2},
+  //-------------------------------- <compiler><lengthrange> ---------------------------------------
+  {"lengthrange", "mode",        kMjXEnum, 0, lrmode_map, 4},
+  {"lengthrange", "useexisting", kMjXEnum, 0, bool_map,   2},
+  {"lengthrange", "uselimit",    kMjXEnum, 0, bool_map,   2},
+  {"lengthrange", "accel",       kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "maxforce",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "timeconst",   kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "timestep",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "inttotal",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "interval",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "tolrange",    kMjXReal, 0, nullptr,    0},
+
+  //-------------------------------- <option> ------------------------------------------------------
+  {"option", "timestep",             kMjXReal,      0, nullptr,        0},
+  {"option", "impratio",             kMjXReal,      0, nullptr,        0},
+  {"option", "tolerance",            kMjXReal,      0, nullptr,        0},
+  {"option", "ls_tolerance",         kMjXReal,      0, nullptr,        0},
+  {"option", "noslip_tolerance",     kMjXReal,      0, nullptr,        0},
+  {"option", "ccd_tolerance",        kMjXReal,      0, nullptr,        0},
+  {"option", "sleep_tolerance",      kMjXReal,      0, nullptr,        0},
+  {"option", "gravity",              kMjXRealN,     3, nullptr,        0},
+  {"option", "wind",                 kMjXRealN,     3, nullptr,        0},
+  {"option", "magnetic",             kMjXRealN,     3, nullptr,        0},
+  {"option", "density",              kMjXReal,      0, nullptr,        0},
+  {"option", "viscosity",            kMjXReal,      0, nullptr,        0},
+  {"option", "o_margin",             kMjXReal,      0, nullptr,        0},
+  {"option", "o_solref",             kMjXRealUpToN, 2, nullptr,        0},
+  {"option", "o_solimp",             kMjXRealUpToN, 5, nullptr,        0},
+  {"option", "o_friction",           kMjXRealUpToN, 5, nullptr,        0},
+  {"option", "integrator",           kMjXEnum,      0, integrator_map, 4},
+  {"option", "cone",                 kMjXEnum,      0, cone_map,       2},
+  {"option", "jacobian",             kMjXEnum,      0, jac_map,        3},
+  {"option", "solver",               kMjXEnum,      0, solver_map,     3},
+  {"option", "iterations",           kMjXInt,       0, nullptr,        0},
+  {"option", "ls_iterations",        kMjXInt,       0, nullptr,        0},
+  {"option", "noslip_iterations",    kMjXInt,       0, nullptr,        0},
+  {"option", "ccd_iterations",       kMjXInt,       0, nullptr,        0},
+  {"option", "sdf_iterations",       kMjXInt,       0, nullptr,        0},
+  {"option", "sdf_initpoints",       kMjXInt,       0, nullptr,        0},
+  {"option", "actuatorgroupdisable", kMjXIntVec,    0, nullptr,        0},
+
+  //-------------------------------- <option><flag> ------------------------------------------------
+  {"flag", "constraint",   kMjXEnum, 0, enable_map, 2},
+  {"flag", "equality",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "frictionloss", kMjXEnum, 0, enable_map, 2},
+  {"flag", "limit",        kMjXEnum, 0, enable_map, 2},
+  {"flag", "contact",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "spring",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "damper",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "gravity",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "clampctrl",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "warmstart",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "filterparent", kMjXEnum, 0, enable_map, 2},
+  {"flag", "actuation",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "refsafe",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "sensor",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "midphase",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "eulerdamp",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "autoreset",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "nativeccd",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "island",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "override",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "energy",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "fwdinv",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "invdiscrete",  kMjXEnum, 0, enable_map, 2},
+  {"flag", "multiccd",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "sleep",        kMjXEnum, 0, enable_map, 2},
+
+  //-------------------------------- <size> --------------------------------------------------------
+  {"size", "memory",         kMjXString, 0, nullptr, 0},
+  {"size", "njmax",          kMjXInt,    0, nullptr, 0},
+  {"size", "nconmax",        kMjXInt,    0, nullptr, 0},
+  {"size", "nstack",         kMjXInt,    0, nullptr, 0},
+  {"size", "nuserdata",      kMjXInt,    0, nullptr, 0},
+  {"size", "nkey",           kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_body",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_jnt",      kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_geom",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_site",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_cam",      kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_tendon",   kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_actuator", kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_sensor",   kMjXInt,    0, nullptr, 0},
+
+  //-------------------------------- <statistic> ---------------------------------------------------
+  {"statistic", "meaninertia", kMjXReal,  0, nullptr, 0},
+  {"statistic", "meanmass",    kMjXReal,  0, nullptr, 0},
+  {"statistic", "meansize",    kMjXReal,  0, nullptr, 0},
+  {"statistic", "extent",      kMjXReal,  0, nullptr, 0},
+  {"statistic", "center",      kMjXRealN, 3, nullptr, 0},
+
+  //-------------------------------- <visual> subelements ------------------------------------------
+  {"global", "cameraid",         kMjXInt,  0, nullptr,  0},
+  {"global", "orthographic",     kMjXEnum, 0, bool_map, 2},
+  {"global", "fovy",             kMjXReal, 0, nullptr,  0},
+  {"global", "ipd",              kMjXReal, 0, nullptr,  0},
+  {"global", "azimuth",          kMjXReal, 0, nullptr,  0},
+  {"global", "elevation",        kMjXReal, 0, nullptr,  0},
+  {"global", "linewidth",        kMjXReal, 0, nullptr,  0},
+  {"global", "glow",             kMjXReal, 0, nullptr,  0},
+  {"global", "offwidth",         kMjXInt,  0, nullptr,  0},
+  {"global", "offheight",        kMjXInt,  0, nullptr,  0},
+  {"global", "realtime",         kMjXReal, 0, nullptr,  0},
+  {"global", "ellipsoidinertia", kMjXEnum, 0, bool_map, 2},
+  {"global", "bvactive",         kMjXEnum, 0, bool_map, 2},
+
+  {"quality", "shadowsize", kMjXInt, 0, nullptr, 0},
+  {"quality", "offsamples", kMjXInt, 0, nullptr, 0},
+  {"quality", "numslices",  kMjXInt, 0, nullptr, 0},
+  {"quality", "numstacks",  kMjXInt, 0, nullptr, 0},
+  {"quality", "numquads",   kMjXInt, 0, nullptr, 0},
+
+  {"headlight", "ambient",  kMjXRealN, 3, nullptr, 0},
+  {"headlight", "diffuse",  kMjXRealN, 3, nullptr, 0},
+  {"headlight", "specular", kMjXRealN, 3, nullptr, 0},
+  {"headlight", "active",   kMjXInt,   0, nullptr, 0},
+
+  {"map", "stiffness",      kMjXReal, 0, nullptr, 0},
+  {"map", "stiffnessrot",   kMjXReal, 0, nullptr, 0},
+  {"map", "force",          kMjXReal, 0, nullptr, 0},
+  {"map", "torque",         kMjXReal, 0, nullptr, 0},
+  {"map", "alpha",          kMjXReal, 0, nullptr, 0},
+  {"map", "fogstart",       kMjXReal, 0, nullptr, 0},
+  {"map", "fogend",         kMjXReal, 0, nullptr, 0},
+  {"map", "znear",          kMjXReal, 0, nullptr, 0},
+  {"map", "zfar",           kMjXReal, 0, nullptr, 0},
+  {"map", "haze",           kMjXReal, 0, nullptr, 0},
+  {"map", "shadowclip",     kMjXReal, 0, nullptr, 0},
+  {"map", "shadowscale",    kMjXReal, 0, nullptr, 0},
+  {"map", "actuatortendon", kMjXReal, 0, nullptr, 0},
+
+  {"scale", "forcewidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "contactwidth",   kMjXReal, 0, nullptr, 0},
+  {"scale", "contactheight",  kMjXReal, 0, nullptr, 0},
+  {"scale", "connect",        kMjXReal, 0, nullptr, 0},
+  {"scale", "com",            kMjXReal, 0, nullptr, 0},
+  {"scale", "camera",         kMjXReal, 0, nullptr, 0},
+  {"scale", "light",          kMjXReal, 0, nullptr, 0},
+  {"scale", "selectpoint",    kMjXReal, 0, nullptr, 0},
+  {"scale", "jointlength",    kMjXReal, 0, nullptr, 0},
+  {"scale", "jointwidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "actuatorlength", kMjXReal, 0, nullptr, 0},
+  {"scale", "actuatorwidth",  kMjXReal, 0, nullptr, 0},
+  {"scale", "framelength",    kMjXReal, 0, nullptr, 0},
+  {"scale", "framewidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "constraint",     kMjXReal, 0, nullptr, 0},
+  {"scale", "slidercrank",    kMjXReal, 0, nullptr, 0},
+  {"scale", "frustum",        kMjXReal, 0, nullptr, 0},
+
+  {"rgba", "fog",              kMjXRealN, 4, nullptr, 0},
+  {"rgba", "haze",             kMjXRealN, 4, nullptr, 0},
+  {"rgba", "force",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "inertia",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "joint",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuator",         kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuatornegative", kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuatorpositive", kMjXRealN, 4, nullptr, 0},
+  {"rgba", "com",              kMjXRealN, 4, nullptr, 0},
+  {"rgba", "camera",           kMjXRealN, 4, nullptr, 0},
+  {"rgba", "light",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "selectpoint",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "connect",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactpoint",     kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactforce",     kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactfriction",  kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contacttorque",    kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactgap",       kMjXRealN, 4, nullptr, 0},
+  {"rgba", "rangefinder",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "constraint",       kMjXRealN, 4, nullptr, 0},
+  {"rgba", "slidercrank",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "crankbroken",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "frustum",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "bv",               kMjXRealN, 4, nullptr, 0},
+  {"rgba", "bvactive",         kMjXRealN, 4, nullptr, 0},
+
+  //-------------------------------- <default> -----------------------------------------------------
+  {"default", "class", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <mesh> (asset + default) -------------------------------------
+  {"mesh", "name",         kMjXString,    0, nullptr,          0},
+  {"mesh", "class",        kMjXString,    0, nullptr,          0},
+  {"mesh", "content_type", kMjXString,    0, nullptr,          0},
+  {"mesh", "file",         kMjXString,    0, nullptr,          0},
+  {"mesh", "vertex",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "normal",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "texcoord",     kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "face",         kMjXIntVec,    0, nullptr,          0},
+  {"mesh", "refpos",       kMjXRealN,     3, nullptr,          0},
+  {"mesh", "refquat",      kMjXRealN,     4, nullptr,          0},
+  {"mesh", "scale",        kMjXRealN,     3, nullptr,          0},
+  {"mesh", "smoothnormal", kMjXEnum,      0, bool_map,         2},
+  {"mesh", "maxhullvert",  kMjXInt,       0, nullptr,          0},
+  {"mesh", "inertia",      kMjXEnum,      0, meshinertia_map,  4},
+  {"mesh", "builtin",      kMjXEnum,      0, meshbuiltin_map,  8},
+  {"mesh", "params",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "material",     kMjXString,    0, nullptr,          0},
+
+  //-------------------------------- <material> (asset + default) ----------------------------------
+  {"material", "name",        kMjXString, 0, nullptr,  0},
+  {"material", "class",       kMjXString, 0, nullptr,  0},
+  {"material", "texture",     kMjXString, 0, nullptr,  0},
+  {"material", "texrepeat",   kMjXRealN,  2, nullptr,  0},
+  {"material", "texuniform",  kMjXEnum,   0, bool_map, 2},
+  {"material", "emission",    kMjXReal,   0, nullptr,  0},
+  {"material", "specular",    kMjXReal,   0, nullptr,  0},
+  {"material", "shininess",   kMjXReal,   0, nullptr,  0},
+  {"material", "reflectance", kMjXReal,   0, nullptr,  0},
+  {"material", "metallic",    kMjXReal,   0, nullptr,  0},
+  {"material", "roughness",   kMjXReal,   0, nullptr,  0},
+  {"material", "rgba",        kMjXRealN,  4, nullptr,  0},
+
+  //-------------------------------- <material><layer> ---------------------------------------------
+  {"layer", "texture", kMjXString, 0, nullptr,     0},
+  {"layer", "role",    kMjXEnum,   0, texrole_map, 9},
+
+  //-------------------------------- <joint> (body + default) --------------------------------------
+  {"joint", "name",              kMjXString,    0, nullptr,    0},
+  {"joint", "class",             kMjXString,    0, nullptr,    0},
+  {"joint", "type",              kMjXEnum,      0, joint_map,  4},
+  {"joint", "group",             kMjXInt,       0, nullptr,    0},
+  {"joint", "pos",               kMjXRealN,     3, nullptr,    0},
+  {"joint", "axis",              kMjXRealN,     3, nullptr,    0},
+  {"joint", "springdamper",      kMjXRealN,     2, nullptr,    0},
+  {"joint", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"joint", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"joint", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"joint", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"joint", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"joint", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"joint", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"joint", "range",             kMjXRealN,     2, nullptr,    0},
+  {"joint", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"joint", "actuatorgravcomp",  kMjXEnum,      0, bool_map,   2},
+  {"joint", "margin",            kMjXReal,      0, nullptr,    0},
+  {"joint", "ref",               kMjXReal,      0, nullptr,    0},
+  {"joint", "springref",         kMjXReal,      0, nullptr,    0},
+  {"joint", "armature",          kMjXReal,      0, nullptr,    0},
+  {"joint", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"joint", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"joint", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <freejoint> (body) --------------------------------------------
+  {"freejoint", "name",  kMjXString, 0, nullptr,    0},
+  {"freejoint", "group", kMjXInt,    0, nullptr,    0},
+  {"freejoint", "align", kMjXEnum,   0, TFAuto_map, 3},
+
+  //-------------------------------- <geom> (body + default) ---------------------------------------
+  {"geom", "name",         kMjXString,    0, nullptr,   0},
+  {"geom", "class",        kMjXString,    0, nullptr,   0},
+  {"geom", "type",         kMjXEnum,      0, geom_map,  mjNGEOMTYPES},
+  {"geom", "pos",          kMjXRealN,     3, nullptr,   0},
+  {"geom", "quat",         kMjXRealN,     4, nullptr,   0},
+  {"geom", "axisangle",    kMjXRealN,     4, nullptr,   0},
+  {"geom", "xyaxes",       kMjXRealN,     6, nullptr,   0},
+  {"geom", "zaxis",        kMjXRealN,     3, nullptr,   0},
+  {"geom", "euler",        kMjXRealN,     3, nullptr,   0},
+  {"geom", "contype",      kMjXInt,       0, nullptr,   0},
+  {"geom", "conaffinity",  kMjXInt,       0, nullptr,   0},
+  {"geom", "condim",       kMjXInt,       0, nullptr,   0},
+  {"geom", "group",        kMjXInt,       0, nullptr,   0},
+  {"geom", "priority",     kMjXInt,       0, nullptr,   0},
+  {"geom", "size",         kMjXRealUpToN, 3, nullptr,   0},
+  {"geom", "material",     kMjXString,    0, nullptr,   0},
+  {"geom", "friction",     kMjXRealUpToN, 3, nullptr,   0},
+  {"geom", "mass",         kMjXReal,      0, nullptr,   0},
+  {"geom", "density",      kMjXReal,      0, nullptr,   0},
+  {"geom", "shellinertia", kMjXEnum,      0, meshtype_map, 2},
+  {"geom", "solmix",       kMjXReal,      0, nullptr,   0},
+  {"geom", "solref",       kMjXRealUpToN, 2, nullptr,   0},
+  {"geom", "solimp",       kMjXRealUpToN, 5, nullptr,   0},
+  {"geom", "margin",       kMjXReal,      0, nullptr,   0},
+  {"geom", "gap",          kMjXReal,      0, nullptr,   0},
+  {"geom", "fromto",       kMjXRealN,     6, nullptr,   0},
+  {"geom", "hfield",       kMjXString,    0, nullptr,   0},
+  {"geom", "mesh",         kMjXString,    0, nullptr,   0},
+  {"geom", "fitscale",     kMjXReal,      0, nullptr,   0},
+  {"geom", "rgba",         kMjXRealN,     4, nullptr,   0},
+  {"geom", "fluidshape",   kMjXEnum,      0, fluid_map, 2},
+  {"geom", "fluidcoef",    kMjXRealUpToN, 5, nullptr,   0},
+  {"geom", "user",         kMjXRealVec,   0, nullptr,   0},
+
+  //-------------------------------- <site> (body + default) ---------------------------------------
+  {"site", "name",      kMjXString,    0, nullptr,  0},
+  {"site", "class",     kMjXString,    0, nullptr,  0},
+  {"site", "type",      kMjXEnum,      0, geom_map, mjNGEOMTYPES},
+  {"site", "group",     kMjXInt,       0, nullptr,  0},
+  {"site", "pos",       kMjXRealN,     3, nullptr,  0},
+  {"site", "quat",      kMjXRealN,     4, nullptr,  0},
+  {"site", "material",  kMjXString,    0, nullptr,  0},
+  {"site", "size",      kMjXRealUpToN, 3, nullptr,  0},
+  {"site", "fromto",    kMjXRealN,     6, nullptr,  0},
+  {"site", "axisangle", kMjXRealN,     4, nullptr,  0},
+  {"site", "xyaxes",    kMjXRealN,     6, nullptr,  0},
+  {"site", "zaxis",     kMjXRealN,     3, nullptr,  0},
+  {"site", "euler",     kMjXRealN,     3, nullptr,  0},
+  {"site", "rgba",      kMjXRealN,     4, nullptr,  0},
+  {"site", "user",      kMjXRealVec,   0, nullptr,  0},
+
+  //-------------------------------- <camera> (body + default) -------------------------------------
+  {"camera", "name",           kMjXString,  0, nullptr,        0},
+  {"camera", "class",          kMjXString,  0, nullptr,        0},
+  {"camera", "projection",     kMjXEnum,    0, projection_map, 2},
+  {"camera", "fovy",           kMjXReal,    0, nullptr,        0},
+  {"camera", "ipd",            kMjXReal,    0, nullptr,        0},
+  {"camera", "resolution",     kMjXIntN,    2, nullptr,        0},
+  {"camera", "output",         kMjXString,  0, nullptr,        0},  // space-separated bitflags
+  {"camera", "pos",            kMjXRealN,   3, nullptr,        0},
+  {"camera", "quat",           kMjXRealN,   4, nullptr,        0},
+  {"camera", "axisangle",      kMjXRealN,   4, nullptr,        0},
+  {"camera", "xyaxes",         kMjXRealN,   6, nullptr,        0},
+  {"camera", "zaxis",          kMjXRealN,   3, nullptr,        0},
+  {"camera", "euler",          kMjXRealN,   3, nullptr,        0},
+  {"camera", "mode",           kMjXEnum,    0, camlight_map,   5},
+  {"camera", "target",         kMjXString,  0, nullptr,        0},
+  {"camera", "focal",          kMjXRealN,   2, nullptr,        0},
+  {"camera", "focalpixel",     kMjXRealN,   2, nullptr,        0},
+  {"camera", "principal",      kMjXRealN,   2, nullptr,        0},
+  {"camera", "principalpixel", kMjXRealN,   2, nullptr,        0},
+  {"camera", "sensorsize",     kMjXRealN,   2, nullptr,        0},
+  {"camera", "user",           kMjXRealVec, 0, nullptr,        0},
+
+  //-------------------------------- <light> (body + default) --------------------------------------
+  {"light", "name",        kMjXString, 0, nullptr,       0},
+  {"light", "class",       kMjXString, 0, nullptr,       0},
+  {"light", "pos",         kMjXRealN,  3, nullptr,       0},
+  {"light", "dir",         kMjXRealN,  3, nullptr,       0},
+  {"light", "bulbradius",  kMjXReal,   0, nullptr,       0},
+  {"light", "intensity",   kMjXReal,   0, nullptr,       0},
+  {"light", "range",       kMjXReal,   0, nullptr,       0},
+  {"light", "directional", kMjXEnum,   0, bool_map,      2},
+  {"light", "type",        kMjXEnum,   0, lighttype_map, 4},
+  {"light", "castshadow",  kMjXEnum,   0, bool_map,      2},
+  {"light", "active",      kMjXEnum,   0, bool_map,      2},
+  {"light", "attenuation", kMjXRealN,  3, nullptr,       0},
+  {"light", "cutoff",      kMjXReal,   0, nullptr,       0},
+  {"light", "exponent",    kMjXReal,   0, nullptr,       0},
+  {"light", "ambient",     kMjXRealN,  3, nullptr,       0},
+  {"light", "diffuse",     kMjXRealN,  3, nullptr,       0},
+  {"light", "specular",    kMjXRealN,  3, nullptr,       0},
+  {"light", "mode",        kMjXEnum,   0, camlight_map,  5},
+  {"light", "target",      kMjXString, 0, nullptr,       0},
+  {"light", "texture",     kMjXString, 0, nullptr,       0},
+
+  //-------------------------------- <pair> (default + contact) -----------------------------------
+  {"pair", "name",           kMjXString,    0, nullptr, 0},
+  {"pair", "class",          kMjXString,    0, nullptr, 0},
+  {"pair", "geom1",          kMjXString,    0, nullptr, 0},
+  {"pair", "geom2",          kMjXString,    0, nullptr, 0},
+  {"pair", "condim",         kMjXInt,       0, nullptr, 0},
+  {"pair", "friction",       kMjXRealUpToN, 5, nullptr, 0},
+  {"pair", "solref",         kMjXRealUpToN, 2, nullptr, 0},
+  {"pair", "solreffriction", kMjXRealUpToN, 2, nullptr, 0},
+  {"pair", "solimp",         kMjXRealUpToN, 5, nullptr, 0},
+  {"pair", "margin",         kMjXReal,      0, nullptr, 0},
+  {"pair", "gap",            kMjXReal,      0, nullptr, 0},
+
+  //-------------------------------- <equality> in <default> --------------------------------------
+  {"equality", "active", kMjXEnum,      0, bool_map, 2},
+  {"equality", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"equality", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  //-------------------------------- <tendon> (default + top-level tendon is a complex section) ---
+  // The <tendon> row in MJCF[] under <default> holds only tendon defaults.
+  // These attrs are shared by <spatial> and <fixed> when emitted from <tendon>.
+  {"tendon", "group",              kMjXInt,       0, nullptr,    0},
+  {"tendon", "limited",            kMjXEnum,      0, TFAuto_map, 3},
+  {"tendon", "range",              kMjXRealN,     2, nullptr,    0},
+  {"tendon", "solreflimit",        kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "solimplimit",        kMjXRealUpToN, 5, nullptr,    0},
+  {"tendon", "solreffriction",     kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "solimpfriction",     kMjXRealUpToN, 5, nullptr,    0},
+  {"tendon", "frictionloss",       kMjXReal,      0, nullptr,    0},
+  {"tendon", "springlength",       kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "width",              kMjXReal,      0, nullptr,    0},
+  {"tendon", "material",           kMjXString,    0, nullptr,    0},
+  {"tendon", "margin",             kMjXReal,      0, nullptr,    0},
+  {"tendon", "stiffness",          kMjXRealUpToN, 3, nullptr,    0},
+  {"tendon", "damping",            kMjXRealUpToN, 3, nullptr,    0},
+  {"tendon", "rgba",               kMjXRealN,     4, nullptr,    0},
+  {"tendon", "user",               kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <spatial> (tendon section) -----------------------------------
+  {"spatial", "name",              kMjXString,    0, nullptr,    0},
+  {"spatial", "class",             kMjXString,    0, nullptr,    0},
+  {"spatial", "group",             kMjXInt,       0, nullptr,    0},
+  {"spatial", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"spatial", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"spatial", "range",             kMjXRealN,     2, nullptr,    0},
+  {"spatial", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"spatial", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"spatial", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"spatial", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"spatial", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "width",             kMjXReal,      0, nullptr,    0},
+  {"spatial", "material",          kMjXString,    0, nullptr,    0},
+  {"spatial", "margin",            kMjXReal,      0, nullptr,    0},
+  {"spatial", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"spatial", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"spatial", "armature",          kMjXReal,      0, nullptr,    0},
+  {"spatial", "rgba",              kMjXRealN,     4, nullptr,    0},
+  {"spatial", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <fixed> (tendon section) -------------------------------------
+  {"fixed", "name",              kMjXString,    0, nullptr,    0},
+  {"fixed", "class",             kMjXString,    0, nullptr,    0},
+  {"fixed", "group",             kMjXInt,       0, nullptr,    0},
+  {"fixed", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"fixed", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"fixed", "range",             kMjXRealN,     2, nullptr,    0},
+  {"fixed", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"fixed", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"fixed", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"fixed", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"fixed", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "margin",            kMjXReal,      0, nullptr,    0},
+  {"fixed", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"fixed", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"fixed", "armature",          kMjXReal,      0, nullptr,    0},
+  {"fixed", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <spatial> children: site/geom/pulley -------------------------
+  // Inside <spatial>, children are <site site=...>/<geom geom=... sidesite=...>/<pulley divisor=...>
+  // However the child element name "site" collides with top-level <site>, and our lookup is by
+  // (element, attr). We accept the collision: "site" attribute "site" is unique to the wrap,
+  // but "geom" attribute "geom" is also unique.
+  {"pulley", "divisor", kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- <fixed><joint> (tendon wrap) ---------------------------------
+  // The <joint> child of <fixed> has attrs {joint, coef}. Our top-level <joint> already uses
+  // "name"/"class"/... so the string refs "joint" and real "coef" are distinct here; map them.
+  {"joint", "coef",    kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- actuator (shared attrs) --------------------------------------
+  // Attributes common to all actuator shortcut types; listed per element so per-(element,attr)
+  // lookups work.
+#define ACT_COMMON(elem) \
+  {elem, "name",          kMjXString,    0, nullptr,    0}, \
+  {elem, "class",         kMjXString,    0, nullptr,    0}, \
+  {elem, "group",         kMjXInt,       0, nullptr,    0}, \
+  {elem, "nsample",       kMjXInt,       0, nullptr,    0}, \
+  {elem, "interp",        kMjXEnum,      0, interp_map, 3}, \
+  {elem, "delay",         kMjXReal,      0, nullptr,    0}, \
+  {elem, "ctrllimited",   kMjXEnum,      0, TFAuto_map, 3}, \
+  {elem, "forcelimited",  kMjXEnum,      0, TFAuto_map, 3}, \
+  {elem, "ctrlrange",     kMjXRealN,     2, nullptr,    0}, \
+  {elem, "forcerange",    kMjXRealN,     2, nullptr,    0}, \
+  {elem, "lengthrange",   kMjXRealN,     2, nullptr,    0}, \
+  {elem, "gear",          kMjXRealUpToN, 6, nullptr,    0}, \
+  {elem, "damping",       kMjXRealUpToN, 3, nullptr,    0}, \
+  {elem, "armature",      kMjXReal,      0, nullptr,    0}, \
+  {elem, "cranklength",   kMjXReal,      0, nullptr,    0}, \
+  {elem, "user",          kMjXRealVec,   0, nullptr,    0}, \
+  {elem, "joint",         kMjXString,    0, nullptr,    0}, \
+  {elem, "jointinparent", kMjXString,    0, nullptr,    0}, \
+  {elem, "tendon",        kMjXString,    0, nullptr,    0}, \
+  {elem, "slidersite",    kMjXString,    0, nullptr,    0}, \
+  {elem, "cranksite",     kMjXString,    0, nullptr,    0}, \
+  {elem, "site",          kMjXString,    0, nullptr,    0}, \
+  {elem, "refsite",       kMjXString,    0, nullptr,    0}, \
+  {elem, "body",          kMjXString,    0, nullptr,    0}
+
+  ACT_COMMON("general"),
+  {"general", "actlimited", kMjXEnum,      0, TFAuto_map, 3},
+  {"general", "actrange",   kMjXRealN,     2, nullptr,    0},
+  {"general", "actdim",     kMjXInt,       0, nullptr,    0},
+  {"general", "dyntype",    kMjXEnum,      0, dyn_map,    7},
+  {"general", "gaintype",   kMjXEnum,      0, gain_map,   5},
+  {"general", "biastype",   kMjXEnum,      0, bias_map,   5},
+  {"general", "dynprm",     kMjXRealUpToN, mjNDYN,  nullptr, 0},
+  {"general", "gainprm",    kMjXRealUpToN, mjNGAIN, nullptr, 0},
+  {"general", "biasprm",    kMjXRealUpToN, mjNBIAS, nullptr, 0},
+  {"general", "actearly",   kMjXEnum,      0, bool_map, 2},
+
+  ACT_COMMON("motor"),
+
+  ACT_COMMON("position"),
+  {"position", "kp",           kMjXReal, 0, nullptr, 0},
+  {"position", "kv",           kMjXReal, 0, nullptr, 0},
+  {"position", "dampratio",    kMjXReal, 0, nullptr, 0},
+  {"position", "timeconst",    kMjXReal, 0, nullptr, 0},
+  {"position", "inheritrange", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("velocity"),
+  {"velocity", "kv", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("intvelocity"),
+  {"intvelocity", "kp",           kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "kv",           kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "dampratio",    kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "actrange",     kMjXRealN, 2, nullptr, 0},
+  {"intvelocity", "inheritrange", kMjXReal,  0, nullptr, 0},
+
+  ACT_COMMON("damper"),
+  {"damper", "kv", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("cylinder"),
+  {"cylinder", "timeconst", kMjXReal,  0, nullptr, 0},
+  {"cylinder", "area",      kMjXReal,  0, nullptr, 0},
+  {"cylinder", "diameter",  kMjXReal,  0, nullptr, 0},
+  {"cylinder", "bias",      kMjXRealN, 3, nullptr, 0},
+
+  ACT_COMMON("muscle"),
+  {"muscle", "timeconst", kMjXRealN, 2, nullptr, 0},
+  {"muscle", "tausmooth", kMjXReal,  0, nullptr, 0},
+  {"muscle", "range",     kMjXRealN, 2, nullptr, 0},
+  {"muscle", "force",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "scale",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "lmin",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "lmax",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "vmax",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "fpmax",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "fvmax",     kMjXReal,  0, nullptr, 0},
+
+  // adhesion doesn't use full ACT_COMMON (no joint/tendon/etc), so list manually.
+  {"adhesion", "name",         kMjXString,    0, nullptr,    0},
+  {"adhesion", "class",        kMjXString,    0, nullptr,    0},
+  {"adhesion", "group",        kMjXInt,       0, nullptr,    0},
+  {"adhesion", "nsample",      kMjXInt,       0, nullptr,    0},
+  {"adhesion", "interp",       kMjXEnum,      0, interp_map, 3},
+  {"adhesion", "delay",        kMjXReal,      0, nullptr,    0},
+  {"adhesion", "forcelimited", kMjXEnum,      0, TFAuto_map, 3},
+  {"adhesion", "ctrlrange",    kMjXRealN,     2, nullptr,    0},
+  {"adhesion", "forcerange",   kMjXRealN,     2, nullptr,    0},
+  {"adhesion", "user",         kMjXRealVec,   0, nullptr,    0},
+  {"adhesion", "body",         kMjXString,    0, nullptr,    0},
+  {"adhesion", "gain",         kMjXReal,      0, nullptr,    0},
+
+  ACT_COMMON("dcmotor"),
+  {"dcmotor", "motorconst", kMjXRealUpToN, 2, nullptr,         0},
+  {"dcmotor", "resistance", kMjXReal,      0, nullptr,         0},
+  {"dcmotor", "nominal",    kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "saturation", kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "inductance", kMjXRealUpToN, 2, nullptr,         0},
+  {"dcmotor", "cogging",    kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "controller", kMjXRealUpToN, 6, nullptr,         0},
+  {"dcmotor", "thermal",    kMjXRealUpToN, 6, nullptr,         0},
+  {"dcmotor", "lugre",      kMjXRealUpToN, 5, nullptr,         0},
+  {"dcmotor", "input",      kMjXEnum,      0, dcmotorinput_map, 3},
+
+#undef ACT_COMMON
+
+  //-------------------------------- <extension> ---------------------------------------------------
+  {"plugin",   "plugin",   kMjXString, 0, nullptr, 0},
+  {"plugin",   "instance", kMjXString, 0, nullptr, 0},
+  {"plugin",   "name",     kMjXString, 0, nullptr, 0},
+  {"plugin",   "class",    kMjXString, 0, nullptr, 0},
+  {"instance", "name",     kMjXString, 0, nullptr, 0},
+  {"config",   "key",      kMjXString, 0, nullptr, 0},
+  {"config",   "value",    kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <custom> ------------------------------------------------------
+  {"numeric", "name", kMjXString,  0, nullptr, 0},
+  {"numeric", "size", kMjXInt,     0, nullptr, 0},
+  {"numeric", "data", kMjXRealVec, 0, nullptr, 0},
+
+  {"text",    "name", kMjXString,  0, nullptr, 0},
+  {"text",    "data", kMjXString,  0, nullptr, 0},
+
+  {"tuple",   "name",    kMjXString, 0, nullptr, 0},
+  {"element", "objtype", kMjXString, 0, nullptr, 0},
+  {"element", "objname", kMjXString, 0, nullptr, 0},
+  {"element", "prm",     kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- <asset><hfield> -----------------------------------------------
+  {"hfield", "name",         kMjXString,  0, nullptr, 0},
+  {"hfield", "content_type", kMjXString,  0, nullptr, 0},
+  {"hfield", "file",         kMjXString,  0, nullptr, 0},
+  {"hfield", "nrow",         kMjXInt,     0, nullptr, 0},
+  {"hfield", "ncol",         kMjXInt,     0, nullptr, 0},
+  {"hfield", "size",         kMjXRealN,   4, nullptr, 0},
+  {"hfield", "elevation",    kMjXRealVec, 0, nullptr, 0},
+
+  //-------------------------------- <asset><skin> / <deformable><skin> ---------------------------
+  {"skin", "name",     kMjXString,  0, nullptr,  0},
+  {"skin", "file",     kMjXString,  0, nullptr,  0},
+  {"skin", "material", kMjXString,  0, nullptr,  0},
+  {"skin", "rgba",     kMjXRealN,   4, nullptr,  0},
+  {"skin", "inflate",  kMjXReal,    0, nullptr,  0},
+  {"skin", "vertex",   kMjXRealVec, 0, nullptr,  0},
+  {"skin", "texcoord", kMjXRealVec, 0, nullptr,  0},
+  {"skin", "face",     kMjXIntVec,  0, nullptr,  0},
+  {"skin", "group",    kMjXInt,     0, nullptr,  0},
+  // composite's <skin> sub-element
+  {"skin", "texcoord_composite", kMjXEnum, 0, bool_map, 2},  // unused placeholder
+  {"skin", "subgrid",  kMjXInt,     0, nullptr,  0},
+
+  {"bone", "body",       kMjXString,  0, nullptr, 0},
+  {"bone", "bindpos",    kMjXRealN,   3, nullptr, 0},
+  {"bone", "bindquat",   kMjXRealN,   4, nullptr, 0},
+  {"bone", "vertid",     kMjXIntVec,  0, nullptr, 0},
+  {"bone", "vertweight", kMjXRealVec, 0, nullptr, 0},
+
+  //-------------------------------- <asset><texture> ----------------------------------------------
+  {"texture", "name",         kMjXString,  0, nullptr,         0},
+  {"texture", "type",         kMjXEnum,    0, texture_map,     3},
+  {"texture", "colorspace",   kMjXEnum,    0, colorspace_map,  3},
+  {"texture", "content_type", kMjXString,  0, nullptr,         0},
+  {"texture", "file",         kMjXString,  0, nullptr,         0},
+  {"texture", "gridsize",     kMjXIntN,    2, nullptr,         0},
+  {"texture", "gridlayout",   kMjXString,  0, nullptr,         0},
+  {"texture", "fileright",    kMjXString,  0, nullptr,         0},
+  {"texture", "fileleft",     kMjXString,  0, nullptr,         0},
+  {"texture", "fileup",       kMjXString,  0, nullptr,         0},
+  {"texture", "filedown",     kMjXString,  0, nullptr,         0},
+  {"texture", "filefront",    kMjXString,  0, nullptr,         0},
+  {"texture", "fileback",     kMjXString,  0, nullptr,         0},
+  {"texture", "builtin",      kMjXEnum,    0, builtin_map,     4},
+  {"texture", "rgb1",         kMjXRealN,   3, nullptr,         0},
+  {"texture", "rgb2",         kMjXRealN,   3, nullptr,         0},
+  {"texture", "mark",         kMjXEnum,    0, mark_map,        4},
+  {"texture", "markrgb",      kMjXRealN,   3, nullptr,         0},
+  {"texture", "random",       kMjXReal,    0, nullptr,         0},
+  {"texture", "width",        kMjXInt,     0, nullptr,         0},
+  {"texture", "height",       kMjXInt,     0, nullptr,         0},
+  {"texture", "hflip",        kMjXEnum,    0, bool_map,        2},
+  {"texture", "vflip",        kMjXEnum,    0, bool_map,        2},
+  {"texture", "nchannel",     kMjXInt,     0, nullptr,         0},
+
+  //-------------------------------- <asset><model> ------------------------------------------------
+  {"model", "name",         kMjXString, 0, nullptr, 0},
+  {"model", "file",         kMjXString, 0, nullptr, 0},
+  {"model", "content_type", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <body> / <worldbody> -----------------------------------------
+  {"body", "name",       kMjXString,  0, nullptr,       0},
+  {"body", "childclass", kMjXString,  0, nullptr,       0},
+  {"body", "pos",        kMjXRealN,   3, nullptr,       0},
+  {"body", "quat",       kMjXRealN,   4, nullptr,       0},
+  {"body", "mocap",      kMjXEnum,    0, bool_map,      2},
+  {"body", "axisangle",  kMjXRealN,   4, nullptr,       0},
+  {"body", "xyaxes",     kMjXRealN,   6, nullptr,       0},
+  {"body", "zaxis",      kMjXRealN,   3, nullptr,       0},
+  {"body", "euler",      kMjXRealN,   3, nullptr,       0},
+  {"body", "gravcomp",   kMjXReal,    0, nullptr,       0},
+  {"body", "sleep",      kMjXEnum,    0, bodysleep_map, 4},
+  {"body", "user",       kMjXRealVec, 0, nullptr,       0},
+
+  //-------------------------------- <body><inertial> ---------------------------------------------
+  {"inertial", "pos",          kMjXRealN, 3, nullptr, 0},
+  {"inertial", "quat",         kMjXRealN, 4, nullptr, 0},
+  {"inertial", "mass",         kMjXReal,  0, nullptr, 0},
+  {"inertial", "diaginertia",  kMjXRealN, 3, nullptr, 0},
+  {"inertial", "axisangle",    kMjXRealN, 4, nullptr, 0},
+  {"inertial", "xyaxes",       kMjXRealN, 6, nullptr, 0},
+  {"inertial", "zaxis",        kMjXRealN, 3, nullptr, 0},
+  {"inertial", "euler",        kMjXRealN, 3, nullptr, 0},
+  {"inertial", "fullinertia",  kMjXRealN, 6, nullptr, 0},
+
+  //-------------------------------- <body><frame> ------------------------------------------------
+  {"frame", "name",       kMjXString, 0, nullptr, 0},
+  {"frame", "childclass", kMjXString, 0, nullptr, 0},
+  {"frame", "pos",        kMjXRealN,  3, nullptr, 0},
+  {"frame", "quat",       kMjXRealN,  4, nullptr, 0},
+  {"frame", "axisangle",  kMjXRealN,  4, nullptr, 0},
+  {"frame", "xyaxes",     kMjXRealN,  6, nullptr, 0},
+  {"frame", "zaxis",      kMjXRealN,  3, nullptr, 0},
+  {"frame", "euler",      kMjXRealN,  3, nullptr, 0},
+
+  //-------------------------------- <body><replicate> --------------------------------------------
+  {"replicate", "count",      kMjXInt,    0, nullptr, 0},
+  {"replicate", "offset",     kMjXRealN,  3, nullptr, 0},
+  {"replicate", "euler",      kMjXRealN,  3, nullptr, 0},
+  {"replicate", "sep",        kMjXString, 0, nullptr, 0},
+  {"replicate", "childclass", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <body><attach> -----------------------------------------------
+  {"attach", "model",  kMjXString, 0, nullptr, 0},
+  {"attach", "body",   kMjXString, 0, nullptr, 0},
+  {"attach", "prefix", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <composite> --------------------------------------------------
+  {"composite", "prefix",  kMjXString,  0, nullptr,  0},
+  {"composite", "type",    kMjXEnum,    0, comp_map, mjNCOMPTYPES},
+  {"composite", "count",   kMjXIntVec,  0, nullptr,  0},
+  {"composite", "offset",  kMjXRealN,   3, nullptr,  0},
+  {"composite", "vertex",  kMjXRealVec, 0, nullptr,  0},
+  {"composite", "initial", kMjXString,  0, nullptr,  0},
+  {"composite", "curve",   kMjXString,  0, nullptr,  0},
+  {"composite", "size",    kMjXRealN,   3, nullptr,  0},
+  {"composite", "quat",    kMjXRealN,   4, nullptr,  0},
+
+  //-------------------------------- <flexcomp> ---------------------------------------------------
+  {"flexcomp", "name",       kMjXString,  0, nullptr,   0},
+  {"flexcomp", "type",       kMjXEnum,    0, fcomp_map, mjNFCOMPTYPES},
+  {"flexcomp", "group",      kMjXInt,     0, nullptr,   0},
+  {"flexcomp", "dim",        kMjXInt,     0, nullptr,   0},
+  {"flexcomp", "dof",        kMjXEnum,    0, fdof_map,  mjNFCOMPDOFS},
+  {"flexcomp", "count",      kMjXIntN,    3, nullptr,   0},
+  {"flexcomp", "cellcount",  kMjXIntN,    3, nullptr,   0},
+  {"flexcomp", "spacing",    kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "radius",     kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "rigid",      kMjXEnum,    0, bool_map,  2},
+  {"flexcomp", "mass",       kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "inertiabox", kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "scale",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "file",       kMjXString,  0, nullptr,   0},
+  {"flexcomp", "point",      kMjXRealVec, 0, nullptr,   0},
+  {"flexcomp", "element",    kMjXIntVec,  0, nullptr,   0},
+  {"flexcomp", "texcoord",   kMjXRealVec, 0, nullptr,   0},
+  {"flexcomp", "material",   kMjXString,  0, nullptr,   0},
+  {"flexcomp", "rgba",       kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "flatskin",   kMjXEnum,    0, bool_map,  2},
+  {"flexcomp", "pos",        kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "quat",       kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "axisangle",  kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "xyaxes",     kMjXRealN,   6, nullptr,   0},
+  {"flexcomp", "zaxis",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "euler",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "origin",     kMjXRealN,   3, nullptr,   0},
+
+  //-------------------------------- <flexcomp>/<flex> children -----------------------------------
+  // <edge> under <flex> has {stiffness, damping}; under <flexcomp> adds {equality, solref, solimp}.
+  // We include the union.
+  {"edge", "equality",  kMjXEnum,      0, flexeq_map, 4},
+  {"edge", "solref",    kMjXRealUpToN, 2, nullptr,  0},
+  {"edge", "solimp",    kMjXRealUpToN, 5, nullptr,  0},
+  {"edge", "stiffness", kMjXReal,      0, nullptr,  0},
+  {"edge", "damping",   kMjXReal,      0, nullptr,  0},
+
+  {"elasticity", "young",     kMjXReal,      0, nullptr,         0},
+  {"elasticity", "poisson",   kMjXReal,      0, nullptr,         0},
+  {"elasticity", "damping",   kMjXReal,      0, nullptr,         0},
+  {"elasticity", "thickness", kMjXReal,      0, nullptr,         0},
+  {"elasticity", "elastic2d", kMjXEnum,      0, elastic2d_map,   5},
+
+  {"contact", "contype",      kMjXInt,       0, nullptr,      0},
+  {"contact", "conaffinity",  kMjXInt,       0, nullptr,      0},
+  {"contact", "condim",       kMjXInt,       0, nullptr,      0},
+  {"contact", "priority",     kMjXInt,       0, nullptr,      0},
+  {"contact", "friction",     kMjXRealUpToN, 3, nullptr,      0},
+  {"contact", "solmix",       kMjXReal,      0, nullptr,      0},
+  {"contact", "solref",       kMjXRealUpToN, 2, nullptr,      0},
+  {"contact", "solimp",       kMjXRealUpToN, 5, nullptr,      0},
+  {"contact", "margin",       kMjXReal,      0, nullptr,      0},
+  {"contact", "gap",          kMjXReal,      0, nullptr,      0},
+  {"contact", "internal",     kMjXEnum,      0, bool_map,     2},
+  {"contact", "selfcollide",  kMjXEnum,      0, flexself_map, 5},
+  {"contact", "activelayers", kMjXInt,       0, nullptr,      0},
+  {"contact", "passive",      kMjXEnum,      0, bool_map,     2},
+
+  {"pin", "id",        kMjXIntVec,   0, nullptr, 0},
+  {"pin", "range",     kMjXRealN,    2, nullptr, 0},
+  {"pin", "grid",      kMjXIntVec,   0, nullptr, 0},
+  {"pin", "gridrange", kMjXIntVec,   0, nullptr, 0},
+
+  //-------------------------------- <composite> children -----------------------------------------
+  // Most of composite's children re-use element names that already have entries.
+  // "kind" is specific to composite's <joint>; treat as a composite-joint attr via shared key.
+
+  //-------------------------------- <deformable><flex> -------------------------------------------
+  {"flex", "name",         kMjXString,   0, nullptr,   0},
+  {"flex", "group",        kMjXInt,      0, nullptr,   0},
+  {"flex", "dim",          kMjXInt,      0, nullptr,   0},
+  {"flex", "radius",       kMjXReal,     0, nullptr,   0},
+  {"flex", "material",     kMjXString,   0, nullptr,   0},
+  {"flex", "rgba",         kMjXRealN,    4, nullptr,   0},
+  {"flex", "flatskin",     kMjXEnum,     0, bool_map,  2},
+  {"flex", "body",         kMjXString,   0, nullptr,   0},
+  {"flex", "vertex",       kMjXRealVec,  0, nullptr,   0},
+  {"flex", "element",      kMjXIntVec,   0, nullptr,   0},
+  {"flex", "texcoord",     kMjXRealVec,  0, nullptr,   0},
+  {"flex", "elemtexcoord", kMjXIntVec,   0, nullptr,   0},
+  {"flex", "node",         kMjXString,   0, nullptr,   0},
+  {"flex", "cellcount",    kMjXIntN,     3, nullptr,   0},
+  {"flex", "dof",          kMjXEnum,     0, fdof_map,  mjNFCOMPDOFS},
+  // equality-flex refs (used in <equality><flex>)
+  {"flex", "class",        kMjXString,   0, nullptr,   0},
+  {"flex", "flex",         kMjXString,   0, nullptr,   0},
+  {"flex", "active",       kMjXEnum,     0, bool_map,  2},
+  {"flex", "solref",       kMjXRealUpToN,2, nullptr,   0},
+  {"flex", "solimp",       kMjXRealUpToN,5, nullptr,   0},
+
+  //-------------------------------- <contact> ----------------------------------------------------
+  {"exclude", "name",  kMjXString, 0, nullptr, 0},
+  {"exclude", "body1", kMjXString, 0, nullptr, 0},
+  {"exclude", "body2", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <equality> children ------------------------------------------
+  {"connect", "name",     kMjXString,    0, nullptr,  0},
+  {"connect", "class",    kMjXString,    0, nullptr,  0},
+  {"connect", "body1",    kMjXString,    0, nullptr,  0},
+  {"connect", "body2",    kMjXString,    0, nullptr,  0},
+  {"connect", "anchor",   kMjXRealN,     3, nullptr,  0},
+  {"connect", "site1",    kMjXString,    0, nullptr,  0},
+  {"connect", "site2",    kMjXString,    0, nullptr,  0},
+  {"connect", "active",   kMjXEnum,      0, bool_map, 2},
+  {"connect", "solref",   kMjXRealUpToN, 2, nullptr,  0},
+  {"connect", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
+
+  {"weld", "name",        kMjXString,    0, nullptr,  0},
+  {"weld", "class",       kMjXString,    0, nullptr,  0},
+  {"weld", "body1",       kMjXString,    0, nullptr,  0},
+  {"weld", "body2",       kMjXString,    0, nullptr,  0},
+  {"weld", "relpose",     kMjXRealN,     7, nullptr,  0},
+  {"weld", "anchor",      kMjXRealN,     3, nullptr,  0},
+  {"weld", "site1",       kMjXString,    0, nullptr,  0},
+  {"weld", "site2",       kMjXString,    0, nullptr,  0},
+  {"weld", "active",      kMjXEnum,      0, bool_map, 2},
+  {"weld", "solref",      kMjXRealUpToN, 2, nullptr,  0},
+  {"weld", "solimp",      kMjXRealUpToN, 5, nullptr,  0},
+  {"weld", "torquescale", kMjXReal,      0, nullptr,  0},
+
+  // <equality><joint> has a distinct set of attrs from top-level <joint>.
+  // Since our lookup key is (element, attr), we add the ones not already covered
+  // by top-level <joint> (joint1, joint2, polycoef).
+  {"joint", "joint1",   kMjXString,    0, nullptr,  0},
+  {"joint", "joint2",   kMjXString,    0, nullptr,  0},
+  {"joint", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
+  {"joint", "active",   kMjXEnum,      0, bool_map, 2},
+  {"joint", "solref",   kMjXRealUpToN, 2, nullptr,  0},
+  {"joint", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
+  {"joint", "kind",     kMjXString,    0, nullptr,  0},  // composite joint kind
+  {"joint", "joint",    kMjXString,    0, nullptr,  0},  // tendon wrap
+
+  // <equality><tendon>
+  {"tendon", "name",     kMjXString,    0, nullptr,  0},
+  {"tendon", "class",    kMjXString,    0, nullptr,  0},
+  {"tendon", "tendon1",  kMjXString,    0, nullptr,  0},
+  {"tendon", "tendon2",  kMjXString,    0, nullptr,  0},
+  {"tendon", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
+
+  // flexvert / flexstrain equality variants
+  {"flexvert", "name",   kMjXString,    0, nullptr,  0},
+  {"flexvert", "class",  kMjXString,    0, nullptr,  0},
+  {"flexvert", "flex",   kMjXString,    0, nullptr,  0},
+  {"flexvert", "active", kMjXEnum,      0, bool_map, 2},
+  {"flexvert", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"flexvert", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  {"flexstrain", "name",   kMjXString,    0, nullptr,  0},
+  {"flexstrain", "class",  kMjXString,    0, nullptr,  0},
+  {"flexstrain", "flex",   kMjXString,    0, nullptr,  0},
+  {"flexstrain", "active", kMjXEnum,      0, bool_map, 2},
+  {"flexstrain", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"flexstrain", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  //-------------------------------- <tendon> wrap subelements ------------------------------------
+  // <site site="..."/>, <geom geom="..." sidesite="..."/>
+  {"site", "site",     kMjXString, 0, nullptr, 0},
+  {"geom", "geom",     kMjXString, 0, nullptr, 0},
+  {"geom", "sidesite", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <sensor> ------------------------------------------------------
+  // shared sensor attrs
+#define SENS_COMMON(elem) \
+  {elem, "name",     kMjXString,    0, nullptr,    0}, \
+  {elem, "nsample",  kMjXInt,       0, nullptr,    0}, \
+  {elem, "interp",   kMjXEnum,      0, interp_map, 3}, \
+  {elem, "delay",    kMjXReal,      0, nullptr,    0}, \
+  {elem, "interval", kMjXRealUpToN, 2, nullptr,    0}, \
+  {elem, "cutoff",   kMjXReal,      0, nullptr,    0}, \
+  {elem, "noise",    kMjXReal,      0, nullptr,    0}, \
+  {elem, "user",     kMjXRealVec,   0, nullptr,    0}
+
+  SENS_COMMON("touch"),         {"touch",         "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("accelerometer"), {"accelerometer", "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("velocimeter"),   {"velocimeter",   "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("gyro"),          {"gyro",          "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("force"),         {"force",         "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("torque"),        {"torque",        "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("magnetometer"),  {"magnetometer",  "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("camprojection"), {"camprojection", "site",     kMjXString, 0, nullptr, 0},
+                                {"camprojection", "camera",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("rangefinder"),   {"rangefinder",   "site",     kMjXString, 0, nullptr, 0},
+                                {"rangefinder",   "camera",   kMjXString, 0, nullptr, 0},
+                                {"rangefinder",   "data",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointpos"),      {"jointpos",      "joint",    kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointvel"),      {"jointvel",      "joint",    kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonpos"),     {"tendonpos",     "tendon",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonvel"),     {"tendonvel",     "tendon",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorpos"),   {"actuatorpos",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorvel"),   {"actuatorvel",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorfrc"),   {"actuatorfrc",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointactuatorfrc"),  {"jointactuatorfrc",  "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonactuatorfrc"), {"tendonactuatorfrc", "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("ballquat"),          {"ballquat",          "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("ballangvel"),        {"ballangvel",        "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitpos"),     {"jointlimitpos",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitvel"),     {"jointlimitvel",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitfrc"),     {"jointlimitfrc",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitpos"),    {"tendonlimitpos",    "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitvel"),    {"tendonlimitvel",    "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitfrc"),    {"tendonlimitfrc",    "tendon", kMjXString, 0, nullptr, 0},
+
+#define SENS_FRAME(elem) \
+  SENS_COMMON(elem), \
+  {elem, "objtype", kMjXString, 0, nullptr, 0}, \
+  {elem, "objname", kMjXString, 0, nullptr, 0}, \
+  {elem, "reftype", kMjXString, 0, nullptr, 0}, \
+  {elem, "refname", kMjXString, 0, nullptr, 0}
+
+  SENS_FRAME("framepos"),
+  SENS_FRAME("framequat"),
+  SENS_FRAME("framexaxis"),
+  SENS_FRAME("frameyaxis"),
+  SENS_FRAME("framezaxis"),
+  SENS_FRAME("framelinvel"),
+  SENS_FRAME("frameangvel"),
+  SENS_COMMON("framelinacc"), {"framelinacc", "objtype", kMjXString, 0, nullptr, 0},
+                              {"framelinacc", "objname", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("frameangacc"), {"frameangacc", "objtype", kMjXString, 0, nullptr, 0},
+                              {"frameangacc", "objname", kMjXString, 0, nullptr, 0},
+
+  SENS_COMMON("subtreecom"),    {"subtreecom",    "body", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("subtreelinvel"), {"subtreelinvel", "body", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("subtreeangmom"), {"subtreeangmom", "body", kMjXString, 0, nullptr, 0},
+
+  SENS_COMMON("insidesite"),
+  {"insidesite", "site",    kMjXString, 0, nullptr, 0},
+  {"insidesite", "objtype", kMjXString, 0, nullptr, 0},
+  {"insidesite", "objname", kMjXString, 0, nullptr, 0},
+
+  // distance/normal/fromto share the same attrs
+  SENS_COMMON("distance"),
+  {"distance", "geom1", kMjXString, 0, nullptr, 0},
+  {"distance", "geom2", kMjXString, 0, nullptr, 0},
+  {"distance", "body1", kMjXString, 0, nullptr, 0},
+  {"distance", "body2", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("normal"),
+  {"normal", "geom1", kMjXString, 0, nullptr, 0},
+  {"normal", "geom2", kMjXString, 0, nullptr, 0},
+  {"normal", "body1", kMjXString, 0, nullptr, 0},
+  {"normal", "body2", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("fromto"),
+  {"fromto", "geom1", kMjXString, 0, nullptr, 0},
+  {"fromto", "geom2", kMjXString, 0, nullptr, 0},
+  {"fromto", "body1", kMjXString, 0, nullptr, 0},
+  {"fromto", "body2", kMjXString, 0, nullptr, 0},
+
+  // contact sensor
+  {"contact", "name",     kMjXString, 0, nullptr,    0},
+  {"contact", "geom1",    kMjXString, 0, nullptr,    0},
+  {"contact", "geom2",    kMjXString, 0, nullptr,    0},
+  {"contact", "body1",    kMjXString, 0, nullptr,    0},
+  {"contact", "body2",    kMjXString, 0, nullptr,    0},
+  {"contact", "subtree1", kMjXString, 0, nullptr,    0},
+  {"contact", "subtree2", kMjXString, 0, nullptr,    0},
+  {"contact", "site",     kMjXString, 0, nullptr,    0},
+  {"contact", "num",      kMjXInt,    0, nullptr,    0},
+  {"contact", "data",     kMjXString, 0, nullptr,    0},  // space-separated enum bitflags
+  {"contact", "reduce",   kMjXEnum,   0, reduce_map, 4},
+  {"contact", "nsample",  kMjXInt,    0, nullptr,    0},
+  {"contact", "interp",   kMjXEnum,   0, interp_map, 3},
+  {"contact", "delay",    kMjXReal,   0, nullptr,    0},
+  {"contact", "interval", kMjXRealUpToN, 2, nullptr, 0},
+  {"contact", "cutoff",   kMjXReal,   0, nullptr,    0},
+  {"contact", "noise",    kMjXReal,   0, nullptr,    0},
+  {"contact", "user",     kMjXRealVec,0, nullptr,    0},
+
+  SENS_COMMON("e_potential"),
+  SENS_COMMON("e_kinetic"),
+  SENS_COMMON("clock"),
+
+  {"tactile", "name",    kMjXString,  0, nullptr,    0},
+  {"tactile", "geom",    kMjXString,  0, nullptr,    0},
+  {"tactile", "mesh",    kMjXString,  0, nullptr,    0},
+  {"tactile", "nsample", kMjXInt,     0, nullptr,    0},
+  {"tactile", "interp",  kMjXEnum,    0, interp_map, 3},
+  {"tactile", "delay",   kMjXReal,    0, nullptr,    0},
+  {"tactile", "interval",kMjXRealUpToN, 2, nullptr,  0},
+  {"tactile", "user",    kMjXRealVec, 0, nullptr,    0},
+
+  {"user", "name",      kMjXString,  0, nullptr,       0},
+  {"user", "objtype",   kMjXString,  0, nullptr,       0},
+  {"user", "objname",   kMjXString,  0, nullptr,       0},
+  {"user", "datatype",  kMjXEnum,    0, datatype_map,  4},
+  {"user", "needstage", kMjXEnum,    0, stage_map,     4},
+  {"user", "dim",       kMjXInt,     0, nullptr,       0},
+  {"user", "cutoff",    kMjXReal,    0, nullptr,       0},
+  {"user", "noise",     kMjXReal,    0, nullptr,       0},
+  {"user", "user",      kMjXRealVec, 0, nullptr,       0},
+
+#undef SENS_COMMON
+#undef SENS_FRAME
+
+  //-------------------------------- <keyframe> ---------------------------------------------------
+  {"key", "name",  kMjXString,  0, nullptr, 0},
+  {"key", "time",  kMjXReal,    0, nullptr, 0},
+  {"key", "qpos",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "qvel",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "act",   kMjXRealVec, 0, nullptr, 0},
+  {"key", "mpos",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "mquat", kMjXRealVec, 0, nullptr, 0},
+  {"key", "ctrl",  kMjXRealVec, 0, nullptr, 0},
+};
+// clang-format on
+
+const int kMjXAttrTableSize =
+    sizeof(kMjXAttrTable) / sizeof(kMjXAttrTable[0]);
 
 
 //---------------------------------- class mjXReader implementation --------------------------------

--- a/src/xml/xml_native_reader.cc
+++ b/src/xml/xml_native_reader.cc
@@ -602,42 +602,42 @@ std::vector<const char*> MJCF[nMJCF] = {
 //---------------------------------- MJCF keywords used in attributes ------------------------------
 
 // coordinate type
-const mjMap coordinate_map[2] = {
+extern const mjMap coordinate_map[2] = {
   {"local",   0},
   {"global",  1}
 };
 
 
 // angle type
-const mjMap angle_map[2] = {
+extern const mjMap angle_map[2] = {
   {"radian",  0},
   {"degree",  1}
 };
 
 
 // bool type
-const mjMap bool_map[2] = {
+extern const mjMap bool_map[2] = {
   {"false",   0},
   {"true",    1}
 };
 
 
 // fluidshape type
-const mjMap fluid_map[2] = {
+extern const mjMap fluid_map[2] = {
   {"none",      0},
   {"ellipsoid", 1}
 };
 
 
 // enable type
-const mjMap enable_map[2] = {
+extern const mjMap enable_map[2] = {
   {"disable", 0},
   {"enable",  1}
 };
 
 
 // TFAuto type
-const mjMap TFAuto_map[3] = {
+extern const mjMap TFAuto_map[3] = {
   {"false",   0},
   {"true",    1},
   {"auto",    2}
@@ -652,8 +652,8 @@ const mjMap FAuto_map[2] = {
 
 
 // body sleep type
-const int bodysleep_sz = 4;
-const mjMap bodysleep_map[bodysleep_sz] = {
+extern const int bodysleep_sz = 4;
+extern const mjMap bodysleep_map[bodysleep_sz] = {
   {"auto",          mjSLEEP_AUTO},
   {"never",         mjSLEEP_NEVER},
   {"allowed",       mjSLEEP_ALLOWED},
@@ -661,8 +661,8 @@ const mjMap bodysleep_map[bodysleep_sz] = {
 };
 
 // joint type
-const int joint_sz = 4;
-const mjMap joint_map[joint_sz] = {
+extern const int joint_sz = 4;
+extern const mjMap joint_map[joint_sz] = {
   {"free",          mjJNT_FREE},
   {"ball",          mjJNT_BALL},
   {"slide",         mjJNT_SLIDE},
@@ -671,7 +671,7 @@ const mjMap joint_map[joint_sz] = {
 
 
 // geom type
-const mjMap geom_map[mjNGEOMTYPES] = {
+extern const mjMap geom_map[mjNGEOMTYPES] = {
   {"plane",         mjGEOM_PLANE},
   {"hfield",        mjGEOM_HFIELD},
   {"sphere",        mjGEOM_SPHERE},
@@ -685,15 +685,15 @@ const mjMap geom_map[mjNGEOMTYPES] = {
 
 
 // projection type
-const int projection_sz = 2;
-const mjMap projection_map[projection_sz] = {
+extern const int projection_sz = 2;
+extern const mjMap projection_map[projection_sz] = {
   {"perspective",   mjPROJ_PERSPECTIVE},
   {"orthographic",  mjPROJ_ORTHOGRAPHIC}
 };
 
 // camlight type
-const int camlight_sz = 5;
-const mjMap camlight_map[camlight_sz] = {
+extern const int camlight_sz = 5;
+extern const mjMap camlight_map[camlight_sz] = {
   {"fixed",         mjCAMLIGHT_FIXED},
   {"track",         mjCAMLIGHT_TRACK},
   {"trackcom",      mjCAMLIGHT_TRACKCOM},
@@ -703,8 +703,8 @@ const mjMap camlight_map[camlight_sz] = {
 
 
 // light type
-const int lighttype_sz = 4;
-const mjMap lighttype_map[lighttype_sz] = {
+extern const int lighttype_sz = 4;
+extern const mjMap lighttype_map[lighttype_sz] = {
   {"spot",          mjLIGHT_SPOT},
   {"directional",   mjLIGHT_DIRECTIONAL},
   {"point",         mjLIGHT_POINT},
@@ -713,8 +713,8 @@ const mjMap lighttype_map[lighttype_sz] = {
 
 
 // texmat role type
-const int texrole_sz = mjNTEXROLE - 1;
-const mjMap texrole_map[texrole_sz] = {
+extern const int texrole_sz = mjNTEXROLE - 1;
+extern const mjMap texrole_map[texrole_sz] = {
   {"rgb",           mjTEXROLE_RGB},
   {"occlusion",     mjTEXROLE_OCCLUSION},
   {"roughness",     mjTEXROLE_ROUGHNESS},
@@ -728,8 +728,8 @@ const mjMap texrole_map[texrole_sz] = {
 
 
 // integrator type
-const int integrator_sz = 4;
-const mjMap integrator_map[integrator_sz] = {
+extern const int integrator_sz = 4;
+extern const mjMap integrator_map[integrator_sz] = {
   {"Euler",         mjINT_EULER},
   {"RK4",           mjINT_RK4},
   {"implicit",      mjINT_IMPLICIT},
@@ -738,16 +738,16 @@ const mjMap integrator_map[integrator_sz] = {
 
 
 // cone type
-const int cone_sz = 2;
-const mjMap cone_map[cone_sz] = {
+extern const int cone_sz = 2;
+extern const mjMap cone_map[cone_sz] = {
   {"pyramidal",     mjCONE_PYRAMIDAL},
   {"elliptic",      mjCONE_ELLIPTIC}
 };
 
 
 // Jacobian type
-const int jac_sz = 3;
-const mjMap jac_map[jac_sz] = {
+extern const int jac_sz = 3;
+extern const mjMap jac_map[jac_sz] = {
   {"dense",         mjJAC_DENSE},
   {"sparse",        mjJAC_SPARSE},
   {"auto",          mjJAC_AUTO}
@@ -755,8 +755,8 @@ const mjMap jac_map[jac_sz] = {
 
 
 // solver type
-const int solver_sz = 3;
-const mjMap solver_map[solver_sz] = {
+extern const int solver_sz = 3;
+extern const mjMap solver_map[solver_sz] = {
   {"PGS",           mjSOL_PGS},
   {"CG",            mjSOL_CG},
   {"Newton",        mjSOL_NEWTON}
@@ -764,8 +764,8 @@ const mjMap solver_map[solver_sz] = {
 
 
 // constraint type
-const int equality_sz = 8;
-const mjMap equality_map[equality_sz] = {
+extern const int equality_sz = 8;
+extern const mjMap equality_map[equality_sz] = {
   {"connect",       mjEQ_CONNECT},
   {"weld",          mjEQ_WELD},
   {"joint",         mjEQ_JOINT},
@@ -778,8 +778,8 @@ const mjMap equality_map[equality_sz] = {
 
 
 // type for texture
-const int texture_sz = 3;
-const mjMap texture_map[texture_sz] = {
+extern const int texture_sz = 3;
+extern const mjMap texture_map[texture_sz] = {
   {"2d",            mjTEXTURE_2D},
   {"cube",          mjTEXTURE_CUBE},
   {"skybox",        mjTEXTURE_SKYBOX}
@@ -787,8 +787,8 @@ const mjMap texture_map[texture_sz] = {
 
 
 // colorspace for texture
-const int colorspace_sz = 3;
-const mjMap colorspace_map[colorspace_sz] = {
+extern const int colorspace_sz = 3;
+extern const mjMap colorspace_map[colorspace_sz] = {
   {"auto",          mjCOLORSPACE_AUTO},
   {"linear",        mjCOLORSPACE_LINEAR},
   {"sRGB",          mjCOLORSPACE_SRGB}
@@ -796,8 +796,8 @@ const mjMap colorspace_map[colorspace_sz] = {
 
 
 // builtin type for texture
-const int builtin_sz = 4;
-const mjMap builtin_map[builtin_sz] = {
+extern const int builtin_sz = 4;
+extern const mjMap builtin_map[builtin_sz] = {
   {"none",          mjBUILTIN_NONE},
   {"gradient",      mjBUILTIN_GRADIENT},
   {"checker",       mjBUILTIN_CHECKER},
@@ -806,8 +806,8 @@ const mjMap builtin_map[builtin_sz] = {
 
 
 // mark type for texture
-const int mark_sz = 4;
-const mjMap mark_map[mark_sz] = {
+extern const int mark_sz = 4;
+extern const mjMap mark_map[mark_sz] = {
   {"none",          mjMARK_NONE},
   {"edge",          mjMARK_EDGE},
   {"cross",         mjMARK_CROSS},
@@ -816,8 +816,8 @@ const mjMap mark_map[mark_sz] = {
 
 
 // dyn type
-const int dyn_sz = 7;
-const mjMap dyn_map[dyn_sz] = {
+extern const int dyn_sz = 7;
+extern const mjMap dyn_map[dyn_sz] = {
   {"none",          mjDYN_NONE},
   {"integrator",    mjDYN_INTEGRATOR},
   {"filter",        mjDYN_FILTER},
@@ -829,8 +829,8 @@ const mjMap dyn_map[dyn_sz] = {
 
 
 // dcmotor controller input mode
-const int dcmotorinput_sz = 3;
-const mjMap dcmotorinput_map[dcmotorinput_sz] = {
+extern const int dcmotorinput_sz = 3;
+extern const mjMap dcmotorinput_map[dcmotorinput_sz] = {
   {"voltage",       0},
   {"position",      1},
   {"velocity",      2}
@@ -838,8 +838,8 @@ const mjMap dcmotorinput_map[dcmotorinput_sz] = {
 
 
 // gain type
-const int gain_sz = 5;
-const mjMap gain_map[gain_sz] = {
+extern const int gain_sz = 5;
+extern const mjMap gain_map[gain_sz] = {
   {"fixed",         mjGAIN_FIXED},
   {"affine",        mjGAIN_AFFINE},
   {"muscle",        mjGAIN_MUSCLE},
@@ -849,8 +849,8 @@ const mjMap gain_map[gain_sz] = {
 
 
 // bias type
-const int bias_sz = 5;
-const mjMap bias_map[bias_sz] = {
+extern const int bias_sz = 5;
+extern const mjMap bias_map[bias_sz] = {
   {"none",          mjBIAS_NONE},
   {"affine",        mjBIAS_AFFINE},
   {"muscle",        mjBIAS_MUSCLE},
@@ -860,8 +860,8 @@ const mjMap bias_map[bias_sz] = {
 
 
 // interpolation type
-const int interp_sz = 3;
-const mjMap interp_map[interp_sz] = {
+extern const int interp_sz = 3;
+extern const mjMap interp_map[interp_sz] = {
   {"zoh",           0},
   {"linear",        1},
   {"cubic",         2}
@@ -869,8 +869,8 @@ const mjMap interp_map[interp_sz] = {
 
 
 // stage type
-const int stage_sz = 4;
-const mjMap stage_map[stage_sz] = {
+extern const int stage_sz = 4;
+extern const mjMap stage_map[stage_sz] = {
   {"none",          mjSTAGE_NONE},
   {"pos",           mjSTAGE_POS},
   {"vel",           mjSTAGE_VEL},
@@ -879,8 +879,8 @@ const mjMap stage_map[stage_sz] = {
 
 
 // data type
-const int datatype_sz = 4;
-const mjMap datatype_map[datatype_sz] = {
+extern const int datatype_sz = 4;
+extern const mjMap datatype_map[datatype_sz] = {
   {"real",          mjDATATYPE_REAL},
   {"positive",      mjDATATYPE_POSITIVE},
   {"axis",          mjDATATYPE_AXIS},
@@ -889,7 +889,7 @@ const mjMap datatype_map[datatype_sz] = {
 
 
 // contact data type
-const mjMap condata_map[mjNCONDATA] = {
+extern const mjMap condata_map[mjNCONDATA] = {
   {"found",         mjCONDATA_FOUND},
   {"force",         mjCONDATA_FORCE},
   {"torque",        mjCONDATA_TORQUE},
@@ -901,7 +901,7 @@ const mjMap condata_map[mjNCONDATA] = {
 
 
 // rangefinder data type
-const mjMap raydata_map[mjNRAYDATA] = {
+extern const mjMap raydata_map[mjNRAYDATA] = {
   {"dist",          mjRAYDATA_DIST},
   {"dir",           mjRAYDATA_DIR},
   {"origin",        mjRAYDATA_ORIGIN},
@@ -911,16 +911,16 @@ const mjMap raydata_map[mjNRAYDATA] = {
 };
 
 // camera output type
-const int camout_sz = mjNCAMOUT;
-const mjMap camout_map[mjNCAMOUT] = {{"rgb", mjCAMOUT_RGB},
+extern const int camout_sz = mjNCAMOUT;
+extern const mjMap camout_map[mjNCAMOUT] = {{"rgb", mjCAMOUT_RGB},
                                      {"depth", mjCAMOUT_DEPTH},
                                      {"distance", mjCAMOUT_DIST},
                                      {"normal", mjCAMOUT_NORMAL},
                                      {"segmentation", mjCAMOUT_SEG}};
 
 // contact reduction type
-const int reduce_sz = 4;
-const mjMap reduce_map[reduce_sz] = {
+extern const int reduce_sz = 4;
+extern const mjMap reduce_map[reduce_sz] = {
   {"none",          0},
   {"mindist",       1},
   {"maxforce",      2},
@@ -934,8 +934,8 @@ const mjMap conflict_map[conflict_sz] = {{"warning", mjCONFLICT_WARNING},
                                          {"error", mjCONFLICT_ERROR}};
 
 // LR mode
-const int lrmode_sz = 4;
-const mjMap lrmode_map[lrmode_sz] = {
+extern const int lrmode_sz = 4;
+extern const mjMap lrmode_map[lrmode_sz] = {
   {"none",          mjLRMODE_NONE},
   {"muscle",        mjLRMODE_MUSCLE},
   {"muscleuser",    mjLRMODE_MUSCLEUSER},
@@ -944,7 +944,7 @@ const mjMap lrmode_map[lrmode_sz] = {
 
 
 // composite type
-const mjMap comp_map[mjNCOMPTYPES] = {
+extern const mjMap comp_map[mjNCOMPTYPES] = {
   {"particle",      mjCOMPTYPE_PARTICLE},
   {"grid",          mjCOMPTYPE_GRID},
   {"rope",          mjCOMPTYPE_ROPE},
@@ -955,13 +955,13 @@ const mjMap comp_map[mjNCOMPTYPES] = {
 
 
 // composite joint kind
-const mjMap jkind_map[1] = {
+extern const mjMap jkind_map[1] = {
   {"main",          mjCOMPKIND_JOINT}
 };
 
 
 // composite rope shape
-const mjMap shape_map[mjNCOMPSHAPES] = {
+extern const mjMap shape_map[mjNCOMPSHAPES] = {
   {"s",             mjCOMPSHAPE_LINE},
   {"cos(s)",        mjCOMPSHAPE_COS},
   {"sin(s)",        mjCOMPSHAPE_SIN},
@@ -970,14 +970,14 @@ const mjMap shape_map[mjNCOMPSHAPES] = {
 
 
 // mesh type
-const mjMap meshtype_map[2] = {
+extern const mjMap meshtype_map[2] = {
   {"false",         mjINERTIA_VOLUME},
   {"true",          mjINERTIA_SHELL},
 };
 
 
 // mesh inertia type
-const mjMap meshinertia_map[4] = {
+extern const mjMap meshinertia_map[4] = {
   {"convex",        mjMESH_INERTIA_CONVEX},
   {"legacy",        mjMESH_INERTIA_LEGACY},
   {"exact",         mjMESH_INERTIA_EXACT},
@@ -986,8 +986,8 @@ const mjMap meshinertia_map[4] = {
 
 
 // mesh builtin type
-const int meshbuiltin_sz = 8;
-const mjMap meshbuiltin_map[meshbuiltin_sz] = {
+extern const int meshbuiltin_sz = 8;
+extern const mjMap meshbuiltin_map[meshbuiltin_sz] = {
   {"none",          mjMESH_BUILTIN_NONE},
   {"sphere",        mjMESH_BUILTIN_SPHERE},
   {"hemisphere",    mjMESH_BUILTIN_HEMISPHERE},
@@ -1000,7 +1000,7 @@ const mjMap meshbuiltin_map[meshbuiltin_sz] = {
 
 
 // flexcomp type
-const mjMap fcomp_map[mjNFCOMPTYPES] = {
+extern const mjMap fcomp_map[mjNFCOMPTYPES] = {
   {"grid",          mjFCOMPTYPE_GRID},
   {"box",           mjFCOMPTYPE_BOX},
   {"cylinder",      mjFCOMPTYPE_CYLINDER},
@@ -1015,7 +1015,7 @@ const mjMap fcomp_map[mjNFCOMPTYPES] = {
 
 
 // flexcomp dof type
-const mjMap fdof_map[mjNFCOMPDOFS] = {
+extern const mjMap fdof_map[mjNFCOMPDOFS] = {
   {"full",          mjFCOMPDOF_FULL},
   {"radial",        mjFCOMPDOF_RADIAL},
   {"trilinear",     mjFCOMPDOF_TRILINEAR},
@@ -1025,7 +1025,7 @@ const mjMap fdof_map[mjNFCOMPDOFS] = {
 
 
 // flex selfcollide type
-const mjMap flexself_map[5] = {
+extern const mjMap flexself_map[5] = {
   {"none",          mjFLEXSELF_NONE},
   {"narrow",        mjFLEXSELF_NARROW},
   {"bvh",           mjFLEXSELF_BVH},
@@ -1035,7 +1035,7 @@ const mjMap flexself_map[5] = {
 
 
 // flex elastic 2d type
-const mjMap elastic2d_map[5] = {
+extern const mjMap elastic2d_map[5] = {
   {"none",          0},
   {"bend",          1},
   {"stretch",       2},
@@ -1044,7 +1044,7 @@ const mjMap elastic2d_map[5] = {
 
 
 // flex equality type
-const mjMap flexeq_map[4] = {
+extern const mjMap flexeq_map[4] = {
   {"false",         0},
   {"true",          1},
   {"vert",          2},

--- a/src/xml/xml_native_reader.cc
+++ b/src/xml/xml_native_reader.cc
@@ -1086,6 +1086,7 @@ const mjXAttr kMjXAttrTable[] = {
   {"compiler", "saveinertial",      kMjXEnum,   0, bool_map,        2},
   {"compiler", "assetdir",          kMjXString, 0, nullptr,         0},
   {"compiler", "alignfree",         kMjXEnum,   0, bool_map,        2},
+  {"compiler", "conflict",          kMjXEnum,   0, conflict_map,    conflict_sz},
   //-------------------------------- <compiler><lengthrange> ---------------------------------------
   {"lengthrange", "mode",        kMjXEnum, 0, lrmode_map, 4},
   {"lengthrange", "useexisting", kMjXEnum, 0, bool_map,   2},
@@ -1749,6 +1750,7 @@ const mjXAttr kMjXAttrTable[] = {
   {"frame", "euler",      kMjXRealN,  3, nullptr, 0},
 
   //-------------------------------- <body><replicate> --------------------------------------------
+  {"replicate", "prefix",     kMjXString, 0, nullptr, 0},
   {"replicate", "count",      kMjXInt,    0, nullptr, 0},
   {"replicate", "offset",     kMjXRealN,  3, nullptr, 0},
   {"replicate", "euler",      kMjXRealN,  3, nullptr, 0},
@@ -1768,7 +1770,7 @@ const mjXAttr kMjXAttrTable[] = {
   {"composite", "vertex",  kMjXRealVec, 0, nullptr,  0},
   {"composite", "initial", kMjXString,  0, nullptr,  0},
   {"composite", "curve",   kMjXString,  0, nullptr,  0},
-  {"composite", "size",    kMjXRealN,   3, nullptr,  0},
+  {"composite", "size",    kMjXRealUpToN, 3, nullptr, 0},
   {"composite", "quat",    kMjXRealN,   4, nullptr,  0},
 
   //-------------------------------- <flexcomp> ---------------------------------------------------

--- a/src/xml/xml_native_reader.h
+++ b/src/xml/xml_native_reader.h
@@ -105,4 +105,36 @@ class mjXReader : public mjXBase {
 #define nMJCF 248
 extern std::vector<const char*> MJCF[nMJCF];
 
+// Kind of data accepted in an attribute value. Mirrors the ReadAttr* / MapValue
+// calls performed by mjXReader::OneX() parsers. Used by the XSD generator in
+// xml_native_schema.cc.
+enum mjXAttrKind {
+  kMjXString = 0,   // arbitrary string
+  kMjXInt,          // single int
+  kMjXIntN,         // exactly N ints        (fixed-length list)
+  kMjXIntVec,       // variable-length int list
+  kMjXReal,         // single real
+  kMjXRealN,        // exactly N reals       (fixed-length list)
+  kMjXRealUpToN,    // up to N reals         (variable, capped)
+  kMjXRealVec,      // variable-length real list
+  kMjXEnum,         // keyword from an mjMap
+};
+
+// One (element, attribute) binding. Consumed by the XSD generator.
+// `map`/`map_size` are only used for kMjXEnum.
+struct mjXAttr {
+  const char* element;
+  const char* attr;
+  mjXAttrKind kind;
+  int size;                  // for kMjXIntN / kMjXRealN / kMjXRealUpToN
+  const mjMap* map;          // for kMjXEnum
+  int map_size;              // for kMjXEnum
+};
+
+// Typed attribute table mirroring the ReadAttr*/MapValue calls in OneX().
+// Defined in xml_native_reader.cc alongside MJCF[] and the enum maps so the
+// maps can keep internal linkage.
+extern const mjXAttr kMjXAttrTable[];
+extern const int kMjXAttrTableSize;
+
 #endif  // MUJOCO_SRC_XML_XML_NATIVE_READER_H_

--- a/src/xml/xml_native_schema.cc
+++ b/src/xml/xml_native_schema.cc
@@ -1,0 +1,1610 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// XSD generator for MJCF.
+//
+// The MJCF language is described in three places inside this directory:
+//   1. MJCF[]   (xml_native_reader.cc) -- element tree + attribute names.
+//   2. *_map    (xml_native_reader.cc) -- enum value sets.
+//   3. OneX()   (xml_native_reader.cc) -- the ReadAttr*/MapValue calls that
+//                                        assign types and enum maps to attrs.
+//
+// (1) and (2) are already declarative and reused directly. (3) is not, so
+// this file adds a single flat table `kMjXAttrTable` mirroring the type
+// decisions made in the OneX() parsers.
+//
+// ---------------------------------------------------------------------------
+// MAINTENANCE: if you add/rename an attribute in the parser, you also need
+// to touch this file. Concretely, when you edit `OneX()` in
+// xml_native_reader.cc (or add an entry to MJCF[]):
+//
+//   * add a row to `kMjXAttrTable` below (one per (element, attr) pair)
+//     matching the ReadAttr*/MapValue call you wrote -- this is the only
+//     per-attribute maintenance burden.
+//   * if you added a new enum map, declare it `extern` at the top of the
+//     reader (most already are), and forward-declare it at the top of this
+//     file alongside the existing ones.
+//   * document the attribute under `.. _<element>-<attr>:` in
+//     doc/XMLreference.rst (default value + prose) -- the enrichment pass in
+//     doc/mjcf_schema_enrich.py picks this up and injects it as
+//     <xs:annotation> on the generated xs:attribute.
+//
+// Release pipeline (regenerating doc/mjcf.xsd):
+//   $ cmake --build build --target xmlschema
+//   $ ./build/bin/xmlschema /tmp/raw.xsd
+//   $ python3 doc/mjcf_schema_enrich.py --in /tmp/raw.xsd \
+//         --rst doc/XMLreference.rst --out doc/mjcf.xsd --strict --report
+//
+// `--strict` exits non-zero if the enricher finds drift between the C table,
+// the RST, and the schema -- wire this into CI to catch stale docs.
+
+#include "xml/xml_native_schema.h"
+
+#include <sstream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "xml/xml_native_reader.h"  // exports MJCF[] and nMJCF
+#include "xml/xml_util.h"           // exports mjMap
+
+// Enum-map symbols and their sizes live at global scope in xml_native_reader.cc
+// (inside a nameless namespace that closes before they are defined). Redeclare
+// them here so the linker resolves them.
+extern const mjMap coordinate_map[2];
+extern const mjMap angle_map[2];
+extern const mjMap bool_map[2];
+extern const mjMap fluid_map[2];
+extern const mjMap TFAuto_map[3];
+extern const mjMap enable_map[2];
+extern const mjMap bodysleep_map[];
+extern const int   bodysleep_sz;
+extern const mjMap joint_map[];
+extern const int   joint_sz;
+extern const mjMap geom_map[];
+extern const mjMap projection_map[];
+extern const int   projection_sz;
+extern const mjMap camlight_map[];
+extern const int   camlight_sz;
+extern const mjMap lighttype_map[];
+extern const int   lighttype_sz;
+extern const mjMap texrole_map[];
+extern const int   texrole_sz;
+extern const mjMap integrator_map[];
+extern const int   integrator_sz;
+extern const mjMap cone_map[];
+extern const int   cone_sz;
+extern const mjMap jac_map[];
+extern const int   jac_sz;
+extern const mjMap solver_map[];
+extern const int   solver_sz;
+extern const mjMap equality_map[];
+extern const int   equality_sz;
+extern const mjMap texture_map[];
+extern const int   texture_sz;
+extern const mjMap colorspace_map[];
+extern const int   colorspace_sz;
+extern const mjMap builtin_map[];
+extern const int   builtin_sz;
+extern const mjMap mark_map[];
+extern const int   mark_sz;
+extern const mjMap dyn_map[];
+extern const int   dyn_sz;
+extern const mjMap dcmotorinput_map[];
+extern const int   dcmotorinput_sz;
+extern const mjMap gain_map[];
+extern const int   gain_sz;
+extern const mjMap bias_map[];
+extern const int   bias_sz;
+extern const mjMap interp_map[];
+extern const int   interp_sz;
+extern const mjMap stage_map[];
+extern const int   stage_sz;
+extern const mjMap datatype_map[];
+extern const int   datatype_sz;
+extern const mjMap condata_map[];
+extern const mjMap raydata_map[];
+extern const mjMap camout_map[];
+extern const int   camout_sz;
+extern const mjMap reduce_map[];
+extern const int   reduce_sz;
+extern const mjMap lrmode_map[];
+extern const int   lrmode_sz;
+extern const mjMap comp_map[];
+extern const mjMap jkind_map[1];
+extern const mjMap shape_map[];
+extern const mjMap meshtype_map[2];
+extern const mjMap meshinertia_map[4];
+extern const mjMap meshbuiltin_map[];
+extern const int   meshbuiltin_sz;
+extern const mjMap fcomp_map[];
+extern const mjMap fdof_map[];
+extern const mjMap flexself_map[5];
+extern const mjMap elastic2d_map[5];
+extern const mjMap flexeq_map[4];
+
+// Literal sizes for the few remaining maps that are sized via mjN* enum
+// constants; kept local rather than pulling in extra headers.
+namespace {
+constexpr int kGeomTypesSz  = 9;   // mjNGEOMTYPES
+constexpr int kCompTypesSz  = 6;   // mjNCOMPTYPES
+constexpr int kFcompTypesSz = 10;  // mjNFCOMPTYPES
+constexpr int kFcompDofsSz  = 4;   // mjNFCOMPDOFS
+constexpr int kNDYN         = 10;  // mjNDYN
+constexpr int kNGAIN        = 10;  // mjNGAIN
+constexpr int kNBIAS        = 10;  // mjNBIAS
+}  // namespace
+
+namespace mujoco {
+
+
+//---------------------------------- Attribute type table ------------------------------------------
+
+// clang-format off
+const mjXAttr kMjXAttrTable[] = {
+
+  //-------------------------------- <mujoco> ------------------------------------------------------
+  {"mujoco", "model", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <compiler> ----------------------------------------------------
+  {"compiler", "autolimits",        kMjXEnum,   0, bool_map,        2},
+  {"compiler", "boundmass",         kMjXReal,   0, nullptr,         0},
+  {"compiler", "boundinertia",      kMjXReal,   0, nullptr,         0},
+  {"compiler", "settotalmass",      kMjXReal,   0, nullptr,         0},
+  {"compiler", "balanceinertia",    kMjXEnum,   0, bool_map,        2},
+  {"compiler", "strippath",         kMjXEnum,   0, bool_map,        2},
+  {"compiler", "coordinate",        kMjXEnum,   0, coordinate_map,  2},
+  {"compiler", "angle",             kMjXEnum,   0, angle_map,       2},
+  {"compiler", "fitaabb",           kMjXEnum,   0, bool_map,        2},
+  {"compiler", "eulerseq",          kMjXString, 0, nullptr,         0},
+  {"compiler", "meshdir",           kMjXString, 0, nullptr,         0},
+  {"compiler", "texturedir",        kMjXString, 0, nullptr,         0},
+  {"compiler", "discardvisual",     kMjXEnum,   0, bool_map,        2},
+  {"compiler", "usethread",         kMjXEnum,   0, bool_map,        2},
+  {"compiler", "fusestatic",        kMjXEnum,   0, bool_map,        2},
+  {"compiler", "inertiafromgeom",   kMjXEnum,   0, TFAuto_map,      3},
+  {"compiler", "inertiagrouprange", kMjXIntN,   2, nullptr,         0},
+  {"compiler", "saveinertial",      kMjXEnum,   0, bool_map,        2},
+  {"compiler", "assetdir",          kMjXString, 0, nullptr,         0},
+  {"compiler", "alignfree",         kMjXEnum,   0, bool_map,        2},
+
+  //-------------------------------- <compiler><lengthrange> ---------------------------------------
+  {"lengthrange", "mode",        kMjXEnum, 0, lrmode_map, 4},
+  {"lengthrange", "useexisting", kMjXEnum, 0, bool_map,   2},
+  {"lengthrange", "uselimit",    kMjXEnum, 0, bool_map,   2},
+  {"lengthrange", "accel",       kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "maxforce",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "timeconst",   kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "timestep",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "inttotal",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "interval",    kMjXReal, 0, nullptr,    0},
+  {"lengthrange", "tolrange",    kMjXReal, 0, nullptr,    0},
+
+  //-------------------------------- <option> ------------------------------------------------------
+  {"option", "timestep",             kMjXReal,      0, nullptr,        0},
+  {"option", "impratio",             kMjXReal,      0, nullptr,        0},
+  {"option", "tolerance",            kMjXReal,      0, nullptr,        0},
+  {"option", "ls_tolerance",         kMjXReal,      0, nullptr,        0},
+  {"option", "noslip_tolerance",     kMjXReal,      0, nullptr,        0},
+  {"option", "ccd_tolerance",        kMjXReal,      0, nullptr,        0},
+  {"option", "sleep_tolerance",      kMjXReal,      0, nullptr,        0},
+  {"option", "gravity",              kMjXRealN,     3, nullptr,        0},
+  {"option", "wind",                 kMjXRealN,     3, nullptr,        0},
+  {"option", "magnetic",             kMjXRealN,     3, nullptr,        0},
+  {"option", "density",              kMjXReal,      0, nullptr,        0},
+  {"option", "viscosity",            kMjXReal,      0, nullptr,        0},
+  {"option", "o_margin",             kMjXReal,      0, nullptr,        0},
+  {"option", "o_solref",             kMjXRealUpToN, 2, nullptr,        0},
+  {"option", "o_solimp",             kMjXRealUpToN, 5, nullptr,        0},
+  {"option", "o_friction",           kMjXRealUpToN, 5, nullptr,        0},
+  {"option", "integrator",           kMjXEnum,      0, integrator_map, 4},
+  {"option", "cone",                 kMjXEnum,      0, cone_map,       2},
+  {"option", "jacobian",             kMjXEnum,      0, jac_map,        3},
+  {"option", "solver",               kMjXEnum,      0, solver_map,     3},
+  {"option", "iterations",           kMjXInt,       0, nullptr,        0},
+  {"option", "ls_iterations",        kMjXInt,       0, nullptr,        0},
+  {"option", "noslip_iterations",    kMjXInt,       0, nullptr,        0},
+  {"option", "ccd_iterations",       kMjXInt,       0, nullptr,        0},
+  {"option", "sdf_iterations",       kMjXInt,       0, nullptr,        0},
+  {"option", "sdf_initpoints",       kMjXInt,       0, nullptr,        0},
+  {"option", "actuatorgroupdisable", kMjXIntVec,    0, nullptr,        0},
+
+  //-------------------------------- <option><flag> ------------------------------------------------
+  {"flag", "constraint",   kMjXEnum, 0, enable_map, 2},
+  {"flag", "equality",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "frictionloss", kMjXEnum, 0, enable_map, 2},
+  {"flag", "limit",        kMjXEnum, 0, enable_map, 2},
+  {"flag", "contact",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "spring",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "damper",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "gravity",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "clampctrl",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "warmstart",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "filterparent", kMjXEnum, 0, enable_map, 2},
+  {"flag", "actuation",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "refsafe",      kMjXEnum, 0, enable_map, 2},
+  {"flag", "sensor",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "midphase",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "eulerdamp",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "autoreset",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "nativeccd",    kMjXEnum, 0, enable_map, 2},
+  {"flag", "island",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "override",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "energy",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "fwdinv",       kMjXEnum, 0, enable_map, 2},
+  {"flag", "invdiscrete",  kMjXEnum, 0, enable_map, 2},
+  {"flag", "multiccd",     kMjXEnum, 0, enable_map, 2},
+  {"flag", "sleep",        kMjXEnum, 0, enable_map, 2},
+
+  //-------------------------------- <size> --------------------------------------------------------
+  {"size", "memory",         kMjXString, 0, nullptr, 0},
+  {"size", "njmax",          kMjXInt,    0, nullptr, 0},
+  {"size", "nconmax",        kMjXInt,    0, nullptr, 0},
+  {"size", "nstack",         kMjXInt,    0, nullptr, 0},
+  {"size", "nuserdata",      kMjXInt,    0, nullptr, 0},
+  {"size", "nkey",           kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_body",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_jnt",      kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_geom",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_site",     kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_cam",      kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_tendon",   kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_actuator", kMjXInt,    0, nullptr, 0},
+  {"size", "nuser_sensor",   kMjXInt,    0, nullptr, 0},
+
+  //-------------------------------- <statistic> ---------------------------------------------------
+  {"statistic", "meaninertia", kMjXReal,  0, nullptr, 0},
+  {"statistic", "meanmass",    kMjXReal,  0, nullptr, 0},
+  {"statistic", "meansize",    kMjXReal,  0, nullptr, 0},
+  {"statistic", "extent",      kMjXReal,  0, nullptr, 0},
+  {"statistic", "center",      kMjXRealN, 3, nullptr, 0},
+
+  //-------------------------------- <visual> subelements ------------------------------------------
+  {"global", "cameraid",         kMjXInt,  0, nullptr,  0},
+  {"global", "orthographic",     kMjXEnum, 0, bool_map, 2},
+  {"global", "fovy",             kMjXReal, 0, nullptr,  0},
+  {"global", "ipd",              kMjXReal, 0, nullptr,  0},
+  {"global", "azimuth",          kMjXReal, 0, nullptr,  0},
+  {"global", "elevation",        kMjXReal, 0, nullptr,  0},
+  {"global", "linewidth",        kMjXReal, 0, nullptr,  0},
+  {"global", "glow",             kMjXReal, 0, nullptr,  0},
+  {"global", "offwidth",         kMjXInt,  0, nullptr,  0},
+  {"global", "offheight",        kMjXInt,  0, nullptr,  0},
+  {"global", "realtime",         kMjXReal, 0, nullptr,  0},
+  {"global", "ellipsoidinertia", kMjXEnum, 0, bool_map, 2},
+  {"global", "bvactive",         kMjXEnum, 0, bool_map, 2},
+
+  {"quality", "shadowsize", kMjXInt, 0, nullptr, 0},
+  {"quality", "offsamples", kMjXInt, 0, nullptr, 0},
+  {"quality", "numslices",  kMjXInt, 0, nullptr, 0},
+  {"quality", "numstacks",  kMjXInt, 0, nullptr, 0},
+  {"quality", "numquads",   kMjXInt, 0, nullptr, 0},
+
+  {"headlight", "ambient",  kMjXRealN, 3, nullptr, 0},
+  {"headlight", "diffuse",  kMjXRealN, 3, nullptr, 0},
+  {"headlight", "specular", kMjXRealN, 3, nullptr, 0},
+  {"headlight", "active",   kMjXInt,   0, nullptr, 0},
+
+  {"map", "stiffness",      kMjXReal, 0, nullptr, 0},
+  {"map", "stiffnessrot",   kMjXReal, 0, nullptr, 0},
+  {"map", "force",          kMjXReal, 0, nullptr, 0},
+  {"map", "torque",         kMjXReal, 0, nullptr, 0},
+  {"map", "alpha",          kMjXReal, 0, nullptr, 0},
+  {"map", "fogstart",       kMjXReal, 0, nullptr, 0},
+  {"map", "fogend",         kMjXReal, 0, nullptr, 0},
+  {"map", "znear",          kMjXReal, 0, nullptr, 0},
+  {"map", "zfar",           kMjXReal, 0, nullptr, 0},
+  {"map", "haze",           kMjXReal, 0, nullptr, 0},
+  {"map", "shadowclip",     kMjXReal, 0, nullptr, 0},
+  {"map", "shadowscale",    kMjXReal, 0, nullptr, 0},
+  {"map", "actuatortendon", kMjXReal, 0, nullptr, 0},
+
+  {"scale", "forcewidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "contactwidth",   kMjXReal, 0, nullptr, 0},
+  {"scale", "contactheight",  kMjXReal, 0, nullptr, 0},
+  {"scale", "connect",        kMjXReal, 0, nullptr, 0},
+  {"scale", "com",            kMjXReal, 0, nullptr, 0},
+  {"scale", "camera",         kMjXReal, 0, nullptr, 0},
+  {"scale", "light",          kMjXReal, 0, nullptr, 0},
+  {"scale", "selectpoint",    kMjXReal, 0, nullptr, 0},
+  {"scale", "jointlength",    kMjXReal, 0, nullptr, 0},
+  {"scale", "jointwidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "actuatorlength", kMjXReal, 0, nullptr, 0},
+  {"scale", "actuatorwidth",  kMjXReal, 0, nullptr, 0},
+  {"scale", "framelength",    kMjXReal, 0, nullptr, 0},
+  {"scale", "framewidth",     kMjXReal, 0, nullptr, 0},
+  {"scale", "constraint",     kMjXReal, 0, nullptr, 0},
+  {"scale", "slidercrank",    kMjXReal, 0, nullptr, 0},
+  {"scale", "frustum",        kMjXReal, 0, nullptr, 0},
+
+  {"rgba", "fog",              kMjXRealN, 4, nullptr, 0},
+  {"rgba", "haze",             kMjXRealN, 4, nullptr, 0},
+  {"rgba", "force",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "inertia",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "joint",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuator",         kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuatornegative", kMjXRealN, 4, nullptr, 0},
+  {"rgba", "actuatorpositive", kMjXRealN, 4, nullptr, 0},
+  {"rgba", "com",              kMjXRealN, 4, nullptr, 0},
+  {"rgba", "camera",           kMjXRealN, 4, nullptr, 0},
+  {"rgba", "light",            kMjXRealN, 4, nullptr, 0},
+  {"rgba", "selectpoint",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "connect",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactpoint",     kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactforce",     kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactfriction",  kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contacttorque",    kMjXRealN, 4, nullptr, 0},
+  {"rgba", "contactgap",       kMjXRealN, 4, nullptr, 0},
+  {"rgba", "rangefinder",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "constraint",       kMjXRealN, 4, nullptr, 0},
+  {"rgba", "slidercrank",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "crankbroken",      kMjXRealN, 4, nullptr, 0},
+  {"rgba", "frustum",          kMjXRealN, 4, nullptr, 0},
+  {"rgba", "bv",               kMjXRealN, 4, nullptr, 0},
+  {"rgba", "bvactive",         kMjXRealN, 4, nullptr, 0},
+
+  //-------------------------------- <default> -----------------------------------------------------
+  {"default", "class", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <mesh> (asset + default) -------------------------------------
+  {"mesh", "name",         kMjXString,    0, nullptr,          0},
+  {"mesh", "class",        kMjXString,    0, nullptr,          0},
+  {"mesh", "content_type", kMjXString,    0, nullptr,          0},
+  {"mesh", "file",         kMjXString,    0, nullptr,          0},
+  {"mesh", "vertex",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "normal",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "texcoord",     kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "face",         kMjXIntVec,    0, nullptr,          0},
+  {"mesh", "refpos",       kMjXRealN,     3, nullptr,          0},
+  {"mesh", "refquat",      kMjXRealN,     4, nullptr,          0},
+  {"mesh", "scale",        kMjXRealN,     3, nullptr,          0},
+  {"mesh", "smoothnormal", kMjXEnum,      0, bool_map,         2},
+  {"mesh", "maxhullvert",  kMjXInt,       0, nullptr,          0},
+  {"mesh", "inertia",      kMjXEnum,      0, meshinertia_map,  4},
+  {"mesh", "builtin",      kMjXEnum,      0, meshbuiltin_map,  8},
+  {"mesh", "params",       kMjXRealVec,   0, nullptr,          0},
+  {"mesh", "material",     kMjXString,    0, nullptr,          0},
+
+  //-------------------------------- <material> (asset + default) ----------------------------------
+  {"material", "name",        kMjXString, 0, nullptr,  0},
+  {"material", "class",       kMjXString, 0, nullptr,  0},
+  {"material", "texture",     kMjXString, 0, nullptr,  0},
+  {"material", "texrepeat",   kMjXRealN,  2, nullptr,  0},
+  {"material", "texuniform",  kMjXEnum,   0, bool_map, 2},
+  {"material", "emission",    kMjXReal,   0, nullptr,  0},
+  {"material", "specular",    kMjXReal,   0, nullptr,  0},
+  {"material", "shininess",   kMjXReal,   0, nullptr,  0},
+  {"material", "reflectance", kMjXReal,   0, nullptr,  0},
+  {"material", "metallic",    kMjXReal,   0, nullptr,  0},
+  {"material", "roughness",   kMjXReal,   0, nullptr,  0},
+  {"material", "rgba",        kMjXRealN,  4, nullptr,  0},
+
+  //-------------------------------- <material><layer> ---------------------------------------------
+  {"layer", "texture", kMjXString, 0, nullptr,     0},
+  {"layer", "role",    kMjXEnum,   0, texrole_map, 9},
+
+  //-------------------------------- <joint> (body + default) --------------------------------------
+  {"joint", "name",              kMjXString,    0, nullptr,    0},
+  {"joint", "class",             kMjXString,    0, nullptr,    0},
+  {"joint", "type",              kMjXEnum,      0, joint_map,  4},
+  {"joint", "group",             kMjXInt,       0, nullptr,    0},
+  {"joint", "pos",               kMjXRealN,     3, nullptr,    0},
+  {"joint", "axis",              kMjXRealN,     3, nullptr,    0},
+  {"joint", "springdamper",      kMjXRealN,     2, nullptr,    0},
+  {"joint", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"joint", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"joint", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"joint", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"joint", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"joint", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"joint", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"joint", "range",             kMjXRealN,     2, nullptr,    0},
+  {"joint", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"joint", "actuatorgravcomp",  kMjXEnum,      0, bool_map,   2},
+  {"joint", "margin",            kMjXReal,      0, nullptr,    0},
+  {"joint", "ref",               kMjXReal,      0, nullptr,    0},
+  {"joint", "springref",         kMjXReal,      0, nullptr,    0},
+  {"joint", "armature",          kMjXReal,      0, nullptr,    0},
+  {"joint", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"joint", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"joint", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <freejoint> (body) --------------------------------------------
+  {"freejoint", "name",  kMjXString, 0, nullptr,    0},
+  {"freejoint", "group", kMjXInt,    0, nullptr,    0},
+  {"freejoint", "align", kMjXEnum,   0, TFAuto_map, 3},
+
+  //-------------------------------- <geom> (body + default) ---------------------------------------
+  {"geom", "name",         kMjXString,    0, nullptr,   0},
+  {"geom", "class",        kMjXString,    0, nullptr,   0},
+  {"geom", "type",         kMjXEnum,      0, geom_map,  kGeomTypesSz},
+  {"geom", "pos",          kMjXRealN,     3, nullptr,   0},
+  {"geom", "quat",         kMjXRealN,     4, nullptr,   0},
+  {"geom", "axisangle",    kMjXRealN,     4, nullptr,   0},
+  {"geom", "xyaxes",       kMjXRealN,     6, nullptr,   0},
+  {"geom", "zaxis",        kMjXRealN,     3, nullptr,   0},
+  {"geom", "euler",        kMjXRealN,     3, nullptr,   0},
+  {"geom", "contype",      kMjXInt,       0, nullptr,   0},
+  {"geom", "conaffinity",  kMjXInt,       0, nullptr,   0},
+  {"geom", "condim",       kMjXInt,       0, nullptr,   0},
+  {"geom", "group",        kMjXInt,       0, nullptr,   0},
+  {"geom", "priority",     kMjXInt,       0, nullptr,   0},
+  {"geom", "size",         kMjXRealUpToN, 3, nullptr,   0},
+  {"geom", "material",     kMjXString,    0, nullptr,   0},
+  {"geom", "friction",     kMjXRealUpToN, 3, nullptr,   0},
+  {"geom", "mass",         kMjXReal,      0, nullptr,   0},
+  {"geom", "density",      kMjXReal,      0, nullptr,   0},
+  {"geom", "shellinertia", kMjXEnum,      0, meshtype_map, 2},
+  {"geom", "solmix",       kMjXReal,      0, nullptr,   0},
+  {"geom", "solref",       kMjXRealUpToN, 2, nullptr,   0},
+  {"geom", "solimp",       kMjXRealUpToN, 5, nullptr,   0},
+  {"geom", "margin",       kMjXReal,      0, nullptr,   0},
+  {"geom", "gap",          kMjXReal,      0, nullptr,   0},
+  {"geom", "fromto",       kMjXRealN,     6, nullptr,   0},
+  {"geom", "hfield",       kMjXString,    0, nullptr,   0},
+  {"geom", "mesh",         kMjXString,    0, nullptr,   0},
+  {"geom", "fitscale",     kMjXReal,      0, nullptr,   0},
+  {"geom", "rgba",         kMjXRealN,     4, nullptr,   0},
+  {"geom", "fluidshape",   kMjXEnum,      0, fluid_map, 2},
+  {"geom", "fluidcoef",    kMjXRealUpToN, 5, nullptr,   0},
+  {"geom", "user",         kMjXRealVec,   0, nullptr,   0},
+
+  //-------------------------------- <site> (body + default) ---------------------------------------
+  {"site", "name",      kMjXString,    0, nullptr,  0},
+  {"site", "class",     kMjXString,    0, nullptr,  0},
+  {"site", "type",      kMjXEnum,      0, geom_map, kGeomTypesSz},
+  {"site", "group",     kMjXInt,       0, nullptr,  0},
+  {"site", "pos",       kMjXRealN,     3, nullptr,  0},
+  {"site", "quat",      kMjXRealN,     4, nullptr,  0},
+  {"site", "material",  kMjXString,    0, nullptr,  0},
+  {"site", "size",      kMjXRealUpToN, 3, nullptr,  0},
+  {"site", "fromto",    kMjXRealN,     6, nullptr,  0},
+  {"site", "axisangle", kMjXRealN,     4, nullptr,  0},
+  {"site", "xyaxes",    kMjXRealN,     6, nullptr,  0},
+  {"site", "zaxis",     kMjXRealN,     3, nullptr,  0},
+  {"site", "euler",     kMjXRealN,     3, nullptr,  0},
+  {"site", "rgba",      kMjXRealN,     4, nullptr,  0},
+  {"site", "user",      kMjXRealVec,   0, nullptr,  0},
+
+  //-------------------------------- <camera> (body + default) -------------------------------------
+  {"camera", "name",           kMjXString,  0, nullptr,        0},
+  {"camera", "class",          kMjXString,  0, nullptr,        0},
+  {"camera", "projection",     kMjXEnum,    0, projection_map, 2},
+  {"camera", "fovy",           kMjXReal,    0, nullptr,        0},
+  {"camera", "ipd",            kMjXReal,    0, nullptr,        0},
+  {"camera", "resolution",     kMjXIntN,    2, nullptr,        0},
+  {"camera", "output",         kMjXString,  0, nullptr,        0},  // space-separated bitflags
+  {"camera", "pos",            kMjXRealN,   3, nullptr,        0},
+  {"camera", "quat",           kMjXRealN,   4, nullptr,        0},
+  {"camera", "axisangle",      kMjXRealN,   4, nullptr,        0},
+  {"camera", "xyaxes",         kMjXRealN,   6, nullptr,        0},
+  {"camera", "zaxis",          kMjXRealN,   3, nullptr,        0},
+  {"camera", "euler",          kMjXRealN,   3, nullptr,        0},
+  {"camera", "mode",           kMjXEnum,    0, camlight_map,   5},
+  {"camera", "target",         kMjXString,  0, nullptr,        0},
+  {"camera", "focal",          kMjXRealN,   2, nullptr,        0},
+  {"camera", "focalpixel",     kMjXRealN,   2, nullptr,        0},
+  {"camera", "principal",      kMjXRealN,   2, nullptr,        0},
+  {"camera", "principalpixel", kMjXRealN,   2, nullptr,        0},
+  {"camera", "sensorsize",     kMjXRealN,   2, nullptr,        0},
+  {"camera", "user",           kMjXRealVec, 0, nullptr,        0},
+
+  //-------------------------------- <light> (body + default) --------------------------------------
+  {"light", "name",        kMjXString, 0, nullptr,       0},
+  {"light", "class",       kMjXString, 0, nullptr,       0},
+  {"light", "pos",         kMjXRealN,  3, nullptr,       0},
+  {"light", "dir",         kMjXRealN,  3, nullptr,       0},
+  {"light", "bulbradius",  kMjXReal,   0, nullptr,       0},
+  {"light", "intensity",   kMjXReal,   0, nullptr,       0},
+  {"light", "range",       kMjXReal,   0, nullptr,       0},
+  {"light", "directional", kMjXEnum,   0, bool_map,      2},
+  {"light", "type",        kMjXEnum,   0, lighttype_map, 4},
+  {"light", "castshadow",  kMjXEnum,   0, bool_map,      2},
+  {"light", "active",      kMjXEnum,   0, bool_map,      2},
+  {"light", "attenuation", kMjXRealN,  3, nullptr,       0},
+  {"light", "cutoff",      kMjXReal,   0, nullptr,       0},
+  {"light", "exponent",    kMjXReal,   0, nullptr,       0},
+  {"light", "ambient",     kMjXRealN,  3, nullptr,       0},
+  {"light", "diffuse",     kMjXRealN,  3, nullptr,       0},
+  {"light", "specular",    kMjXRealN,  3, nullptr,       0},
+  {"light", "mode",        kMjXEnum,   0, camlight_map,  5},
+  {"light", "target",      kMjXString, 0, nullptr,       0},
+  {"light", "texture",     kMjXString, 0, nullptr,       0},
+
+  //-------------------------------- <pair> (default + contact) -----------------------------------
+  {"pair", "name",           kMjXString,    0, nullptr, 0},
+  {"pair", "class",          kMjXString,    0, nullptr, 0},
+  {"pair", "geom1",          kMjXString,    0, nullptr, 0},
+  {"pair", "geom2",          kMjXString,    0, nullptr, 0},
+  {"pair", "condim",         kMjXInt,       0, nullptr, 0},
+  {"pair", "friction",       kMjXRealUpToN, 5, nullptr, 0},
+  {"pair", "solref",         kMjXRealUpToN, 2, nullptr, 0},
+  {"pair", "solreffriction", kMjXRealUpToN, 2, nullptr, 0},
+  {"pair", "solimp",         kMjXRealUpToN, 5, nullptr, 0},
+  {"pair", "margin",         kMjXReal,      0, nullptr, 0},
+  {"pair", "gap",            kMjXReal,      0, nullptr, 0},
+
+  //-------------------------------- <equality> in <default> --------------------------------------
+  {"equality", "active", kMjXEnum,      0, bool_map, 2},
+  {"equality", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"equality", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  //-------------------------------- <tendon> (default + top-level tendon is a complex section) ---
+  // The <tendon> row in MJCF[] under <default> holds only tendon defaults.
+  // These attrs are shared by <spatial> and <fixed> when emitted from <tendon>.
+  {"tendon", "group",              kMjXInt,       0, nullptr,    0},
+  {"tendon", "limited",            kMjXEnum,      0, TFAuto_map, 3},
+  {"tendon", "range",              kMjXRealN,     2, nullptr,    0},
+  {"tendon", "solreflimit",        kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "solimplimit",        kMjXRealUpToN, 5, nullptr,    0},
+  {"tendon", "solreffriction",     kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "solimpfriction",     kMjXRealUpToN, 5, nullptr,    0},
+  {"tendon", "frictionloss",       kMjXReal,      0, nullptr,    0},
+  {"tendon", "springlength",       kMjXRealUpToN, 2, nullptr,    0},
+  {"tendon", "width",              kMjXReal,      0, nullptr,    0},
+  {"tendon", "material",           kMjXString,    0, nullptr,    0},
+  {"tendon", "margin",             kMjXReal,      0, nullptr,    0},
+  {"tendon", "stiffness",          kMjXRealUpToN, 3, nullptr,    0},
+  {"tendon", "damping",            kMjXRealUpToN, 3, nullptr,    0},
+  {"tendon", "rgba",               kMjXRealN,     4, nullptr,    0},
+  {"tendon", "user",               kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <spatial> (tendon section) -----------------------------------
+  {"spatial", "name",              kMjXString,    0, nullptr,    0},
+  {"spatial", "class",             kMjXString,    0, nullptr,    0},
+  {"spatial", "group",             kMjXInt,       0, nullptr,    0},
+  {"spatial", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"spatial", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"spatial", "range",             kMjXRealN,     2, nullptr,    0},
+  {"spatial", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"spatial", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"spatial", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"spatial", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"spatial", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
+  {"spatial", "width",             kMjXReal,      0, nullptr,    0},
+  {"spatial", "material",          kMjXString,    0, nullptr,    0},
+  {"spatial", "margin",            kMjXReal,      0, nullptr,    0},
+  {"spatial", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"spatial", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"spatial", "armature",          kMjXReal,      0, nullptr,    0},
+  {"spatial", "rgba",              kMjXRealN,     4, nullptr,    0},
+  {"spatial", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <fixed> (tendon section) -------------------------------------
+  {"fixed", "name",              kMjXString,    0, nullptr,    0},
+  {"fixed", "class",             kMjXString,    0, nullptr,    0},
+  {"fixed", "group",             kMjXInt,       0, nullptr,    0},
+  {"fixed", "limited",           kMjXEnum,      0, TFAuto_map, 3},
+  {"fixed", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
+  {"fixed", "range",             kMjXRealN,     2, nullptr,    0},
+  {"fixed", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
+  {"fixed", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
+  {"fixed", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
+  {"fixed", "frictionloss",      kMjXReal,      0, nullptr,    0},
+  {"fixed", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
+  {"fixed", "margin",            kMjXReal,      0, nullptr,    0},
+  {"fixed", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
+  {"fixed", "damping",           kMjXRealUpToN, 3, nullptr,    0},
+  {"fixed", "armature",          kMjXReal,      0, nullptr,    0},
+  {"fixed", "user",              kMjXRealVec,   0, nullptr,    0},
+
+  //-------------------------------- <spatial> children: site/geom/pulley -------------------------
+  // Inside <spatial>, children are <site site=...>/<geom geom=... sidesite=...>/<pulley divisor=...>
+  // However the child element name "site" collides with top-level <site>, and our lookup is by
+  // (element, attr). We accept the collision: "site" attribute "site" is unique to the wrap,
+  // but "geom" attribute "geom" is also unique.
+  {"pulley", "divisor", kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- <fixed><joint> (tendon wrap) ---------------------------------
+  // The <joint> child of <fixed> has attrs {joint, coef}. Our top-level <joint> already uses
+  // "name"/"class"/... so the string refs "joint" and real "coef" are distinct here; map them.
+  {"joint", "coef",    kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- actuator (shared attrs) --------------------------------------
+  // Attributes common to all actuator shortcut types; listed per element so per-(element,attr)
+  // lookups work.
+#define ACT_COMMON(elem) \
+  {elem, "name",          kMjXString,    0, nullptr,    0}, \
+  {elem, "class",         kMjXString,    0, nullptr,    0}, \
+  {elem, "group",         kMjXInt,       0, nullptr,    0}, \
+  {elem, "nsample",       kMjXInt,       0, nullptr,    0}, \
+  {elem, "interp",        kMjXEnum,      0, interp_map, 3}, \
+  {elem, "delay",         kMjXReal,      0, nullptr,    0}, \
+  {elem, "ctrllimited",   kMjXEnum,      0, TFAuto_map, 3}, \
+  {elem, "forcelimited",  kMjXEnum,      0, TFAuto_map, 3}, \
+  {elem, "ctrlrange",     kMjXRealN,     2, nullptr,    0}, \
+  {elem, "forcerange",    kMjXRealN,     2, nullptr,    0}, \
+  {elem, "lengthrange",   kMjXRealN,     2, nullptr,    0}, \
+  {elem, "gear",          kMjXRealUpToN, 6, nullptr,    0}, \
+  {elem, "damping",       kMjXRealUpToN, 3, nullptr,    0}, \
+  {elem, "armature",      kMjXReal,      0, nullptr,    0}, \
+  {elem, "cranklength",   kMjXReal,      0, nullptr,    0}, \
+  {elem, "user",          kMjXRealVec,   0, nullptr,    0}, \
+  {elem, "joint",         kMjXString,    0, nullptr,    0}, \
+  {elem, "jointinparent", kMjXString,    0, nullptr,    0}, \
+  {elem, "tendon",        kMjXString,    0, nullptr,    0}, \
+  {elem, "slidersite",    kMjXString,    0, nullptr,    0}, \
+  {elem, "cranksite",     kMjXString,    0, nullptr,    0}, \
+  {elem, "site",          kMjXString,    0, nullptr,    0}, \
+  {elem, "refsite",       kMjXString,    0, nullptr,    0}, \
+  {elem, "body",          kMjXString,    0, nullptr,    0}
+
+  ACT_COMMON("general"),
+  {"general", "actlimited", kMjXEnum,      0, TFAuto_map, 3},
+  {"general", "actrange",   kMjXRealN,     2, nullptr,    0},
+  {"general", "actdim",     kMjXInt,       0, nullptr,    0},
+  {"general", "dyntype",    kMjXEnum,      0, dyn_map,    7},
+  {"general", "gaintype",   kMjXEnum,      0, gain_map,   5},
+  {"general", "biastype",   kMjXEnum,      0, bias_map,   5},
+  {"general", "dynprm",     kMjXRealUpToN, kNDYN,  nullptr, 0},
+  {"general", "gainprm",    kMjXRealUpToN, kNGAIN, nullptr, 0},
+  {"general", "biasprm",    kMjXRealUpToN, kNBIAS, nullptr, 0},
+  {"general", "actearly",   kMjXEnum,      0, bool_map, 2},
+
+  ACT_COMMON("motor"),
+
+  ACT_COMMON("position"),
+  {"position", "kp",           kMjXReal, 0, nullptr, 0},
+  {"position", "kv",           kMjXReal, 0, nullptr, 0},
+  {"position", "dampratio",    kMjXReal, 0, nullptr, 0},
+  {"position", "timeconst",    kMjXReal, 0, nullptr, 0},
+  {"position", "inheritrange", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("velocity"),
+  {"velocity", "kv", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("intvelocity"),
+  {"intvelocity", "kp",           kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "kv",           kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "dampratio",    kMjXReal,  0, nullptr, 0},
+  {"intvelocity", "actrange",     kMjXRealN, 2, nullptr, 0},
+  {"intvelocity", "inheritrange", kMjXReal,  0, nullptr, 0},
+
+  ACT_COMMON("damper"),
+  {"damper", "kv", kMjXReal, 0, nullptr, 0},
+
+  ACT_COMMON("cylinder"),
+  {"cylinder", "timeconst", kMjXReal,  0, nullptr, 0},
+  {"cylinder", "area",      kMjXReal,  0, nullptr, 0},
+  {"cylinder", "diameter",  kMjXReal,  0, nullptr, 0},
+  {"cylinder", "bias",      kMjXRealN, 3, nullptr, 0},
+
+  ACT_COMMON("muscle"),
+  {"muscle", "timeconst", kMjXRealN, 2, nullptr, 0},
+  {"muscle", "tausmooth", kMjXReal,  0, nullptr, 0},
+  {"muscle", "range",     kMjXRealN, 2, nullptr, 0},
+  {"muscle", "force",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "scale",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "lmin",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "lmax",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "vmax",      kMjXReal,  0, nullptr, 0},
+  {"muscle", "fpmax",     kMjXReal,  0, nullptr, 0},
+  {"muscle", "fvmax",     kMjXReal,  0, nullptr, 0},
+
+  // adhesion doesn't use full ACT_COMMON (no joint/tendon/etc), so list manually.
+  {"adhesion", "name",         kMjXString,    0, nullptr,    0},
+  {"adhesion", "class",        kMjXString,    0, nullptr,    0},
+  {"adhesion", "group",        kMjXInt,       0, nullptr,    0},
+  {"adhesion", "nsample",      kMjXInt,       0, nullptr,    0},
+  {"adhesion", "interp",       kMjXEnum,      0, interp_map, 3},
+  {"adhesion", "delay",        kMjXReal,      0, nullptr,    0},
+  {"adhesion", "forcelimited", kMjXEnum,      0, TFAuto_map, 3},
+  {"adhesion", "ctrlrange",    kMjXRealN,     2, nullptr,    0},
+  {"adhesion", "forcerange",   kMjXRealN,     2, nullptr,    0},
+  {"adhesion", "user",         kMjXRealVec,   0, nullptr,    0},
+  {"adhesion", "body",         kMjXString,    0, nullptr,    0},
+  {"adhesion", "gain",         kMjXReal,      0, nullptr,    0},
+
+  ACT_COMMON("dcmotor"),
+  {"dcmotor", "motorconst", kMjXRealUpToN, 2, nullptr,         0},
+  {"dcmotor", "resistance", kMjXReal,      0, nullptr,         0},
+  {"dcmotor", "nominal",    kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "saturation", kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "inductance", kMjXRealUpToN, 2, nullptr,         0},
+  {"dcmotor", "cogging",    kMjXRealUpToN, 3, nullptr,         0},
+  {"dcmotor", "controller", kMjXRealUpToN, 6, nullptr,         0},
+  {"dcmotor", "thermal",    kMjXRealUpToN, 6, nullptr,         0},
+  {"dcmotor", "lugre",      kMjXRealUpToN, 5, nullptr,         0},
+  {"dcmotor", "input",      kMjXEnum,      0, dcmotorinput_map, 3},
+
+#undef ACT_COMMON
+
+  //-------------------------------- <extension> ---------------------------------------------------
+  {"plugin",   "plugin",   kMjXString, 0, nullptr, 0},
+  {"plugin",   "instance", kMjXString, 0, nullptr, 0},
+  {"plugin",   "name",     kMjXString, 0, nullptr, 0},
+  {"plugin",   "class",    kMjXString, 0, nullptr, 0},
+  {"instance", "name",     kMjXString, 0, nullptr, 0},
+  {"config",   "key",      kMjXString, 0, nullptr, 0},
+  {"config",   "value",    kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <custom> ------------------------------------------------------
+  {"numeric", "name", kMjXString,  0, nullptr, 0},
+  {"numeric", "size", kMjXInt,     0, nullptr, 0},
+  {"numeric", "data", kMjXRealVec, 0, nullptr, 0},
+
+  {"text",    "name", kMjXString,  0, nullptr, 0},
+  {"text",    "data", kMjXString,  0, nullptr, 0},
+
+  {"tuple",   "name",    kMjXString, 0, nullptr, 0},
+  {"element", "objtype", kMjXString, 0, nullptr, 0},
+  {"element", "objname", kMjXString, 0, nullptr, 0},
+  {"element", "prm",     kMjXReal,   0, nullptr, 0},
+
+  //-------------------------------- <asset><hfield> -----------------------------------------------
+  {"hfield", "name",         kMjXString,  0, nullptr, 0},
+  {"hfield", "content_type", kMjXString,  0, nullptr, 0},
+  {"hfield", "file",         kMjXString,  0, nullptr, 0},
+  {"hfield", "nrow",         kMjXInt,     0, nullptr, 0},
+  {"hfield", "ncol",         kMjXInt,     0, nullptr, 0},
+  {"hfield", "size",         kMjXRealN,   4, nullptr, 0},
+  {"hfield", "elevation",    kMjXRealVec, 0, nullptr, 0},
+
+  //-------------------------------- <asset><skin> / <deformable><skin> ---------------------------
+  {"skin", "name",     kMjXString,  0, nullptr,  0},
+  {"skin", "file",     kMjXString,  0, nullptr,  0},
+  {"skin", "material", kMjXString,  0, nullptr,  0},
+  {"skin", "rgba",     kMjXRealN,   4, nullptr,  0},
+  {"skin", "inflate",  kMjXReal,    0, nullptr,  0},
+  {"skin", "vertex",   kMjXRealVec, 0, nullptr,  0},
+  {"skin", "texcoord", kMjXRealVec, 0, nullptr,  0},
+  {"skin", "face",     kMjXIntVec,  0, nullptr,  0},
+  {"skin", "group",    kMjXInt,     0, nullptr,  0},
+  // composite's <skin> sub-element
+  {"skin", "texcoord_composite", kMjXEnum, 0, bool_map, 2},  // unused placeholder
+  {"skin", "subgrid",  kMjXInt,     0, nullptr,  0},
+
+  {"bone", "body",       kMjXString,  0, nullptr, 0},
+  {"bone", "bindpos",    kMjXRealN,   3, nullptr, 0},
+  {"bone", "bindquat",   kMjXRealN,   4, nullptr, 0},
+  {"bone", "vertid",     kMjXIntVec,  0, nullptr, 0},
+  {"bone", "vertweight", kMjXRealVec, 0, nullptr, 0},
+
+  //-------------------------------- <asset><texture> ----------------------------------------------
+  {"texture", "name",         kMjXString,  0, nullptr,         0},
+  {"texture", "type",         kMjXEnum,    0, texture_map,     3},
+  {"texture", "colorspace",   kMjXEnum,    0, colorspace_map,  3},
+  {"texture", "content_type", kMjXString,  0, nullptr,         0},
+  {"texture", "file",         kMjXString,  0, nullptr,         0},
+  {"texture", "gridsize",     kMjXIntN,    2, nullptr,         0},
+  {"texture", "gridlayout",   kMjXString,  0, nullptr,         0},
+  {"texture", "fileright",    kMjXString,  0, nullptr,         0},
+  {"texture", "fileleft",     kMjXString,  0, nullptr,         0},
+  {"texture", "fileup",       kMjXString,  0, nullptr,         0},
+  {"texture", "filedown",     kMjXString,  0, nullptr,         0},
+  {"texture", "filefront",    kMjXString,  0, nullptr,         0},
+  {"texture", "fileback",     kMjXString,  0, nullptr,         0},
+  {"texture", "builtin",      kMjXEnum,    0, builtin_map,     4},
+  {"texture", "rgb1",         kMjXRealN,   3, nullptr,         0},
+  {"texture", "rgb2",         kMjXRealN,   3, nullptr,         0},
+  {"texture", "mark",         kMjXEnum,    0, mark_map,        4},
+  {"texture", "markrgb",      kMjXRealN,   3, nullptr,         0},
+  {"texture", "random",       kMjXReal,    0, nullptr,         0},
+  {"texture", "width",        kMjXInt,     0, nullptr,         0},
+  {"texture", "height",       kMjXInt,     0, nullptr,         0},
+  {"texture", "hflip",        kMjXEnum,    0, bool_map,        2},
+  {"texture", "vflip",        kMjXEnum,    0, bool_map,        2},
+  {"texture", "nchannel",     kMjXInt,     0, nullptr,         0},
+
+  //-------------------------------- <asset><model> ------------------------------------------------
+  {"model", "name",         kMjXString, 0, nullptr, 0},
+  {"model", "file",         kMjXString, 0, nullptr, 0},
+  {"model", "content_type", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <body> / <worldbody> -----------------------------------------
+  {"body", "name",       kMjXString,  0, nullptr,       0},
+  {"body", "childclass", kMjXString,  0, nullptr,       0},
+  {"body", "pos",        kMjXRealN,   3, nullptr,       0},
+  {"body", "quat",       kMjXRealN,   4, nullptr,       0},
+  {"body", "mocap",      kMjXEnum,    0, bool_map,      2},
+  {"body", "axisangle",  kMjXRealN,   4, nullptr,       0},
+  {"body", "xyaxes",     kMjXRealN,   6, nullptr,       0},
+  {"body", "zaxis",      kMjXRealN,   3, nullptr,       0},
+  {"body", "euler",      kMjXRealN,   3, nullptr,       0},
+  {"body", "gravcomp",   kMjXReal,    0, nullptr,       0},
+  {"body", "sleep",      kMjXEnum,    0, bodysleep_map, 4},
+  {"body", "user",       kMjXRealVec, 0, nullptr,       0},
+
+  //-------------------------------- <body><inertial> ---------------------------------------------
+  {"inertial", "pos",          kMjXRealN, 3, nullptr, 0},
+  {"inertial", "quat",         kMjXRealN, 4, nullptr, 0},
+  {"inertial", "mass",         kMjXReal,  0, nullptr, 0},
+  {"inertial", "diaginertia",  kMjXRealN, 3, nullptr, 0},
+  {"inertial", "axisangle",    kMjXRealN, 4, nullptr, 0},
+  {"inertial", "xyaxes",       kMjXRealN, 6, nullptr, 0},
+  {"inertial", "zaxis",        kMjXRealN, 3, nullptr, 0},
+  {"inertial", "euler",        kMjXRealN, 3, nullptr, 0},
+  {"inertial", "fullinertia",  kMjXRealN, 6, nullptr, 0},
+
+  //-------------------------------- <body><frame> ------------------------------------------------
+  {"frame", "name",       kMjXString, 0, nullptr, 0},
+  {"frame", "childclass", kMjXString, 0, nullptr, 0},
+  {"frame", "pos",        kMjXRealN,  3, nullptr, 0},
+  {"frame", "quat",       kMjXRealN,  4, nullptr, 0},
+  {"frame", "axisangle",  kMjXRealN,  4, nullptr, 0},
+  {"frame", "xyaxes",     kMjXRealN,  6, nullptr, 0},
+  {"frame", "zaxis",      kMjXRealN,  3, nullptr, 0},
+  {"frame", "euler",      kMjXRealN,  3, nullptr, 0},
+
+  //-------------------------------- <body><replicate> --------------------------------------------
+  {"replicate", "count",      kMjXInt,    0, nullptr, 0},
+  {"replicate", "offset",     kMjXRealN,  3, nullptr, 0},
+  {"replicate", "euler",      kMjXRealN,  3, nullptr, 0},
+  {"replicate", "sep",        kMjXString, 0, nullptr, 0},
+  {"replicate", "childclass", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <body><attach> -----------------------------------------------
+  {"attach", "model",  kMjXString, 0, nullptr, 0},
+  {"attach", "body",   kMjXString, 0, nullptr, 0},
+  {"attach", "prefix", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <composite> --------------------------------------------------
+  {"composite", "prefix",  kMjXString,  0, nullptr,  0},
+  {"composite", "type",    kMjXEnum,    0, comp_map, kCompTypesSz},
+  {"composite", "count",   kMjXIntVec,  0, nullptr,  0},
+  {"composite", "offset",  kMjXRealN,   3, nullptr,  0},
+  {"composite", "vertex",  kMjXRealVec, 0, nullptr,  0},
+  {"composite", "initial", kMjXString,  0, nullptr,  0},
+  {"composite", "curve",   kMjXString,  0, nullptr,  0},
+  {"composite", "size",    kMjXRealN,   3, nullptr,  0},
+  {"composite", "quat",    kMjXRealN,   4, nullptr,  0},
+
+  //-------------------------------- <flexcomp> ---------------------------------------------------
+  {"flexcomp", "name",       kMjXString,  0, nullptr,   0},
+  {"flexcomp", "type",       kMjXEnum,    0, fcomp_map, kFcompTypesSz},
+  {"flexcomp", "group",      kMjXInt,     0, nullptr,   0},
+  {"flexcomp", "dim",        kMjXInt,     0, nullptr,   0},
+  {"flexcomp", "dof",        kMjXEnum,    0, fdof_map,  kFcompDofsSz},
+  {"flexcomp", "count",      kMjXIntN,    3, nullptr,   0},
+  {"flexcomp", "cellcount",  kMjXIntN,    3, nullptr,   0},
+  {"flexcomp", "spacing",    kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "radius",     kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "rigid",      kMjXEnum,    0, bool_map,  2},
+  {"flexcomp", "mass",       kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "inertiabox", kMjXReal,    0, nullptr,   0},
+  {"flexcomp", "scale",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "file",       kMjXString,  0, nullptr,   0},
+  {"flexcomp", "point",      kMjXRealVec, 0, nullptr,   0},
+  {"flexcomp", "element",    kMjXIntVec,  0, nullptr,   0},
+  {"flexcomp", "texcoord",   kMjXRealVec, 0, nullptr,   0},
+  {"flexcomp", "material",   kMjXString,  0, nullptr,   0},
+  {"flexcomp", "rgba",       kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "flatskin",   kMjXEnum,    0, bool_map,  2},
+  {"flexcomp", "pos",        kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "quat",       kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "axisangle",  kMjXRealN,   4, nullptr,   0},
+  {"flexcomp", "xyaxes",     kMjXRealN,   6, nullptr,   0},
+  {"flexcomp", "zaxis",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "euler",      kMjXRealN,   3, nullptr,   0},
+  {"flexcomp", "origin",     kMjXRealN,   3, nullptr,   0},
+
+  //-------------------------------- <flexcomp>/<flex> children -----------------------------------
+  // <edge> under <flex> has {stiffness, damping}; under <flexcomp> adds {equality, solref, solimp}.
+  // We include the union.
+  {"edge", "equality",  kMjXEnum,      0, flexeq_map, 4},
+  {"edge", "solref",    kMjXRealUpToN, 2, nullptr,  0},
+  {"edge", "solimp",    kMjXRealUpToN, 5, nullptr,  0},
+  {"edge", "stiffness", kMjXReal,      0, nullptr,  0},
+  {"edge", "damping",   kMjXReal,      0, nullptr,  0},
+
+  {"elasticity", "young",     kMjXReal,      0, nullptr,         0},
+  {"elasticity", "poisson",   kMjXReal,      0, nullptr,         0},
+  {"elasticity", "damping",   kMjXReal,      0, nullptr,         0},
+  {"elasticity", "thickness", kMjXReal,      0, nullptr,         0},
+  {"elasticity", "elastic2d", kMjXEnum,      0, elastic2d_map,   5},
+
+  {"contact", "contype",      kMjXInt,       0, nullptr,      0},
+  {"contact", "conaffinity",  kMjXInt,       0, nullptr,      0},
+  {"contact", "condim",       kMjXInt,       0, nullptr,      0},
+  {"contact", "priority",     kMjXInt,       0, nullptr,      0},
+  {"contact", "friction",     kMjXRealUpToN, 3, nullptr,      0},
+  {"contact", "solmix",       kMjXReal,      0, nullptr,      0},
+  {"contact", "solref",       kMjXRealUpToN, 2, nullptr,      0},
+  {"contact", "solimp",       kMjXRealUpToN, 5, nullptr,      0},
+  {"contact", "margin",       kMjXReal,      0, nullptr,      0},
+  {"contact", "gap",          kMjXReal,      0, nullptr,      0},
+  {"contact", "internal",     kMjXEnum,      0, bool_map,     2},
+  {"contact", "selfcollide",  kMjXEnum,      0, flexself_map, 5},
+  {"contact", "activelayers", kMjXInt,       0, nullptr,      0},
+  {"contact", "passive",      kMjXEnum,      0, bool_map,     2},
+
+  {"pin", "id",        kMjXIntVec,   0, nullptr, 0},
+  {"pin", "range",     kMjXRealN,    2, nullptr, 0},
+  {"pin", "grid",      kMjXIntVec,   0, nullptr, 0},
+  {"pin", "gridrange", kMjXIntVec,   0, nullptr, 0},
+
+  //-------------------------------- <composite> children -----------------------------------------
+  // Most of composite's children re-use element names that already have entries.
+  // "kind" is specific to composite's <joint>; treat as a composite-joint attr via shared key.
+
+  //-------------------------------- <deformable><flex> -------------------------------------------
+  {"flex", "name",         kMjXString,   0, nullptr,   0},
+  {"flex", "group",        kMjXInt,      0, nullptr,   0},
+  {"flex", "dim",          kMjXInt,      0, nullptr,   0},
+  {"flex", "radius",       kMjXReal,     0, nullptr,   0},
+  {"flex", "material",     kMjXString,   0, nullptr,   0},
+  {"flex", "rgba",         kMjXRealN,    4, nullptr,   0},
+  {"flex", "flatskin",     kMjXEnum,     0, bool_map,  2},
+  {"flex", "body",         kMjXString,   0, nullptr,   0},
+  {"flex", "vertex",       kMjXRealVec,  0, nullptr,   0},
+  {"flex", "element",      kMjXIntVec,   0, nullptr,   0},
+  {"flex", "texcoord",     kMjXRealVec,  0, nullptr,   0},
+  {"flex", "elemtexcoord", kMjXIntVec,   0, nullptr,   0},
+  {"flex", "node",         kMjXString,   0, nullptr,   0},
+  {"flex", "cellcount",    kMjXIntN,     3, nullptr,   0},
+  {"flex", "dof",          kMjXEnum,     0, fdof_map,  kFcompDofsSz},
+  // equality-flex refs (used in <equality><flex>)
+  {"flex", "class",        kMjXString,   0, nullptr,   0},
+  {"flex", "flex",         kMjXString,   0, nullptr,   0},
+  {"flex", "active",       kMjXEnum,     0, bool_map,  2},
+  {"flex", "solref",       kMjXRealUpToN,2, nullptr,   0},
+  {"flex", "solimp",       kMjXRealUpToN,5, nullptr,   0},
+
+  //-------------------------------- <contact> ----------------------------------------------------
+  {"exclude", "name",  kMjXString, 0, nullptr, 0},
+  {"exclude", "body1", kMjXString, 0, nullptr, 0},
+  {"exclude", "body2", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <equality> children ------------------------------------------
+  {"connect", "name",     kMjXString,    0, nullptr,  0},
+  {"connect", "class",    kMjXString,    0, nullptr,  0},
+  {"connect", "body1",    kMjXString,    0, nullptr,  0},
+  {"connect", "body2",    kMjXString,    0, nullptr,  0},
+  {"connect", "anchor",   kMjXRealN,     3, nullptr,  0},
+  {"connect", "site1",    kMjXString,    0, nullptr,  0},
+  {"connect", "site2",    kMjXString,    0, nullptr,  0},
+  {"connect", "active",   kMjXEnum,      0, bool_map, 2},
+  {"connect", "solref",   kMjXRealUpToN, 2, nullptr,  0},
+  {"connect", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
+
+  {"weld", "name",        kMjXString,    0, nullptr,  0},
+  {"weld", "class",       kMjXString,    0, nullptr,  0},
+  {"weld", "body1",       kMjXString,    0, nullptr,  0},
+  {"weld", "body2",       kMjXString,    0, nullptr,  0},
+  {"weld", "relpose",     kMjXRealN,     7, nullptr,  0},
+  {"weld", "anchor",      kMjXRealN,     3, nullptr,  0},
+  {"weld", "site1",       kMjXString,    0, nullptr,  0},
+  {"weld", "site2",       kMjXString,    0, nullptr,  0},
+  {"weld", "active",      kMjXEnum,      0, bool_map, 2},
+  {"weld", "solref",      kMjXRealUpToN, 2, nullptr,  0},
+  {"weld", "solimp",      kMjXRealUpToN, 5, nullptr,  0},
+  {"weld", "torquescale", kMjXReal,      0, nullptr,  0},
+
+  // <equality><joint> has a distinct set of attrs from top-level <joint>.
+  // Since our lookup key is (element, attr), we add the ones not already covered
+  // by top-level <joint> (joint1, joint2, polycoef).
+  {"joint", "joint1",   kMjXString,    0, nullptr,  0},
+  {"joint", "joint2",   kMjXString,    0, nullptr,  0},
+  {"joint", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
+  {"joint", "active",   kMjXEnum,      0, bool_map, 2},
+  {"joint", "solref",   kMjXRealUpToN, 2, nullptr,  0},
+  {"joint", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
+  {"joint", "kind",     kMjXString,    0, nullptr,  0},  // composite joint kind
+  {"joint", "joint",    kMjXString,    0, nullptr,  0},  // tendon wrap
+
+  // <equality><tendon>
+  {"tendon", "name",     kMjXString,    0, nullptr,  0},
+  {"tendon", "class",    kMjXString,    0, nullptr,  0},
+  {"tendon", "tendon1",  kMjXString,    0, nullptr,  0},
+  {"tendon", "tendon2",  kMjXString,    0, nullptr,  0},
+  {"tendon", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
+
+  // flexvert / flexstrain equality variants
+  {"flexvert", "name",   kMjXString,    0, nullptr,  0},
+  {"flexvert", "class",  kMjXString,    0, nullptr,  0},
+  {"flexvert", "flex",   kMjXString,    0, nullptr,  0},
+  {"flexvert", "active", kMjXEnum,      0, bool_map, 2},
+  {"flexvert", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"flexvert", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  {"flexstrain", "name",   kMjXString,    0, nullptr,  0},
+  {"flexstrain", "class",  kMjXString,    0, nullptr,  0},
+  {"flexstrain", "flex",   kMjXString,    0, nullptr,  0},
+  {"flexstrain", "active", kMjXEnum,      0, bool_map, 2},
+  {"flexstrain", "solref", kMjXRealUpToN, 2, nullptr,  0},
+  {"flexstrain", "solimp", kMjXRealUpToN, 5, nullptr,  0},
+
+  //-------------------------------- <tendon> wrap subelements ------------------------------------
+  // <site site="..."/>, <geom geom="..." sidesite="..."/>
+  {"site", "site",     kMjXString, 0, nullptr, 0},
+  {"geom", "geom",     kMjXString, 0, nullptr, 0},
+  {"geom", "sidesite", kMjXString, 0, nullptr, 0},
+
+  //-------------------------------- <sensor> ------------------------------------------------------
+  // shared sensor attrs
+#define SENS_COMMON(elem) \
+  {elem, "name",     kMjXString,    0, nullptr,    0}, \
+  {elem, "nsample",  kMjXInt,       0, nullptr,    0}, \
+  {elem, "interp",   kMjXEnum,      0, interp_map, 3}, \
+  {elem, "delay",    kMjXReal,      0, nullptr,    0}, \
+  {elem, "interval", kMjXRealUpToN, 2, nullptr,    0}, \
+  {elem, "cutoff",   kMjXReal,      0, nullptr,    0}, \
+  {elem, "noise",    kMjXReal,      0, nullptr,    0}, \
+  {elem, "user",     kMjXRealVec,   0, nullptr,    0}
+
+  SENS_COMMON("touch"),         {"touch",         "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("accelerometer"), {"accelerometer", "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("velocimeter"),   {"velocimeter",   "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("gyro"),          {"gyro",          "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("force"),         {"force",         "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("torque"),        {"torque",        "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("magnetometer"),  {"magnetometer",  "site",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("camprojection"), {"camprojection", "site",     kMjXString, 0, nullptr, 0},
+                                {"camprojection", "camera",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("rangefinder"),   {"rangefinder",   "site",     kMjXString, 0, nullptr, 0},
+                                {"rangefinder",   "camera",   kMjXString, 0, nullptr, 0},
+                                {"rangefinder",   "data",     kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointpos"),      {"jointpos",      "joint",    kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointvel"),      {"jointvel",      "joint",    kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonpos"),     {"tendonpos",     "tendon",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonvel"),     {"tendonvel",     "tendon",   kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorpos"),   {"actuatorpos",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorvel"),   {"actuatorvel",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("actuatorfrc"),   {"actuatorfrc",   "actuator", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointactuatorfrc"),  {"jointactuatorfrc",  "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonactuatorfrc"), {"tendonactuatorfrc", "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("ballquat"),          {"ballquat",          "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("ballangvel"),        {"ballangvel",        "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitpos"),     {"jointlimitpos",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitvel"),     {"jointlimitvel",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("jointlimitfrc"),     {"jointlimitfrc",     "joint",  kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitpos"),    {"tendonlimitpos",    "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitvel"),    {"tendonlimitvel",    "tendon", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("tendonlimitfrc"),    {"tendonlimitfrc",    "tendon", kMjXString, 0, nullptr, 0},
+
+#define SENS_FRAME(elem) \
+  SENS_COMMON(elem), \
+  {elem, "objtype", kMjXString, 0, nullptr, 0}, \
+  {elem, "objname", kMjXString, 0, nullptr, 0}, \
+  {elem, "reftype", kMjXString, 0, nullptr, 0}, \
+  {elem, "refname", kMjXString, 0, nullptr, 0}
+
+  SENS_FRAME("framepos"),
+  SENS_FRAME("framequat"),
+  SENS_FRAME("framexaxis"),
+  SENS_FRAME("frameyaxis"),
+  SENS_FRAME("framezaxis"),
+  SENS_FRAME("framelinvel"),
+  SENS_FRAME("frameangvel"),
+  SENS_COMMON("framelinacc"), {"framelinacc", "objtype", kMjXString, 0, nullptr, 0},
+                              {"framelinacc", "objname", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("frameangacc"), {"frameangacc", "objtype", kMjXString, 0, nullptr, 0},
+                              {"frameangacc", "objname", kMjXString, 0, nullptr, 0},
+
+  SENS_COMMON("subtreecom"),    {"subtreecom",    "body", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("subtreelinvel"), {"subtreelinvel", "body", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("subtreeangmom"), {"subtreeangmom", "body", kMjXString, 0, nullptr, 0},
+
+  SENS_COMMON("insidesite"),
+  {"insidesite", "site",    kMjXString, 0, nullptr, 0},
+  {"insidesite", "objtype", kMjXString, 0, nullptr, 0},
+  {"insidesite", "objname", kMjXString, 0, nullptr, 0},
+
+  // distance/normal/fromto share the same attrs
+  SENS_COMMON("distance"),
+  {"distance", "geom1", kMjXString, 0, nullptr, 0},
+  {"distance", "geom2", kMjXString, 0, nullptr, 0},
+  {"distance", "body1", kMjXString, 0, nullptr, 0},
+  {"distance", "body2", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("normal"),
+  {"normal", "geom1", kMjXString, 0, nullptr, 0},
+  {"normal", "geom2", kMjXString, 0, nullptr, 0},
+  {"normal", "body1", kMjXString, 0, nullptr, 0},
+  {"normal", "body2", kMjXString, 0, nullptr, 0},
+  SENS_COMMON("fromto"),
+  {"fromto", "geom1", kMjXString, 0, nullptr, 0},
+  {"fromto", "geom2", kMjXString, 0, nullptr, 0},
+  {"fromto", "body1", kMjXString, 0, nullptr, 0},
+  {"fromto", "body2", kMjXString, 0, nullptr, 0},
+
+  // contact sensor
+  {"contact", "name",     kMjXString, 0, nullptr,    0},
+  {"contact", "geom1",    kMjXString, 0, nullptr,    0},
+  {"contact", "geom2",    kMjXString, 0, nullptr,    0},
+  {"contact", "body1",    kMjXString, 0, nullptr,    0},
+  {"contact", "body2",    kMjXString, 0, nullptr,    0},
+  {"contact", "subtree1", kMjXString, 0, nullptr,    0},
+  {"contact", "subtree2", kMjXString, 0, nullptr,    0},
+  {"contact", "site",     kMjXString, 0, nullptr,    0},
+  {"contact", "num",      kMjXInt,    0, nullptr,    0},
+  {"contact", "data",     kMjXString, 0, nullptr,    0},  // space-separated enum bitflags
+  {"contact", "reduce",   kMjXEnum,   0, reduce_map, 4},
+  {"contact", "nsample",  kMjXInt,    0, nullptr,    0},
+  {"contact", "interp",   kMjXEnum,   0, interp_map, 3},
+  {"contact", "delay",    kMjXReal,   0, nullptr,    0},
+  {"contact", "interval", kMjXRealUpToN, 2, nullptr, 0},
+  {"contact", "cutoff",   kMjXReal,   0, nullptr,    0},
+  {"contact", "noise",    kMjXReal,   0, nullptr,    0},
+  {"contact", "user",     kMjXRealVec,0, nullptr,    0},
+
+  SENS_COMMON("e_potential"),
+  SENS_COMMON("e_kinetic"),
+  SENS_COMMON("clock"),
+
+  {"tactile", "name",    kMjXString,  0, nullptr,    0},
+  {"tactile", "geom",    kMjXString,  0, nullptr,    0},
+  {"tactile", "mesh",    kMjXString,  0, nullptr,    0},
+  {"tactile", "nsample", kMjXInt,     0, nullptr,    0},
+  {"tactile", "interp",  kMjXEnum,    0, interp_map, 3},
+  {"tactile", "delay",   kMjXReal,    0, nullptr,    0},
+  {"tactile", "interval",kMjXRealUpToN, 2, nullptr,  0},
+  {"tactile", "user",    kMjXRealVec, 0, nullptr,    0},
+
+  {"user", "name",      kMjXString,  0, nullptr,       0},
+  {"user", "objtype",   kMjXString,  0, nullptr,       0},
+  {"user", "objname",   kMjXString,  0, nullptr,       0},
+  {"user", "datatype",  kMjXEnum,    0, datatype_map,  4},
+  {"user", "needstage", kMjXEnum,    0, stage_map,     4},
+  {"user", "dim",       kMjXInt,     0, nullptr,       0},
+  {"user", "cutoff",    kMjXReal,    0, nullptr,       0},
+  {"user", "noise",     kMjXReal,    0, nullptr,       0},
+  {"user", "user",      kMjXRealVec, 0, nullptr,       0},
+
+#undef SENS_COMMON
+#undef SENS_FRAME
+
+  //-------------------------------- <keyframe> ---------------------------------------------------
+  {"key", "name",  kMjXString,  0, nullptr, 0},
+  {"key", "time",  kMjXReal,    0, nullptr, 0},
+  {"key", "qpos",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "qvel",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "act",   kMjXRealVec, 0, nullptr, 0},
+  {"key", "mpos",  kMjXRealVec, 0, nullptr, 0},
+  {"key", "mquat", kMjXRealVec, 0, nullptr, 0},
+  {"key", "ctrl",  kMjXRealVec, 0, nullptr, 0},
+};
+// clang-format on
+
+const int kMjXAttrTableSize =
+    sizeof(kMjXAttrTable) / sizeof(kMjXAttrTable[0]);
+
+
+//---------------------------------- MJCF tree parser ----------------------------------------------
+
+namespace {
+
+struct Node {
+  const char* name = nullptr;
+  char type = '?';
+  std::vector<const char*> attrs;
+  std::vector<Node> children;
+};
+
+int ParseNode(int start, int nrow, Node& out) {
+  out.name = MJCF[start][0];
+  out.type = MJCF[start][1][0];
+  const int nattr = static_cast<int>(MJCF[start].size()) - 2;
+  for (int i = 0; i < nattr; i++) {
+    out.attrs.push_back(MJCF[start][2 + i]);
+  }
+
+  int next = start + 1;
+  if (next < nrow && MJCF[next][0][0] == '<') {
+    next++;  // skip '<'
+    while (next < nrow && MJCF[next][0][0] != '>') {
+      Node child;
+      next = ParseNode(next, nrow, child);
+      out.children.push_back(std::move(child));
+    }
+    next++;  // skip '>'
+  }
+  return next;
+}
+
+
+//---------------------------------- XSD emit helpers ----------------------------------------------
+
+void Indent(std::stringstream& out, int level) {
+  for (int i = 0; i < level; i++) out << "  ";
+}
+
+const mjXAttr* Lookup(const char* element, const char* attr) {
+  for (int i = 0; i < kMjXAttrTableSize; i++) {
+    const mjXAttr& e = kMjXAttrTable[i];
+    if (std::string(e.element) == element && std::string(e.attr) == attr) {
+      return &e;
+    }
+  }
+  return nullptr;
+}
+
+void CardinalityToOccurs(char type, const char** min_occurs,
+                         const char** max_occurs) {
+  switch (type) {
+    case '!': *min_occurs = "1"; *max_occurs = "1";         break;
+    case '?': *min_occurs = "0"; *max_occurs = "1";         break;
+    case '*': *min_occurs = "0"; *max_occurs = "unbounded"; break;
+    case 'R': *min_occurs = "0"; *max_occurs = "unbounded"; break;
+    default:  *min_occurs = "0"; *max_occurs = "1";         break;
+  }
+}
+
+std::string EnumTypeName(const char* element, const char* attr) {
+  return std::string(element) + "_" + attr + "_enum";
+}
+
+std::string ListTypeName(mjXAttrKind kind, int size) {
+  switch (kind) {
+    case kMjXIntN:      return "list_int_" + std::to_string(size);
+    case kMjXIntVec:    return "vec_int";
+    case kMjXRealN:     return "list_real_" + std::to_string(size);
+    case kMjXRealUpToN: return "uptolist_real_" + std::to_string(size);
+    case kMjXRealVec:   return "vec_real";
+    default:            return "unknown";
+  }
+}
+
+
+//---------------------------------- Emit: enum / list types ---------------------------------------
+
+void CollectTypes(
+    const Node& node,
+    std::set<std::string>& list_types,
+    std::vector<std::pair<std::string, const mjXAttr*>>& enum_types,
+    std::set<std::string>& enum_seen) {
+  for (const char* a : node.attrs) {
+    const mjXAttr* info = Lookup(node.name, a);
+    if (!info) continue;
+
+    if (info->kind == kMjXEnum) {
+      std::string n = EnumTypeName(node.name, a);
+      if (enum_seen.insert(n).second) {
+        enum_types.emplace_back(n, info);
+      }
+    } else if (info->kind == kMjXIntN || info->kind == kMjXRealN ||
+               info->kind == kMjXRealUpToN || info->kind == kMjXIntVec ||
+               info->kind == kMjXRealVec) {
+      list_types.insert(ListTypeName(info->kind, info->size));
+    }
+  }
+  for (const Node& child : node.children) {
+    CollectTypes(child, list_types, enum_types, enum_seen);
+  }
+}
+
+void EmitListType(std::stringstream& out, const std::string& name) {
+  const bool is_real = name.find("_real") != std::string::npos;
+  const bool is_upto = name.rfind("uptolist_", 0) == 0;
+  const bool is_vec  = name.rfind("vec_", 0) == 0;
+  int size = 0;
+  if (!is_vec) {
+    auto pos = name.find_last_of('_');
+    if (pos != std::string::npos) {
+      try {
+        size = std::stoi(name.substr(pos + 1));
+      } catch (...) { size = 0; }
+    }
+  }
+
+  Indent(out, 1);
+  out << "<xs:simpleType name=\"" << name << "\">\n";
+  Indent(out, 2);
+  out << "<xs:restriction>\n";
+  Indent(out, 3);
+  out << "<xs:simpleType>\n";
+  Indent(out, 4);
+  out << "<xs:list itemType=\"" << (is_real ? "xs:double" : "xs:int") << "\"/>\n";
+  Indent(out, 3);
+  out << "</xs:simpleType>\n";
+  if (is_vec) {
+    // unconstrained length
+  } else if (is_upto) {
+    Indent(out, 3);
+    out << "<xs:minLength value=\"1\"/>\n";
+    Indent(out, 3);
+    out << "<xs:maxLength value=\"" << size << "\"/>\n";
+  } else {
+    Indent(out, 3);
+    out << "<xs:length value=\"" << size << "\"/>\n";
+  }
+  Indent(out, 2);
+  out << "</xs:restriction>\n";
+  Indent(out, 1);
+  out << "</xs:simpleType>\n";
+}
+
+void EmitEnumType(std::stringstream& out, const std::string& name,
+                  const mjXAttr& info) {
+  Indent(out, 1);
+  out << "<xs:simpleType name=\"" << name << "\">\n";
+  Indent(out, 2);
+  out << "<xs:restriction base=\"xs:string\">\n";
+  for (int i = 0; i < info.map_size; i++) {
+    // Some map arrays in xml_native_reader.cc are sized larger than the
+    // number of initialized entries (e.g. elastic2d_map[5] with 4 entries);
+    // skip nullptr sentinels defensively.
+    if (!info.map[i].key) break;
+    Indent(out, 3);
+    out << "<xs:enumeration value=\"" << info.map[i].key << "\"/>\n";
+  }
+  Indent(out, 2);
+  out << "</xs:restriction>\n";
+  Indent(out, 1);
+  out << "</xs:simpleType>\n";
+}
+
+
+//---------------------------------- Emit: elements ------------------------------------------------
+
+void EmitAttribute(std::stringstream& out, int level, const char* element,
+                   const char* attr) {
+  const mjXAttr* info = Lookup(element, attr);
+  Indent(out, level);
+  out << "<xs:attribute name=\"" << attr << "\"";
+  if (!info) {
+    out << " type=\"xs:string\"/>  <!-- No type found -->\n";
+    return;
+  }
+  switch (info->kind) {
+    case kMjXString: out << " type=\"xs:string\"/>\n"; break;
+    case kMjXInt:    out << " type=\"xs:int\"/>\n";    break;
+    case kMjXReal:   out << " type=\"xs:double\"/>\n"; break;
+    case kMjXEnum:
+      out << " type=\"" << EnumTypeName(element, attr) << "\"/>\n";
+      break;
+    case kMjXIntN:
+    case kMjXRealN:
+    case kMjXRealUpToN:
+    case kMjXIntVec:
+    case kMjXRealVec:
+      out << " type=\"" << ListTypeName(info->kind, info->size) << "\"/>\n";
+      break;
+  }
+}
+
+// Is this node recursive? ('R' cardinality)
+bool IsRecursive(const Node& n) { return n.type == 'R'; }
+
+// Emit the body of a complexType (choice + attributes) for a given element.
+// Separated from EmitElement so it can be reused for named types that are
+// referenced from multiple places.
+void EmitComplexTypeBody(std::stringstream& out, const Node& node, int level,
+                         const char* effective_name) {
+  if (!node.children.empty() || IsRecursive(node) ||
+      std::string(effective_name) == "body") {
+    Indent(out, level);
+    out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
+    for (const Node& child : node.children) {
+      extern void EmitElementInternal(std::stringstream&, const Node&, int,
+                                       bool, const char*);
+      EmitElementInternal(out, child, level + 1, /*top_level=*/false, nullptr);
+    }
+    // Recursive self-reference for 'R' elements.
+    if (IsRecursive(node)) {
+      Indent(out, level + 1);
+      out << "<xs:element name=\"" << effective_name << "\" type=\""
+          << effective_name << "_type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+    }
+    // Body special-cases: <body> can also contain <body>/<frame>/<replicate>
+    // (per mjXSchema::NameMatch). Emit them when effective_name is body-family.
+    // Each alias points at its own named complexType so its own attributes
+    // (declared in kMjXAttrTable) are honored -- body_type would drop them.
+    if (std::string(effective_name) == "body" ||
+        std::string(effective_name) == "worldbody") {
+      for (const char* alias : {"body", "frame", "replicate"}) {
+        Indent(out, level + 1);
+        out << "<xs:element name=\"" << alias << "\" type=\"" << alias << "_type\""
+            << " minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+      }
+    }
+    // <include> is handled by the XML preprocessor (xml.cc::IncludeXML) and
+    // can appear as a child of any element. Always allow it.
+    Indent(out, level + 1);
+    out << "<xs:element ref=\"include\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+    Indent(out, level);
+    out << "</xs:choice>\n";
+  }
+
+  for (const char* a : node.attrs) {
+    EmitAttribute(out, level, node.name, a);
+  }
+}
+
+// Internal implementation (exposed via the `extern` inside EmitComplexTypeBody).
+void EmitElementInternal(std::stringstream& out, const Node& node, int level,
+                         bool top_level, const char* name_override) {
+  const char* min_occurs = "0";
+  const char* max_occurs = "1";
+  CardinalityToOccurs(node.type, &min_occurs, &max_occurs);
+
+  const char* element_name = name_override ? name_override : node.name;
+
+  // Recursive elements use a named complexType so they can be self-referenced.
+  const bool use_named_type = IsRecursive(node) ||
+                              std::string(node.name) == "body";
+
+  Indent(out, level);
+  out << "<xs:element name=\"" << element_name << "\"";
+  if (use_named_type) {
+    out << " type=\"" << node.name << "_type\"";
+  }
+  if (!top_level) {
+    if (std::string(min_occurs) != "1") out << " minOccurs=\"" << min_occurs << "\"";
+    if (std::string(max_occurs) != "1") out << " maxOccurs=\"" << max_occurs << "\"";
+  }
+  if (use_named_type) {
+    out << "/>\n";
+    return;
+  }
+  out << ">\n";
+
+  Indent(out, level + 1);
+  out << "<xs:complexType>\n";
+  EmitComplexTypeBody(out, node, level + 2, element_name);
+  Indent(out, level + 1);
+  out << "</xs:complexType>\n";
+  Indent(out, level);
+  out << "</xs:element>\n";
+}
+
+// Collect recursive (or body-family) nodes for named-type emission.
+void CollectNamedTypes(const Node& node, std::vector<const Node*>& out) {
+  if (IsRecursive(node) || std::string(node.name) == "body") {
+    out.push_back(&node);
+  }
+  for (const Node& child : node.children) {
+    CollectNamedTypes(child, out);
+  }
+}
+
+void EmitNamedType(std::stringstream& out, const Node& node) {
+  Indent(out, 1);
+  out << "<xs:complexType name=\"" << node.name << "_type\">\n";
+  EmitComplexTypeBody(out, node, 2, node.name);
+  Indent(out, 1);
+  out << "</xs:complexType>\n";
+}
+
+// Emit a named complexType that shares the <body> content model but has its
+// own attributes (from kMjXAttrTable). Used for <frame> and <replicate>,
+// which are aliases of <body> at the tree level but carry distinct attrs.
+void EmitAliasType(std::stringstream& out, const Node& body_node,
+                   const char* alias_name) {
+  Indent(out, 1);
+  out << "<xs:complexType name=\"" << alias_name << "_type\">\n";
+  // Choice block mirrors body_type: same children + body-family aliases.
+  Indent(out, 2);
+  out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
+  for (const Node& child : body_node.children) {
+    EmitElementInternal(out, child, 3, /*top_level=*/false, nullptr);
+  }
+  // Body-family recursion: allow body/frame/replicate nested inside.
+  for (const char* sub : {"body", "frame", "replicate"}) {
+    Indent(out, 3);
+    out << "<xs:element name=\"" << sub << "\" type=\"" << sub << "_type\""
+        << " minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+  }
+  Indent(out, 3);
+  out << "<xs:element ref=\"include\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+  Indent(out, 2);
+  out << "</xs:choice>\n";
+  // Attributes come from the flat kMjXAttrTable entries for this element.
+  for (int i = 0; i < kMjXAttrTableSize; i++) {
+    const mjXAttr& row = kMjXAttrTable[i];
+    if (std::string(row.element) == alias_name) {
+      EmitAttribute(out, 2, alias_name, row.attr);
+    }
+  }
+  Indent(out, 1);
+  out << "</xs:complexType>\n";
+}
+
+}  // namespace
+
+
+//---------------------------------- Entry point ---------------------------------------------------
+
+void PrintSchemaXSD(std::stringstream& out) {
+  Node root;
+  ParseNode(0, nMJCF, root);
+
+  std::set<std::string> list_types;
+  std::vector<std::pair<std::string, const mjXAttr*>> enum_types;
+  std::set<std::string> enum_seen;
+  CollectTypes(root, list_types, enum_types, enum_seen);
+
+  // Find recursive / body-family nodes so we can emit them as named types.
+  std::vector<const Node*> named_types;
+  CollectNamedTypes(root, named_types);
+
+  out << "<?xml version=\"1.0\"?>\n";
+  out << "<!-- Auto-generated from MuJoCo MJCF schema. DO NOT EDIT. -->\n";
+  out << "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\""
+         " elementFormDefault=\"qualified\">\n";
+
+  if (!list_types.empty()) {
+    out << "\n  <!-- List types -->\n";
+    for (const std::string& n : list_types) {
+      EmitListType(out, n);
+    }
+  }
+
+  if (!enum_types.empty()) {
+    out << "\n  <!-- Enum types -->\n";
+    for (const auto& [n, info] : enum_types) {
+      EmitEnumType(out, n, *info);
+    }
+  }
+
+  // Named complex types (for recursive elements like <body> and <default>).
+  if (!named_types.empty()) {
+    out << "\n  <!-- Recursive complex types -->\n";
+    const Node* body_node = nullptr;
+    for (const Node* n : named_types) {
+      EmitNamedType(out, *n);
+      if (std::string(n->name) == "body") body_node = n;
+    }
+    // <frame> and <replicate> are body-family aliases handled outside MJCF[]
+    // (see mjXSchema::NameMatch). They share body's content model but each
+    // has its own attribute set in kMjXAttrTable; emit dedicated types so
+    // those attrs are actually applied when validating.
+    if (body_node) {
+      for (const char* alias : {"frame", "replicate"}) {
+        EmitAliasType(out, *body_node, alias);
+      }
+    }
+  }
+
+  // Global <include> element (preprocessor directive, allowed as a child of
+  // any element in the tree).
+  out << "\n  <!-- Preprocessor include -->\n";
+  Indent(out, 1);
+  out << "<xs:element name=\"include\">\n";
+  Indent(out, 2);
+  out << "<xs:complexType>\n";
+  Indent(out, 3);
+  out << "<xs:attribute name=\"file\" type=\"xs:string\" use=\"required\"/>\n";
+  Indent(out, 3);
+  out << "<xs:attribute name=\"prefix\" type=\"xs:string\"/>\n";
+  Indent(out, 2);
+  out << "</xs:complexType>\n";
+  Indent(out, 1);
+  out << "</xs:element>\n";
+
+  out << "\n  <!-- Root element -->\n";
+
+  // Emit the <mujoco> root manually so we can rename top-level <body> →
+  // <worldbody> (mjXSchema::NameMatch handles this at level==1).
+  Indent(out, 1);
+  out << "<xs:element name=\"" << root.name << "\">\n";
+  Indent(out, 2);
+  out << "<xs:complexType>\n";
+  Indent(out, 3);
+  out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
+  for (const Node& child : root.children) {
+    const char* override_name =
+        (std::string(child.name) == "body") ? "worldbody" : nullptr;
+    EmitElementInternal(out, child, 4, /*top_level=*/false, override_name);
+  }
+  Indent(out, 4);
+  out << "<xs:element ref=\"include\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
+  Indent(out, 3);
+  out << "</xs:choice>\n";
+  for (const char* a : root.attrs) {
+    EmitAttribute(out, 3, root.name, a);
+  }
+  Indent(out, 2);
+  out << "</xs:complexType>\n";
+  Indent(out, 1);
+  out << "</xs:element>\n";
+
+  out << "</xs:schema>\n";
+}
+
+}  // namespace mujoco

--- a/src/xml/xml_native_schema.cc
+++ b/src/xml/xml_native_schema.cc
@@ -14,1170 +14,47 @@
 
 // XSD generator for MJCF.
 //
-// The MJCF language is described in three places inside this directory:
-//   1. MJCF[]   (xml_native_reader.cc) -- element tree + attribute names.
-//   2. *_map    (xml_native_reader.cc) -- enum value sets.
-//   3. OneX()   (xml_native_reader.cc) -- the ReadAttr*/MapValue calls that
-//                                        assign types and enum maps to attrs.
-//
-// (1) and (2) are already declarative and reused directly. (3) is not, so
-// this file adds a single flat table `kMjXAttrTable` mirroring the type
-// decisions made in the OneX() parsers.
-//
-// ---------------------------------------------------------------------------
-// MAINTENANCE: if you add/rename an attribute in the parser, you also need
-// to touch this file. Concretely, when you edit `OneX()` in
-// xml_native_reader.cc (or add an entry to MJCF[]):
-//
-//   * add a row to `kMjXAttrTable` below (one per (element, attr) pair)
-//     matching the ReadAttr*/MapValue call you wrote -- this is the only
-//     per-attribute maintenance burden.
-//   * if you added a new enum map, declare it `extern` at the top of the
-//     reader (most already are), and forward-declare it at the top of this
-//     file alongside the existing ones.
-//   * document the attribute under `.. _<element>-<attr>:` in
-//     doc/XMLreference.rst (default value + prose) -- the enrichment pass in
-//     doc/mjcf_schema_enrich.py picks this up and injects it as
-//     <xs:annotation> on the generated xs:attribute.
+// Walks MJCF[] from xml_native_reader.h for tree structure, and consults
+// kMjXAttrTable (also in xml_native_reader.cc) for per-attribute type info.
 //
 // Release pipeline (regenerating doc/mjcf.xsd):
 //   $ cmake --build build --target xmlschema
 //   $ ./build/bin/xmlschema /tmp/raw.xsd
 //   $ python3 doc/mjcf_schema_enrich.py --in /tmp/raw.xsd \
 //         --rst doc/XMLreference.rst --out doc/mjcf.xsd --strict --report
-//
-// `--strict` exits non-zero if the enricher finds drift between the C table,
-// the RST, and the schema -- wire this into CI to catch stale docs.
 
 #include "xml/xml_native_schema.h"
 
+#include <cstddef>
+#include <cstring>
 #include <sstream>
 #include <set>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include "xml/xml_native_reader.h"  // exports MJCF[] and nMJCF
-#include "xml/xml_util.h"           // exports mjMap
+#include "xml/xml_native_reader.h"  // MJCF[], nMJCF, mjXAttr*, kMjXAttrTable
+#include "xml/xml_util.h"           // mjMap
 
-// Enum-map symbols and their sizes live at global scope in xml_native_reader.cc
-// (inside a nameless namespace that closes before they are defined). Redeclare
-// them here so the linker resolves them.
-extern const mjMap coordinate_map[2];
-extern const mjMap angle_map[2];
-extern const mjMap bool_map[2];
-extern const mjMap fluid_map[2];
-extern const mjMap TFAuto_map[3];
-extern const mjMap enable_map[2];
-extern const mjMap bodysleep_map[];
-extern const int   bodysleep_sz;
-extern const mjMap joint_map[];
-extern const int   joint_sz;
-extern const mjMap geom_map[];
-extern const mjMap projection_map[];
-extern const int   projection_sz;
-extern const mjMap camlight_map[];
-extern const int   camlight_sz;
-extern const mjMap lighttype_map[];
-extern const int   lighttype_sz;
-extern const mjMap texrole_map[];
-extern const int   texrole_sz;
-extern const mjMap integrator_map[];
-extern const int   integrator_sz;
-extern const mjMap cone_map[];
-extern const int   cone_sz;
-extern const mjMap jac_map[];
-extern const int   jac_sz;
-extern const mjMap solver_map[];
-extern const int   solver_sz;
-extern const mjMap equality_map[];
-extern const int   equality_sz;
-extern const mjMap texture_map[];
-extern const int   texture_sz;
-extern const mjMap colorspace_map[];
-extern const int   colorspace_sz;
-extern const mjMap builtin_map[];
-extern const int   builtin_sz;
-extern const mjMap mark_map[];
-extern const int   mark_sz;
-extern const mjMap dyn_map[];
-extern const int   dyn_sz;
-extern const mjMap dcmotorinput_map[];
-extern const int   dcmotorinput_sz;
-extern const mjMap gain_map[];
-extern const int   gain_sz;
-extern const mjMap bias_map[];
-extern const int   bias_sz;
-extern const mjMap interp_map[];
-extern const int   interp_sz;
-extern const mjMap stage_map[];
-extern const int   stage_sz;
-extern const mjMap datatype_map[];
-extern const int   datatype_sz;
-extern const mjMap condata_map[];
-extern const mjMap raydata_map[];
-extern const mjMap camout_map[];
-extern const int   camout_sz;
-extern const mjMap reduce_map[];
-extern const int   reduce_sz;
-extern const mjMap lrmode_map[];
-extern const int   lrmode_sz;
-extern const mjMap comp_map[];
-extern const mjMap jkind_map[1];
-extern const mjMap shape_map[];
-extern const mjMap meshtype_map[2];
-extern const mjMap meshinertia_map[4];
-extern const mjMap meshbuiltin_map[];
-extern const int   meshbuiltin_sz;
-extern const mjMap fcomp_map[];
-extern const mjMap fdof_map[];
-extern const mjMap flexself_map[5];
-extern const mjMap elastic2d_map[5];
-extern const mjMap flexeq_map[4];
-
-// Literal sizes for the few remaining maps that are sized via mjN* enum
-// constants; kept local rather than pulling in extra headers.
-namespace {
-constexpr int kGeomTypesSz  = 9;   // mjNGEOMTYPES
-constexpr int kCompTypesSz  = 6;   // mjNCOMPTYPES
-constexpr int kFcompTypesSz = 10;  // mjNFCOMPTYPES
-constexpr int kFcompDofsSz  = 4;   // mjNFCOMPDOFS
-constexpr int kNDYN         = 10;  // mjNDYN
-constexpr int kNGAIN        = 10;  // mjNGAIN
-constexpr int kNBIAS        = 10;  // mjNBIAS
-}  // namespace
 
 namespace mujoco {
-
-
-//---------------------------------- Attribute type table ------------------------------------------
-
-// clang-format off
-const mjXAttr kMjXAttrTable[] = {
-
-  //-------------------------------- <mujoco> ------------------------------------------------------
-  {"mujoco", "model", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <compiler> ----------------------------------------------------
-  {"compiler", "autolimits",        kMjXEnum,   0, bool_map,        2},
-  {"compiler", "boundmass",         kMjXReal,   0, nullptr,         0},
-  {"compiler", "boundinertia",      kMjXReal,   0, nullptr,         0},
-  {"compiler", "settotalmass",      kMjXReal,   0, nullptr,         0},
-  {"compiler", "balanceinertia",    kMjXEnum,   0, bool_map,        2},
-  {"compiler", "strippath",         kMjXEnum,   0, bool_map,        2},
-  {"compiler", "coordinate",        kMjXEnum,   0, coordinate_map,  2},
-  {"compiler", "angle",             kMjXEnum,   0, angle_map,       2},
-  {"compiler", "fitaabb",           kMjXEnum,   0, bool_map,        2},
-  {"compiler", "eulerseq",          kMjXString, 0, nullptr,         0},
-  {"compiler", "meshdir",           kMjXString, 0, nullptr,         0},
-  {"compiler", "texturedir",        kMjXString, 0, nullptr,         0},
-  {"compiler", "discardvisual",     kMjXEnum,   0, bool_map,        2},
-  {"compiler", "usethread",         kMjXEnum,   0, bool_map,        2},
-  {"compiler", "fusestatic",        kMjXEnum,   0, bool_map,        2},
-  {"compiler", "inertiafromgeom",   kMjXEnum,   0, TFAuto_map,      3},
-  {"compiler", "inertiagrouprange", kMjXIntN,   2, nullptr,         0},
-  {"compiler", "saveinertial",      kMjXEnum,   0, bool_map,        2},
-  {"compiler", "assetdir",          kMjXString, 0, nullptr,         0},
-  {"compiler", "alignfree",         kMjXEnum,   0, bool_map,        2},
-
-  //-------------------------------- <compiler><lengthrange> ---------------------------------------
-  {"lengthrange", "mode",        kMjXEnum, 0, lrmode_map, 4},
-  {"lengthrange", "useexisting", kMjXEnum, 0, bool_map,   2},
-  {"lengthrange", "uselimit",    kMjXEnum, 0, bool_map,   2},
-  {"lengthrange", "accel",       kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "maxforce",    kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "timeconst",   kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "timestep",    kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "inttotal",    kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "interval",    kMjXReal, 0, nullptr,    0},
-  {"lengthrange", "tolrange",    kMjXReal, 0, nullptr,    0},
-
-  //-------------------------------- <option> ------------------------------------------------------
-  {"option", "timestep",             kMjXReal,      0, nullptr,        0},
-  {"option", "impratio",             kMjXReal,      0, nullptr,        0},
-  {"option", "tolerance",            kMjXReal,      0, nullptr,        0},
-  {"option", "ls_tolerance",         kMjXReal,      0, nullptr,        0},
-  {"option", "noslip_tolerance",     kMjXReal,      0, nullptr,        0},
-  {"option", "ccd_tolerance",        kMjXReal,      0, nullptr,        0},
-  {"option", "sleep_tolerance",      kMjXReal,      0, nullptr,        0},
-  {"option", "gravity",              kMjXRealN,     3, nullptr,        0},
-  {"option", "wind",                 kMjXRealN,     3, nullptr,        0},
-  {"option", "magnetic",             kMjXRealN,     3, nullptr,        0},
-  {"option", "density",              kMjXReal,      0, nullptr,        0},
-  {"option", "viscosity",            kMjXReal,      0, nullptr,        0},
-  {"option", "o_margin",             kMjXReal,      0, nullptr,        0},
-  {"option", "o_solref",             kMjXRealUpToN, 2, nullptr,        0},
-  {"option", "o_solimp",             kMjXRealUpToN, 5, nullptr,        0},
-  {"option", "o_friction",           kMjXRealUpToN, 5, nullptr,        0},
-  {"option", "integrator",           kMjXEnum,      0, integrator_map, 4},
-  {"option", "cone",                 kMjXEnum,      0, cone_map,       2},
-  {"option", "jacobian",             kMjXEnum,      0, jac_map,        3},
-  {"option", "solver",               kMjXEnum,      0, solver_map,     3},
-  {"option", "iterations",           kMjXInt,       0, nullptr,        0},
-  {"option", "ls_iterations",        kMjXInt,       0, nullptr,        0},
-  {"option", "noslip_iterations",    kMjXInt,       0, nullptr,        0},
-  {"option", "ccd_iterations",       kMjXInt,       0, nullptr,        0},
-  {"option", "sdf_iterations",       kMjXInt,       0, nullptr,        0},
-  {"option", "sdf_initpoints",       kMjXInt,       0, nullptr,        0},
-  {"option", "actuatorgroupdisable", kMjXIntVec,    0, nullptr,        0},
-
-  //-------------------------------- <option><flag> ------------------------------------------------
-  {"flag", "constraint",   kMjXEnum, 0, enable_map, 2},
-  {"flag", "equality",     kMjXEnum, 0, enable_map, 2},
-  {"flag", "frictionloss", kMjXEnum, 0, enable_map, 2},
-  {"flag", "limit",        kMjXEnum, 0, enable_map, 2},
-  {"flag", "contact",      kMjXEnum, 0, enable_map, 2},
-  {"flag", "spring",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "damper",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "gravity",      kMjXEnum, 0, enable_map, 2},
-  {"flag", "clampctrl",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "warmstart",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "filterparent", kMjXEnum, 0, enable_map, 2},
-  {"flag", "actuation",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "refsafe",      kMjXEnum, 0, enable_map, 2},
-  {"flag", "sensor",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "midphase",     kMjXEnum, 0, enable_map, 2},
-  {"flag", "eulerdamp",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "autoreset",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "nativeccd",    kMjXEnum, 0, enable_map, 2},
-  {"flag", "island",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "override",     kMjXEnum, 0, enable_map, 2},
-  {"flag", "energy",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "fwdinv",       kMjXEnum, 0, enable_map, 2},
-  {"flag", "invdiscrete",  kMjXEnum, 0, enable_map, 2},
-  {"flag", "multiccd",     kMjXEnum, 0, enable_map, 2},
-  {"flag", "sleep",        kMjXEnum, 0, enable_map, 2},
-
-  //-------------------------------- <size> --------------------------------------------------------
-  {"size", "memory",         kMjXString, 0, nullptr, 0},
-  {"size", "njmax",          kMjXInt,    0, nullptr, 0},
-  {"size", "nconmax",        kMjXInt,    0, nullptr, 0},
-  {"size", "nstack",         kMjXInt,    0, nullptr, 0},
-  {"size", "nuserdata",      kMjXInt,    0, nullptr, 0},
-  {"size", "nkey",           kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_body",     kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_jnt",      kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_geom",     kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_site",     kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_cam",      kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_tendon",   kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_actuator", kMjXInt,    0, nullptr, 0},
-  {"size", "nuser_sensor",   kMjXInt,    0, nullptr, 0},
-
-  //-------------------------------- <statistic> ---------------------------------------------------
-  {"statistic", "meaninertia", kMjXReal,  0, nullptr, 0},
-  {"statistic", "meanmass",    kMjXReal,  0, nullptr, 0},
-  {"statistic", "meansize",    kMjXReal,  0, nullptr, 0},
-  {"statistic", "extent",      kMjXReal,  0, nullptr, 0},
-  {"statistic", "center",      kMjXRealN, 3, nullptr, 0},
-
-  //-------------------------------- <visual> subelements ------------------------------------------
-  {"global", "cameraid",         kMjXInt,  0, nullptr,  0},
-  {"global", "orthographic",     kMjXEnum, 0, bool_map, 2},
-  {"global", "fovy",             kMjXReal, 0, nullptr,  0},
-  {"global", "ipd",              kMjXReal, 0, nullptr,  0},
-  {"global", "azimuth",          kMjXReal, 0, nullptr,  0},
-  {"global", "elevation",        kMjXReal, 0, nullptr,  0},
-  {"global", "linewidth",        kMjXReal, 0, nullptr,  0},
-  {"global", "glow",             kMjXReal, 0, nullptr,  0},
-  {"global", "offwidth",         kMjXInt,  0, nullptr,  0},
-  {"global", "offheight",        kMjXInt,  0, nullptr,  0},
-  {"global", "realtime",         kMjXReal, 0, nullptr,  0},
-  {"global", "ellipsoidinertia", kMjXEnum, 0, bool_map, 2},
-  {"global", "bvactive",         kMjXEnum, 0, bool_map, 2},
-
-  {"quality", "shadowsize", kMjXInt, 0, nullptr, 0},
-  {"quality", "offsamples", kMjXInt, 0, nullptr, 0},
-  {"quality", "numslices",  kMjXInt, 0, nullptr, 0},
-  {"quality", "numstacks",  kMjXInt, 0, nullptr, 0},
-  {"quality", "numquads",   kMjXInt, 0, nullptr, 0},
-
-  {"headlight", "ambient",  kMjXRealN, 3, nullptr, 0},
-  {"headlight", "diffuse",  kMjXRealN, 3, nullptr, 0},
-  {"headlight", "specular", kMjXRealN, 3, nullptr, 0},
-  {"headlight", "active",   kMjXInt,   0, nullptr, 0},
-
-  {"map", "stiffness",      kMjXReal, 0, nullptr, 0},
-  {"map", "stiffnessrot",   kMjXReal, 0, nullptr, 0},
-  {"map", "force",          kMjXReal, 0, nullptr, 0},
-  {"map", "torque",         kMjXReal, 0, nullptr, 0},
-  {"map", "alpha",          kMjXReal, 0, nullptr, 0},
-  {"map", "fogstart",       kMjXReal, 0, nullptr, 0},
-  {"map", "fogend",         kMjXReal, 0, nullptr, 0},
-  {"map", "znear",          kMjXReal, 0, nullptr, 0},
-  {"map", "zfar",           kMjXReal, 0, nullptr, 0},
-  {"map", "haze",           kMjXReal, 0, nullptr, 0},
-  {"map", "shadowclip",     kMjXReal, 0, nullptr, 0},
-  {"map", "shadowscale",    kMjXReal, 0, nullptr, 0},
-  {"map", "actuatortendon", kMjXReal, 0, nullptr, 0},
-
-  {"scale", "forcewidth",     kMjXReal, 0, nullptr, 0},
-  {"scale", "contactwidth",   kMjXReal, 0, nullptr, 0},
-  {"scale", "contactheight",  kMjXReal, 0, nullptr, 0},
-  {"scale", "connect",        kMjXReal, 0, nullptr, 0},
-  {"scale", "com",            kMjXReal, 0, nullptr, 0},
-  {"scale", "camera",         kMjXReal, 0, nullptr, 0},
-  {"scale", "light",          kMjXReal, 0, nullptr, 0},
-  {"scale", "selectpoint",    kMjXReal, 0, nullptr, 0},
-  {"scale", "jointlength",    kMjXReal, 0, nullptr, 0},
-  {"scale", "jointwidth",     kMjXReal, 0, nullptr, 0},
-  {"scale", "actuatorlength", kMjXReal, 0, nullptr, 0},
-  {"scale", "actuatorwidth",  kMjXReal, 0, nullptr, 0},
-  {"scale", "framelength",    kMjXReal, 0, nullptr, 0},
-  {"scale", "framewidth",     kMjXReal, 0, nullptr, 0},
-  {"scale", "constraint",     kMjXReal, 0, nullptr, 0},
-  {"scale", "slidercrank",    kMjXReal, 0, nullptr, 0},
-  {"scale", "frustum",        kMjXReal, 0, nullptr, 0},
-
-  {"rgba", "fog",              kMjXRealN, 4, nullptr, 0},
-  {"rgba", "haze",             kMjXRealN, 4, nullptr, 0},
-  {"rgba", "force",            kMjXRealN, 4, nullptr, 0},
-  {"rgba", "inertia",          kMjXRealN, 4, nullptr, 0},
-  {"rgba", "joint",            kMjXRealN, 4, nullptr, 0},
-  {"rgba", "actuator",         kMjXRealN, 4, nullptr, 0},
-  {"rgba", "actuatornegative", kMjXRealN, 4, nullptr, 0},
-  {"rgba", "actuatorpositive", kMjXRealN, 4, nullptr, 0},
-  {"rgba", "com",              kMjXRealN, 4, nullptr, 0},
-  {"rgba", "camera",           kMjXRealN, 4, nullptr, 0},
-  {"rgba", "light",            kMjXRealN, 4, nullptr, 0},
-  {"rgba", "selectpoint",      kMjXRealN, 4, nullptr, 0},
-  {"rgba", "connect",          kMjXRealN, 4, nullptr, 0},
-  {"rgba", "contactpoint",     kMjXRealN, 4, nullptr, 0},
-  {"rgba", "contactforce",     kMjXRealN, 4, nullptr, 0},
-  {"rgba", "contactfriction",  kMjXRealN, 4, nullptr, 0},
-  {"rgba", "contacttorque",    kMjXRealN, 4, nullptr, 0},
-  {"rgba", "contactgap",       kMjXRealN, 4, nullptr, 0},
-  {"rgba", "rangefinder",      kMjXRealN, 4, nullptr, 0},
-  {"rgba", "constraint",       kMjXRealN, 4, nullptr, 0},
-  {"rgba", "slidercrank",      kMjXRealN, 4, nullptr, 0},
-  {"rgba", "crankbroken",      kMjXRealN, 4, nullptr, 0},
-  {"rgba", "frustum",          kMjXRealN, 4, nullptr, 0},
-  {"rgba", "bv",               kMjXRealN, 4, nullptr, 0},
-  {"rgba", "bvactive",         kMjXRealN, 4, nullptr, 0},
-
-  //-------------------------------- <default> -----------------------------------------------------
-  {"default", "class", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <mesh> (asset + default) -------------------------------------
-  {"mesh", "name",         kMjXString,    0, nullptr,          0},
-  {"mesh", "class",        kMjXString,    0, nullptr,          0},
-  {"mesh", "content_type", kMjXString,    0, nullptr,          0},
-  {"mesh", "file",         kMjXString,    0, nullptr,          0},
-  {"mesh", "vertex",       kMjXRealVec,   0, nullptr,          0},
-  {"mesh", "normal",       kMjXRealVec,   0, nullptr,          0},
-  {"mesh", "texcoord",     kMjXRealVec,   0, nullptr,          0},
-  {"mesh", "face",         kMjXIntVec,    0, nullptr,          0},
-  {"mesh", "refpos",       kMjXRealN,     3, nullptr,          0},
-  {"mesh", "refquat",      kMjXRealN,     4, nullptr,          0},
-  {"mesh", "scale",        kMjXRealN,     3, nullptr,          0},
-  {"mesh", "smoothnormal", kMjXEnum,      0, bool_map,         2},
-  {"mesh", "maxhullvert",  kMjXInt,       0, nullptr,          0},
-  {"mesh", "inertia",      kMjXEnum,      0, meshinertia_map,  4},
-  {"mesh", "builtin",      kMjXEnum,      0, meshbuiltin_map,  8},
-  {"mesh", "params",       kMjXRealVec,   0, nullptr,          0},
-  {"mesh", "material",     kMjXString,    0, nullptr,          0},
-
-  //-------------------------------- <material> (asset + default) ----------------------------------
-  {"material", "name",        kMjXString, 0, nullptr,  0},
-  {"material", "class",       kMjXString, 0, nullptr,  0},
-  {"material", "texture",     kMjXString, 0, nullptr,  0},
-  {"material", "texrepeat",   kMjXRealN,  2, nullptr,  0},
-  {"material", "texuniform",  kMjXEnum,   0, bool_map, 2},
-  {"material", "emission",    kMjXReal,   0, nullptr,  0},
-  {"material", "specular",    kMjXReal,   0, nullptr,  0},
-  {"material", "shininess",   kMjXReal,   0, nullptr,  0},
-  {"material", "reflectance", kMjXReal,   0, nullptr,  0},
-  {"material", "metallic",    kMjXReal,   0, nullptr,  0},
-  {"material", "roughness",   kMjXReal,   0, nullptr,  0},
-  {"material", "rgba",        kMjXRealN,  4, nullptr,  0},
-
-  //-------------------------------- <material><layer> ---------------------------------------------
-  {"layer", "texture", kMjXString, 0, nullptr,     0},
-  {"layer", "role",    kMjXEnum,   0, texrole_map, 9},
-
-  //-------------------------------- <joint> (body + default) --------------------------------------
-  {"joint", "name",              kMjXString,    0, nullptr,    0},
-  {"joint", "class",             kMjXString,    0, nullptr,    0},
-  {"joint", "type",              kMjXEnum,      0, joint_map,  4},
-  {"joint", "group",             kMjXInt,       0, nullptr,    0},
-  {"joint", "pos",               kMjXRealN,     3, nullptr,    0},
-  {"joint", "axis",              kMjXRealN,     3, nullptr,    0},
-  {"joint", "springdamper",      kMjXRealN,     2, nullptr,    0},
-  {"joint", "limited",           kMjXEnum,      0, TFAuto_map, 3},
-  {"joint", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
-  {"joint", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
-  {"joint", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
-  {"joint", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
-  {"joint", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
-  {"joint", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
-  {"joint", "range",             kMjXRealN,     2, nullptr,    0},
-  {"joint", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
-  {"joint", "actuatorgravcomp",  kMjXEnum,      0, bool_map,   2},
-  {"joint", "margin",            kMjXReal,      0, nullptr,    0},
-  {"joint", "ref",               kMjXReal,      0, nullptr,    0},
-  {"joint", "springref",         kMjXReal,      0, nullptr,    0},
-  {"joint", "armature",          kMjXReal,      0, nullptr,    0},
-  {"joint", "damping",           kMjXRealUpToN, 3, nullptr,    0},
-  {"joint", "frictionloss",      kMjXReal,      0, nullptr,    0},
-  {"joint", "user",              kMjXRealVec,   0, nullptr,    0},
-
-  //-------------------------------- <freejoint> (body) --------------------------------------------
-  {"freejoint", "name",  kMjXString, 0, nullptr,    0},
-  {"freejoint", "group", kMjXInt,    0, nullptr,    0},
-  {"freejoint", "align", kMjXEnum,   0, TFAuto_map, 3},
-
-  //-------------------------------- <geom> (body + default) ---------------------------------------
-  {"geom", "name",         kMjXString,    0, nullptr,   0},
-  {"geom", "class",        kMjXString,    0, nullptr,   0},
-  {"geom", "type",         kMjXEnum,      0, geom_map,  kGeomTypesSz},
-  {"geom", "pos",          kMjXRealN,     3, nullptr,   0},
-  {"geom", "quat",         kMjXRealN,     4, nullptr,   0},
-  {"geom", "axisangle",    kMjXRealN,     4, nullptr,   0},
-  {"geom", "xyaxes",       kMjXRealN,     6, nullptr,   0},
-  {"geom", "zaxis",        kMjXRealN,     3, nullptr,   0},
-  {"geom", "euler",        kMjXRealN,     3, nullptr,   0},
-  {"geom", "contype",      kMjXInt,       0, nullptr,   0},
-  {"geom", "conaffinity",  kMjXInt,       0, nullptr,   0},
-  {"geom", "condim",       kMjXInt,       0, nullptr,   0},
-  {"geom", "group",        kMjXInt,       0, nullptr,   0},
-  {"geom", "priority",     kMjXInt,       0, nullptr,   0},
-  {"geom", "size",         kMjXRealUpToN, 3, nullptr,   0},
-  {"geom", "material",     kMjXString,    0, nullptr,   0},
-  {"geom", "friction",     kMjXRealUpToN, 3, nullptr,   0},
-  {"geom", "mass",         kMjXReal,      0, nullptr,   0},
-  {"geom", "density",      kMjXReal,      0, nullptr,   0},
-  {"geom", "shellinertia", kMjXEnum,      0, meshtype_map, 2},
-  {"geom", "solmix",       kMjXReal,      0, nullptr,   0},
-  {"geom", "solref",       kMjXRealUpToN, 2, nullptr,   0},
-  {"geom", "solimp",       kMjXRealUpToN, 5, nullptr,   0},
-  {"geom", "margin",       kMjXReal,      0, nullptr,   0},
-  {"geom", "gap",          kMjXReal,      0, nullptr,   0},
-  {"geom", "fromto",       kMjXRealN,     6, nullptr,   0},
-  {"geom", "hfield",       kMjXString,    0, nullptr,   0},
-  {"geom", "mesh",         kMjXString,    0, nullptr,   0},
-  {"geom", "fitscale",     kMjXReal,      0, nullptr,   0},
-  {"geom", "rgba",         kMjXRealN,     4, nullptr,   0},
-  {"geom", "fluidshape",   kMjXEnum,      0, fluid_map, 2},
-  {"geom", "fluidcoef",    kMjXRealUpToN, 5, nullptr,   0},
-  {"geom", "user",         kMjXRealVec,   0, nullptr,   0},
-
-  //-------------------------------- <site> (body + default) ---------------------------------------
-  {"site", "name",      kMjXString,    0, nullptr,  0},
-  {"site", "class",     kMjXString,    0, nullptr,  0},
-  {"site", "type",      kMjXEnum,      0, geom_map, kGeomTypesSz},
-  {"site", "group",     kMjXInt,       0, nullptr,  0},
-  {"site", "pos",       kMjXRealN,     3, nullptr,  0},
-  {"site", "quat",      kMjXRealN,     4, nullptr,  0},
-  {"site", "material",  kMjXString,    0, nullptr,  0},
-  {"site", "size",      kMjXRealUpToN, 3, nullptr,  0},
-  {"site", "fromto",    kMjXRealN,     6, nullptr,  0},
-  {"site", "axisangle", kMjXRealN,     4, nullptr,  0},
-  {"site", "xyaxes",    kMjXRealN,     6, nullptr,  0},
-  {"site", "zaxis",     kMjXRealN,     3, nullptr,  0},
-  {"site", "euler",     kMjXRealN,     3, nullptr,  0},
-  {"site", "rgba",      kMjXRealN,     4, nullptr,  0},
-  {"site", "user",      kMjXRealVec,   0, nullptr,  0},
-
-  //-------------------------------- <camera> (body + default) -------------------------------------
-  {"camera", "name",           kMjXString,  0, nullptr,        0},
-  {"camera", "class",          kMjXString,  0, nullptr,        0},
-  {"camera", "projection",     kMjXEnum,    0, projection_map, 2},
-  {"camera", "fovy",           kMjXReal,    0, nullptr,        0},
-  {"camera", "ipd",            kMjXReal,    0, nullptr,        0},
-  {"camera", "resolution",     kMjXIntN,    2, nullptr,        0},
-  {"camera", "output",         kMjXString,  0, nullptr,        0},  // space-separated bitflags
-  {"camera", "pos",            kMjXRealN,   3, nullptr,        0},
-  {"camera", "quat",           kMjXRealN,   4, nullptr,        0},
-  {"camera", "axisangle",      kMjXRealN,   4, nullptr,        0},
-  {"camera", "xyaxes",         kMjXRealN,   6, nullptr,        0},
-  {"camera", "zaxis",          kMjXRealN,   3, nullptr,        0},
-  {"camera", "euler",          kMjXRealN,   3, nullptr,        0},
-  {"camera", "mode",           kMjXEnum,    0, camlight_map,   5},
-  {"camera", "target",         kMjXString,  0, nullptr,        0},
-  {"camera", "focal",          kMjXRealN,   2, nullptr,        0},
-  {"camera", "focalpixel",     kMjXRealN,   2, nullptr,        0},
-  {"camera", "principal",      kMjXRealN,   2, nullptr,        0},
-  {"camera", "principalpixel", kMjXRealN,   2, nullptr,        0},
-  {"camera", "sensorsize",     kMjXRealN,   2, nullptr,        0},
-  {"camera", "user",           kMjXRealVec, 0, nullptr,        0},
-
-  //-------------------------------- <light> (body + default) --------------------------------------
-  {"light", "name",        kMjXString, 0, nullptr,       0},
-  {"light", "class",       kMjXString, 0, nullptr,       0},
-  {"light", "pos",         kMjXRealN,  3, nullptr,       0},
-  {"light", "dir",         kMjXRealN,  3, nullptr,       0},
-  {"light", "bulbradius",  kMjXReal,   0, nullptr,       0},
-  {"light", "intensity",   kMjXReal,   0, nullptr,       0},
-  {"light", "range",       kMjXReal,   0, nullptr,       0},
-  {"light", "directional", kMjXEnum,   0, bool_map,      2},
-  {"light", "type",        kMjXEnum,   0, lighttype_map, 4},
-  {"light", "castshadow",  kMjXEnum,   0, bool_map,      2},
-  {"light", "active",      kMjXEnum,   0, bool_map,      2},
-  {"light", "attenuation", kMjXRealN,  3, nullptr,       0},
-  {"light", "cutoff",      kMjXReal,   0, nullptr,       0},
-  {"light", "exponent",    kMjXReal,   0, nullptr,       0},
-  {"light", "ambient",     kMjXRealN,  3, nullptr,       0},
-  {"light", "diffuse",     kMjXRealN,  3, nullptr,       0},
-  {"light", "specular",    kMjXRealN,  3, nullptr,       0},
-  {"light", "mode",        kMjXEnum,   0, camlight_map,  5},
-  {"light", "target",      kMjXString, 0, nullptr,       0},
-  {"light", "texture",     kMjXString, 0, nullptr,       0},
-
-  //-------------------------------- <pair> (default + contact) -----------------------------------
-  {"pair", "name",           kMjXString,    0, nullptr, 0},
-  {"pair", "class",          kMjXString,    0, nullptr, 0},
-  {"pair", "geom1",          kMjXString,    0, nullptr, 0},
-  {"pair", "geom2",          kMjXString,    0, nullptr, 0},
-  {"pair", "condim",         kMjXInt,       0, nullptr, 0},
-  {"pair", "friction",       kMjXRealUpToN, 5, nullptr, 0},
-  {"pair", "solref",         kMjXRealUpToN, 2, nullptr, 0},
-  {"pair", "solreffriction", kMjXRealUpToN, 2, nullptr, 0},
-  {"pair", "solimp",         kMjXRealUpToN, 5, nullptr, 0},
-  {"pair", "margin",         kMjXReal,      0, nullptr, 0},
-  {"pair", "gap",            kMjXReal,      0, nullptr, 0},
-
-  //-------------------------------- <equality> in <default> --------------------------------------
-  {"equality", "active", kMjXEnum,      0, bool_map, 2},
-  {"equality", "solref", kMjXRealUpToN, 2, nullptr,  0},
-  {"equality", "solimp", kMjXRealUpToN, 5, nullptr,  0},
-
-  //-------------------------------- <tendon> (default + top-level tendon is a complex section) ---
-  // The <tendon> row in MJCF[] under <default> holds only tendon defaults.
-  // These attrs are shared by <spatial> and <fixed> when emitted from <tendon>.
-  {"tendon", "group",              kMjXInt,       0, nullptr,    0},
-  {"tendon", "limited",            kMjXEnum,      0, TFAuto_map, 3},
-  {"tendon", "range",              kMjXRealN,     2, nullptr,    0},
-  {"tendon", "solreflimit",        kMjXRealUpToN, 2, nullptr,    0},
-  {"tendon", "solimplimit",        kMjXRealUpToN, 5, nullptr,    0},
-  {"tendon", "solreffriction",     kMjXRealUpToN, 2, nullptr,    0},
-  {"tendon", "solimpfriction",     kMjXRealUpToN, 5, nullptr,    0},
-  {"tendon", "frictionloss",       kMjXReal,      0, nullptr,    0},
-  {"tendon", "springlength",       kMjXRealUpToN, 2, nullptr,    0},
-  {"tendon", "width",              kMjXReal,      0, nullptr,    0},
-  {"tendon", "material",           kMjXString,    0, nullptr,    0},
-  {"tendon", "margin",             kMjXReal,      0, nullptr,    0},
-  {"tendon", "stiffness",          kMjXRealUpToN, 3, nullptr,    0},
-  {"tendon", "damping",            kMjXRealUpToN, 3, nullptr,    0},
-  {"tendon", "rgba",               kMjXRealN,     4, nullptr,    0},
-  {"tendon", "user",               kMjXRealVec,   0, nullptr,    0},
-
-  //-------------------------------- <spatial> (tendon section) -----------------------------------
-  {"spatial", "name",              kMjXString,    0, nullptr,    0},
-  {"spatial", "class",             kMjXString,    0, nullptr,    0},
-  {"spatial", "group",             kMjXInt,       0, nullptr,    0},
-  {"spatial", "limited",           kMjXEnum,      0, TFAuto_map, 3},
-  {"spatial", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
-  {"spatial", "range",             kMjXRealN,     2, nullptr,    0},
-  {"spatial", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
-  {"spatial", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
-  {"spatial", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
-  {"spatial", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
-  {"spatial", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
-  {"spatial", "frictionloss",      kMjXReal,      0, nullptr,    0},
-  {"spatial", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
-  {"spatial", "width",             kMjXReal,      0, nullptr,    0},
-  {"spatial", "material",          kMjXString,    0, nullptr,    0},
-  {"spatial", "margin",            kMjXReal,      0, nullptr,    0},
-  {"spatial", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
-  {"spatial", "damping",           kMjXRealUpToN, 3, nullptr,    0},
-  {"spatial", "armature",          kMjXReal,      0, nullptr,    0},
-  {"spatial", "rgba",              kMjXRealN,     4, nullptr,    0},
-  {"spatial", "user",              kMjXRealVec,   0, nullptr,    0},
-
-  //-------------------------------- <fixed> (tendon section) -------------------------------------
-  {"fixed", "name",              kMjXString,    0, nullptr,    0},
-  {"fixed", "class",             kMjXString,    0, nullptr,    0},
-  {"fixed", "group",             kMjXInt,       0, nullptr,    0},
-  {"fixed", "limited",           kMjXEnum,      0, TFAuto_map, 3},
-  {"fixed", "actuatorfrclimited",kMjXEnum,      0, TFAuto_map, 3},
-  {"fixed", "range",             kMjXRealN,     2, nullptr,    0},
-  {"fixed", "actuatorfrcrange",  kMjXRealN,     2, nullptr,    0},
-  {"fixed", "solreflimit",       kMjXRealUpToN, 2, nullptr,    0},
-  {"fixed", "solimplimit",       kMjXRealUpToN, 5, nullptr,    0},
-  {"fixed", "solreffriction",    kMjXRealUpToN, 2, nullptr,    0},
-  {"fixed", "solimpfriction",    kMjXRealUpToN, 5, nullptr,    0},
-  {"fixed", "frictionloss",      kMjXReal,      0, nullptr,    0},
-  {"fixed", "springlength",      kMjXRealUpToN, 2, nullptr,    0},
-  {"fixed", "margin",            kMjXReal,      0, nullptr,    0},
-  {"fixed", "stiffness",         kMjXRealUpToN, 3, nullptr,    0},
-  {"fixed", "damping",           kMjXRealUpToN, 3, nullptr,    0},
-  {"fixed", "armature",          kMjXReal,      0, nullptr,    0},
-  {"fixed", "user",              kMjXRealVec,   0, nullptr,    0},
-
-  //-------------------------------- <spatial> children: site/geom/pulley -------------------------
-  // Inside <spatial>, children are <site site=...>/<geom geom=... sidesite=...>/<pulley divisor=...>
-  // However the child element name "site" collides with top-level <site>, and our lookup is by
-  // (element, attr). We accept the collision: "site" attribute "site" is unique to the wrap,
-  // but "geom" attribute "geom" is also unique.
-  {"pulley", "divisor", kMjXReal,   0, nullptr, 0},
-
-  //-------------------------------- <fixed><joint> (tendon wrap) ---------------------------------
-  // The <joint> child of <fixed> has attrs {joint, coef}. Our top-level <joint> already uses
-  // "name"/"class"/... so the string refs "joint" and real "coef" are distinct here; map them.
-  {"joint", "coef",    kMjXReal,   0, nullptr, 0},
-
-  //-------------------------------- actuator (shared attrs) --------------------------------------
-  // Attributes common to all actuator shortcut types; listed per element so per-(element,attr)
-  // lookups work.
-#define ACT_COMMON(elem) \
-  {elem, "name",          kMjXString,    0, nullptr,    0}, \
-  {elem, "class",         kMjXString,    0, nullptr,    0}, \
-  {elem, "group",         kMjXInt,       0, nullptr,    0}, \
-  {elem, "nsample",       kMjXInt,       0, nullptr,    0}, \
-  {elem, "interp",        kMjXEnum,      0, interp_map, 3}, \
-  {elem, "delay",         kMjXReal,      0, nullptr,    0}, \
-  {elem, "ctrllimited",   kMjXEnum,      0, TFAuto_map, 3}, \
-  {elem, "forcelimited",  kMjXEnum,      0, TFAuto_map, 3}, \
-  {elem, "ctrlrange",     kMjXRealN,     2, nullptr,    0}, \
-  {elem, "forcerange",    kMjXRealN,     2, nullptr,    0}, \
-  {elem, "lengthrange",   kMjXRealN,     2, nullptr,    0}, \
-  {elem, "gear",          kMjXRealUpToN, 6, nullptr,    0}, \
-  {elem, "damping",       kMjXRealUpToN, 3, nullptr,    0}, \
-  {elem, "armature",      kMjXReal,      0, nullptr,    0}, \
-  {elem, "cranklength",   kMjXReal,      0, nullptr,    0}, \
-  {elem, "user",          kMjXRealVec,   0, nullptr,    0}, \
-  {elem, "joint",         kMjXString,    0, nullptr,    0}, \
-  {elem, "jointinparent", kMjXString,    0, nullptr,    0}, \
-  {elem, "tendon",        kMjXString,    0, nullptr,    0}, \
-  {elem, "slidersite",    kMjXString,    0, nullptr,    0}, \
-  {elem, "cranksite",     kMjXString,    0, nullptr,    0}, \
-  {elem, "site",          kMjXString,    0, nullptr,    0}, \
-  {elem, "refsite",       kMjXString,    0, nullptr,    0}, \
-  {elem, "body",          kMjXString,    0, nullptr,    0}
-
-  ACT_COMMON("general"),
-  {"general", "actlimited", kMjXEnum,      0, TFAuto_map, 3},
-  {"general", "actrange",   kMjXRealN,     2, nullptr,    0},
-  {"general", "actdim",     kMjXInt,       0, nullptr,    0},
-  {"general", "dyntype",    kMjXEnum,      0, dyn_map,    7},
-  {"general", "gaintype",   kMjXEnum,      0, gain_map,   5},
-  {"general", "biastype",   kMjXEnum,      0, bias_map,   5},
-  {"general", "dynprm",     kMjXRealUpToN, kNDYN,  nullptr, 0},
-  {"general", "gainprm",    kMjXRealUpToN, kNGAIN, nullptr, 0},
-  {"general", "biasprm",    kMjXRealUpToN, kNBIAS, nullptr, 0},
-  {"general", "actearly",   kMjXEnum,      0, bool_map, 2},
-
-  ACT_COMMON("motor"),
-
-  ACT_COMMON("position"),
-  {"position", "kp",           kMjXReal, 0, nullptr, 0},
-  {"position", "kv",           kMjXReal, 0, nullptr, 0},
-  {"position", "dampratio",    kMjXReal, 0, nullptr, 0},
-  {"position", "timeconst",    kMjXReal, 0, nullptr, 0},
-  {"position", "inheritrange", kMjXReal, 0, nullptr, 0},
-
-  ACT_COMMON("velocity"),
-  {"velocity", "kv", kMjXReal, 0, nullptr, 0},
-
-  ACT_COMMON("intvelocity"),
-  {"intvelocity", "kp",           kMjXReal,  0, nullptr, 0},
-  {"intvelocity", "kv",           kMjXReal,  0, nullptr, 0},
-  {"intvelocity", "dampratio",    kMjXReal,  0, nullptr, 0},
-  {"intvelocity", "actrange",     kMjXRealN, 2, nullptr, 0},
-  {"intvelocity", "inheritrange", kMjXReal,  0, nullptr, 0},
-
-  ACT_COMMON("damper"),
-  {"damper", "kv", kMjXReal, 0, nullptr, 0},
-
-  ACT_COMMON("cylinder"),
-  {"cylinder", "timeconst", kMjXReal,  0, nullptr, 0},
-  {"cylinder", "area",      kMjXReal,  0, nullptr, 0},
-  {"cylinder", "diameter",  kMjXReal,  0, nullptr, 0},
-  {"cylinder", "bias",      kMjXRealN, 3, nullptr, 0},
-
-  ACT_COMMON("muscle"),
-  {"muscle", "timeconst", kMjXRealN, 2, nullptr, 0},
-  {"muscle", "tausmooth", kMjXReal,  0, nullptr, 0},
-  {"muscle", "range",     kMjXRealN, 2, nullptr, 0},
-  {"muscle", "force",     kMjXReal,  0, nullptr, 0},
-  {"muscle", "scale",     kMjXReal,  0, nullptr, 0},
-  {"muscle", "lmin",      kMjXReal,  0, nullptr, 0},
-  {"muscle", "lmax",      kMjXReal,  0, nullptr, 0},
-  {"muscle", "vmax",      kMjXReal,  0, nullptr, 0},
-  {"muscle", "fpmax",     kMjXReal,  0, nullptr, 0},
-  {"muscle", "fvmax",     kMjXReal,  0, nullptr, 0},
-
-  // adhesion doesn't use full ACT_COMMON (no joint/tendon/etc), so list manually.
-  {"adhesion", "name",         kMjXString,    0, nullptr,    0},
-  {"adhesion", "class",        kMjXString,    0, nullptr,    0},
-  {"adhesion", "group",        kMjXInt,       0, nullptr,    0},
-  {"adhesion", "nsample",      kMjXInt,       0, nullptr,    0},
-  {"adhesion", "interp",       kMjXEnum,      0, interp_map, 3},
-  {"adhesion", "delay",        kMjXReal,      0, nullptr,    0},
-  {"adhesion", "forcelimited", kMjXEnum,      0, TFAuto_map, 3},
-  {"adhesion", "ctrlrange",    kMjXRealN,     2, nullptr,    0},
-  {"adhesion", "forcerange",   kMjXRealN,     2, nullptr,    0},
-  {"adhesion", "user",         kMjXRealVec,   0, nullptr,    0},
-  {"adhesion", "body",         kMjXString,    0, nullptr,    0},
-  {"adhesion", "gain",         kMjXReal,      0, nullptr,    0},
-
-  ACT_COMMON("dcmotor"),
-  {"dcmotor", "motorconst", kMjXRealUpToN, 2, nullptr,         0},
-  {"dcmotor", "resistance", kMjXReal,      0, nullptr,         0},
-  {"dcmotor", "nominal",    kMjXRealUpToN, 3, nullptr,         0},
-  {"dcmotor", "saturation", kMjXRealUpToN, 3, nullptr,         0},
-  {"dcmotor", "inductance", kMjXRealUpToN, 2, nullptr,         0},
-  {"dcmotor", "cogging",    kMjXRealUpToN, 3, nullptr,         0},
-  {"dcmotor", "controller", kMjXRealUpToN, 6, nullptr,         0},
-  {"dcmotor", "thermal",    kMjXRealUpToN, 6, nullptr,         0},
-  {"dcmotor", "lugre",      kMjXRealUpToN, 5, nullptr,         0},
-  {"dcmotor", "input",      kMjXEnum,      0, dcmotorinput_map, 3},
-
-#undef ACT_COMMON
-
-  //-------------------------------- <extension> ---------------------------------------------------
-  {"plugin",   "plugin",   kMjXString, 0, nullptr, 0},
-  {"plugin",   "instance", kMjXString, 0, nullptr, 0},
-  {"plugin",   "name",     kMjXString, 0, nullptr, 0},
-  {"plugin",   "class",    kMjXString, 0, nullptr, 0},
-  {"instance", "name",     kMjXString, 0, nullptr, 0},
-  {"config",   "key",      kMjXString, 0, nullptr, 0},
-  {"config",   "value",    kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <custom> ------------------------------------------------------
-  {"numeric", "name", kMjXString,  0, nullptr, 0},
-  {"numeric", "size", kMjXInt,     0, nullptr, 0},
-  {"numeric", "data", kMjXRealVec, 0, nullptr, 0},
-
-  {"text",    "name", kMjXString,  0, nullptr, 0},
-  {"text",    "data", kMjXString,  0, nullptr, 0},
-
-  {"tuple",   "name",    kMjXString, 0, nullptr, 0},
-  {"element", "objtype", kMjXString, 0, nullptr, 0},
-  {"element", "objname", kMjXString, 0, nullptr, 0},
-  {"element", "prm",     kMjXReal,   0, nullptr, 0},
-
-  //-------------------------------- <asset><hfield> -----------------------------------------------
-  {"hfield", "name",         kMjXString,  0, nullptr, 0},
-  {"hfield", "content_type", kMjXString,  0, nullptr, 0},
-  {"hfield", "file",         kMjXString,  0, nullptr, 0},
-  {"hfield", "nrow",         kMjXInt,     0, nullptr, 0},
-  {"hfield", "ncol",         kMjXInt,     0, nullptr, 0},
-  {"hfield", "size",         kMjXRealN,   4, nullptr, 0},
-  {"hfield", "elevation",    kMjXRealVec, 0, nullptr, 0},
-
-  //-------------------------------- <asset><skin> / <deformable><skin> ---------------------------
-  {"skin", "name",     kMjXString,  0, nullptr,  0},
-  {"skin", "file",     kMjXString,  0, nullptr,  0},
-  {"skin", "material", kMjXString,  0, nullptr,  0},
-  {"skin", "rgba",     kMjXRealN,   4, nullptr,  0},
-  {"skin", "inflate",  kMjXReal,    0, nullptr,  0},
-  {"skin", "vertex",   kMjXRealVec, 0, nullptr,  0},
-  {"skin", "texcoord", kMjXRealVec, 0, nullptr,  0},
-  {"skin", "face",     kMjXIntVec,  0, nullptr,  0},
-  {"skin", "group",    kMjXInt,     0, nullptr,  0},
-  // composite's <skin> sub-element
-  {"skin", "texcoord_composite", kMjXEnum, 0, bool_map, 2},  // unused placeholder
-  {"skin", "subgrid",  kMjXInt,     0, nullptr,  0},
-
-  {"bone", "body",       kMjXString,  0, nullptr, 0},
-  {"bone", "bindpos",    kMjXRealN,   3, nullptr, 0},
-  {"bone", "bindquat",   kMjXRealN,   4, nullptr, 0},
-  {"bone", "vertid",     kMjXIntVec,  0, nullptr, 0},
-  {"bone", "vertweight", kMjXRealVec, 0, nullptr, 0},
-
-  //-------------------------------- <asset><texture> ----------------------------------------------
-  {"texture", "name",         kMjXString,  0, nullptr,         0},
-  {"texture", "type",         kMjXEnum,    0, texture_map,     3},
-  {"texture", "colorspace",   kMjXEnum,    0, colorspace_map,  3},
-  {"texture", "content_type", kMjXString,  0, nullptr,         0},
-  {"texture", "file",         kMjXString,  0, nullptr,         0},
-  {"texture", "gridsize",     kMjXIntN,    2, nullptr,         0},
-  {"texture", "gridlayout",   kMjXString,  0, nullptr,         0},
-  {"texture", "fileright",    kMjXString,  0, nullptr,         0},
-  {"texture", "fileleft",     kMjXString,  0, nullptr,         0},
-  {"texture", "fileup",       kMjXString,  0, nullptr,         0},
-  {"texture", "filedown",     kMjXString,  0, nullptr,         0},
-  {"texture", "filefront",    kMjXString,  0, nullptr,         0},
-  {"texture", "fileback",     kMjXString,  0, nullptr,         0},
-  {"texture", "builtin",      kMjXEnum,    0, builtin_map,     4},
-  {"texture", "rgb1",         kMjXRealN,   3, nullptr,         0},
-  {"texture", "rgb2",         kMjXRealN,   3, nullptr,         0},
-  {"texture", "mark",         kMjXEnum,    0, mark_map,        4},
-  {"texture", "markrgb",      kMjXRealN,   3, nullptr,         0},
-  {"texture", "random",       kMjXReal,    0, nullptr,         0},
-  {"texture", "width",        kMjXInt,     0, nullptr,         0},
-  {"texture", "height",       kMjXInt,     0, nullptr,         0},
-  {"texture", "hflip",        kMjXEnum,    0, bool_map,        2},
-  {"texture", "vflip",        kMjXEnum,    0, bool_map,        2},
-  {"texture", "nchannel",     kMjXInt,     0, nullptr,         0},
-
-  //-------------------------------- <asset><model> ------------------------------------------------
-  {"model", "name",         kMjXString, 0, nullptr, 0},
-  {"model", "file",         kMjXString, 0, nullptr, 0},
-  {"model", "content_type", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <body> / <worldbody> -----------------------------------------
-  {"body", "name",       kMjXString,  0, nullptr,       0},
-  {"body", "childclass", kMjXString,  0, nullptr,       0},
-  {"body", "pos",        kMjXRealN,   3, nullptr,       0},
-  {"body", "quat",       kMjXRealN,   4, nullptr,       0},
-  {"body", "mocap",      kMjXEnum,    0, bool_map,      2},
-  {"body", "axisangle",  kMjXRealN,   4, nullptr,       0},
-  {"body", "xyaxes",     kMjXRealN,   6, nullptr,       0},
-  {"body", "zaxis",      kMjXRealN,   3, nullptr,       0},
-  {"body", "euler",      kMjXRealN,   3, nullptr,       0},
-  {"body", "gravcomp",   kMjXReal,    0, nullptr,       0},
-  {"body", "sleep",      kMjXEnum,    0, bodysleep_map, 4},
-  {"body", "user",       kMjXRealVec, 0, nullptr,       0},
-
-  //-------------------------------- <body><inertial> ---------------------------------------------
-  {"inertial", "pos",          kMjXRealN, 3, nullptr, 0},
-  {"inertial", "quat",         kMjXRealN, 4, nullptr, 0},
-  {"inertial", "mass",         kMjXReal,  0, nullptr, 0},
-  {"inertial", "diaginertia",  kMjXRealN, 3, nullptr, 0},
-  {"inertial", "axisangle",    kMjXRealN, 4, nullptr, 0},
-  {"inertial", "xyaxes",       kMjXRealN, 6, nullptr, 0},
-  {"inertial", "zaxis",        kMjXRealN, 3, nullptr, 0},
-  {"inertial", "euler",        kMjXRealN, 3, nullptr, 0},
-  {"inertial", "fullinertia",  kMjXRealN, 6, nullptr, 0},
-
-  //-------------------------------- <body><frame> ------------------------------------------------
-  {"frame", "name",       kMjXString, 0, nullptr, 0},
-  {"frame", "childclass", kMjXString, 0, nullptr, 0},
-  {"frame", "pos",        kMjXRealN,  3, nullptr, 0},
-  {"frame", "quat",       kMjXRealN,  4, nullptr, 0},
-  {"frame", "axisangle",  kMjXRealN,  4, nullptr, 0},
-  {"frame", "xyaxes",     kMjXRealN,  6, nullptr, 0},
-  {"frame", "zaxis",      kMjXRealN,  3, nullptr, 0},
-  {"frame", "euler",      kMjXRealN,  3, nullptr, 0},
-
-  //-------------------------------- <body><replicate> --------------------------------------------
-  {"replicate", "count",      kMjXInt,    0, nullptr, 0},
-  {"replicate", "offset",     kMjXRealN,  3, nullptr, 0},
-  {"replicate", "euler",      kMjXRealN,  3, nullptr, 0},
-  {"replicate", "sep",        kMjXString, 0, nullptr, 0},
-  {"replicate", "childclass", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <body><attach> -----------------------------------------------
-  {"attach", "model",  kMjXString, 0, nullptr, 0},
-  {"attach", "body",   kMjXString, 0, nullptr, 0},
-  {"attach", "prefix", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <composite> --------------------------------------------------
-  {"composite", "prefix",  kMjXString,  0, nullptr,  0},
-  {"composite", "type",    kMjXEnum,    0, comp_map, kCompTypesSz},
-  {"composite", "count",   kMjXIntVec,  0, nullptr,  0},
-  {"composite", "offset",  kMjXRealN,   3, nullptr,  0},
-  {"composite", "vertex",  kMjXRealVec, 0, nullptr,  0},
-  {"composite", "initial", kMjXString,  0, nullptr,  0},
-  {"composite", "curve",   kMjXString,  0, nullptr,  0},
-  {"composite", "size",    kMjXRealN,   3, nullptr,  0},
-  {"composite", "quat",    kMjXRealN,   4, nullptr,  0},
-
-  //-------------------------------- <flexcomp> ---------------------------------------------------
-  {"flexcomp", "name",       kMjXString,  0, nullptr,   0},
-  {"flexcomp", "type",       kMjXEnum,    0, fcomp_map, kFcompTypesSz},
-  {"flexcomp", "group",      kMjXInt,     0, nullptr,   0},
-  {"flexcomp", "dim",        kMjXInt,     0, nullptr,   0},
-  {"flexcomp", "dof",        kMjXEnum,    0, fdof_map,  kFcompDofsSz},
-  {"flexcomp", "count",      kMjXIntN,    3, nullptr,   0},
-  {"flexcomp", "cellcount",  kMjXIntN,    3, nullptr,   0},
-  {"flexcomp", "spacing",    kMjXRealN,   3, nullptr,   0},
-  {"flexcomp", "radius",     kMjXReal,    0, nullptr,   0},
-  {"flexcomp", "rigid",      kMjXEnum,    0, bool_map,  2},
-  {"flexcomp", "mass",       kMjXReal,    0, nullptr,   0},
-  {"flexcomp", "inertiabox", kMjXReal,    0, nullptr,   0},
-  {"flexcomp", "scale",      kMjXRealN,   3, nullptr,   0},
-  {"flexcomp", "file",       kMjXString,  0, nullptr,   0},
-  {"flexcomp", "point",      kMjXRealVec, 0, nullptr,   0},
-  {"flexcomp", "element",    kMjXIntVec,  0, nullptr,   0},
-  {"flexcomp", "texcoord",   kMjXRealVec, 0, nullptr,   0},
-  {"flexcomp", "material",   kMjXString,  0, nullptr,   0},
-  {"flexcomp", "rgba",       kMjXRealN,   4, nullptr,   0},
-  {"flexcomp", "flatskin",   kMjXEnum,    0, bool_map,  2},
-  {"flexcomp", "pos",        kMjXRealN,   3, nullptr,   0},
-  {"flexcomp", "quat",       kMjXRealN,   4, nullptr,   0},
-  {"flexcomp", "axisangle",  kMjXRealN,   4, nullptr,   0},
-  {"flexcomp", "xyaxes",     kMjXRealN,   6, nullptr,   0},
-  {"flexcomp", "zaxis",      kMjXRealN,   3, nullptr,   0},
-  {"flexcomp", "euler",      kMjXRealN,   3, nullptr,   0},
-  {"flexcomp", "origin",     kMjXRealN,   3, nullptr,   0},
-
-  //-------------------------------- <flexcomp>/<flex> children -----------------------------------
-  // <edge> under <flex> has {stiffness, damping}; under <flexcomp> adds {equality, solref, solimp}.
-  // We include the union.
-  {"edge", "equality",  kMjXEnum,      0, flexeq_map, 4},
-  {"edge", "solref",    kMjXRealUpToN, 2, nullptr,  0},
-  {"edge", "solimp",    kMjXRealUpToN, 5, nullptr,  0},
-  {"edge", "stiffness", kMjXReal,      0, nullptr,  0},
-  {"edge", "damping",   kMjXReal,      0, nullptr,  0},
-
-  {"elasticity", "young",     kMjXReal,      0, nullptr,         0},
-  {"elasticity", "poisson",   kMjXReal,      0, nullptr,         0},
-  {"elasticity", "damping",   kMjXReal,      0, nullptr,         0},
-  {"elasticity", "thickness", kMjXReal,      0, nullptr,         0},
-  {"elasticity", "elastic2d", kMjXEnum,      0, elastic2d_map,   5},
-
-  {"contact", "contype",      kMjXInt,       0, nullptr,      0},
-  {"contact", "conaffinity",  kMjXInt,       0, nullptr,      0},
-  {"contact", "condim",       kMjXInt,       0, nullptr,      0},
-  {"contact", "priority",     kMjXInt,       0, nullptr,      0},
-  {"contact", "friction",     kMjXRealUpToN, 3, nullptr,      0},
-  {"contact", "solmix",       kMjXReal,      0, nullptr,      0},
-  {"contact", "solref",       kMjXRealUpToN, 2, nullptr,      0},
-  {"contact", "solimp",       kMjXRealUpToN, 5, nullptr,      0},
-  {"contact", "margin",       kMjXReal,      0, nullptr,      0},
-  {"contact", "gap",          kMjXReal,      0, nullptr,      0},
-  {"contact", "internal",     kMjXEnum,      0, bool_map,     2},
-  {"contact", "selfcollide",  kMjXEnum,      0, flexself_map, 5},
-  {"contact", "activelayers", kMjXInt,       0, nullptr,      0},
-  {"contact", "passive",      kMjXEnum,      0, bool_map,     2},
-
-  {"pin", "id",        kMjXIntVec,   0, nullptr, 0},
-  {"pin", "range",     kMjXRealN,    2, nullptr, 0},
-  {"pin", "grid",      kMjXIntVec,   0, nullptr, 0},
-  {"pin", "gridrange", kMjXIntVec,   0, nullptr, 0},
-
-  //-------------------------------- <composite> children -----------------------------------------
-  // Most of composite's children re-use element names that already have entries.
-  // "kind" is specific to composite's <joint>; treat as a composite-joint attr via shared key.
-
-  //-------------------------------- <deformable><flex> -------------------------------------------
-  {"flex", "name",         kMjXString,   0, nullptr,   0},
-  {"flex", "group",        kMjXInt,      0, nullptr,   0},
-  {"flex", "dim",          kMjXInt,      0, nullptr,   0},
-  {"flex", "radius",       kMjXReal,     0, nullptr,   0},
-  {"flex", "material",     kMjXString,   0, nullptr,   0},
-  {"flex", "rgba",         kMjXRealN,    4, nullptr,   0},
-  {"flex", "flatskin",     kMjXEnum,     0, bool_map,  2},
-  {"flex", "body",         kMjXString,   0, nullptr,   0},
-  {"flex", "vertex",       kMjXRealVec,  0, nullptr,   0},
-  {"flex", "element",      kMjXIntVec,   0, nullptr,   0},
-  {"flex", "texcoord",     kMjXRealVec,  0, nullptr,   0},
-  {"flex", "elemtexcoord", kMjXIntVec,   0, nullptr,   0},
-  {"flex", "node",         kMjXString,   0, nullptr,   0},
-  {"flex", "cellcount",    kMjXIntN,     3, nullptr,   0},
-  {"flex", "dof",          kMjXEnum,     0, fdof_map,  kFcompDofsSz},
-  // equality-flex refs (used in <equality><flex>)
-  {"flex", "class",        kMjXString,   0, nullptr,   0},
-  {"flex", "flex",         kMjXString,   0, nullptr,   0},
-  {"flex", "active",       kMjXEnum,     0, bool_map,  2},
-  {"flex", "solref",       kMjXRealUpToN,2, nullptr,   0},
-  {"flex", "solimp",       kMjXRealUpToN,5, nullptr,   0},
-
-  //-------------------------------- <contact> ----------------------------------------------------
-  {"exclude", "name",  kMjXString, 0, nullptr, 0},
-  {"exclude", "body1", kMjXString, 0, nullptr, 0},
-  {"exclude", "body2", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <equality> children ------------------------------------------
-  {"connect", "name",     kMjXString,    0, nullptr,  0},
-  {"connect", "class",    kMjXString,    0, nullptr,  0},
-  {"connect", "body1",    kMjXString,    0, nullptr,  0},
-  {"connect", "body2",    kMjXString,    0, nullptr,  0},
-  {"connect", "anchor",   kMjXRealN,     3, nullptr,  0},
-  {"connect", "site1",    kMjXString,    0, nullptr,  0},
-  {"connect", "site2",    kMjXString,    0, nullptr,  0},
-  {"connect", "active",   kMjXEnum,      0, bool_map, 2},
-  {"connect", "solref",   kMjXRealUpToN, 2, nullptr,  0},
-  {"connect", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
-
-  {"weld", "name",        kMjXString,    0, nullptr,  0},
-  {"weld", "class",       kMjXString,    0, nullptr,  0},
-  {"weld", "body1",       kMjXString,    0, nullptr,  0},
-  {"weld", "body2",       kMjXString,    0, nullptr,  0},
-  {"weld", "relpose",     kMjXRealN,     7, nullptr,  0},
-  {"weld", "anchor",      kMjXRealN,     3, nullptr,  0},
-  {"weld", "site1",       kMjXString,    0, nullptr,  0},
-  {"weld", "site2",       kMjXString,    0, nullptr,  0},
-  {"weld", "active",      kMjXEnum,      0, bool_map, 2},
-  {"weld", "solref",      kMjXRealUpToN, 2, nullptr,  0},
-  {"weld", "solimp",      kMjXRealUpToN, 5, nullptr,  0},
-  {"weld", "torquescale", kMjXReal,      0, nullptr,  0},
-
-  // <equality><joint> has a distinct set of attrs from top-level <joint>.
-  // Since our lookup key is (element, attr), we add the ones not already covered
-  // by top-level <joint> (joint1, joint2, polycoef).
-  {"joint", "joint1",   kMjXString,    0, nullptr,  0},
-  {"joint", "joint2",   kMjXString,    0, nullptr,  0},
-  {"joint", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
-  {"joint", "active",   kMjXEnum,      0, bool_map, 2},
-  {"joint", "solref",   kMjXRealUpToN, 2, nullptr,  0},
-  {"joint", "solimp",   kMjXRealUpToN, 5, nullptr,  0},
-  {"joint", "kind",     kMjXString,    0, nullptr,  0},  // composite joint kind
-  {"joint", "joint",    kMjXString,    0, nullptr,  0},  // tendon wrap
-
-  // <equality><tendon>
-  {"tendon", "name",     kMjXString,    0, nullptr,  0},
-  {"tendon", "class",    kMjXString,    0, nullptr,  0},
-  {"tendon", "tendon1",  kMjXString,    0, nullptr,  0},
-  {"tendon", "tendon2",  kMjXString,    0, nullptr,  0},
-  {"tendon", "polycoef", kMjXRealUpToN, 5, nullptr,  0},
-
-  // flexvert / flexstrain equality variants
-  {"flexvert", "name",   kMjXString,    0, nullptr,  0},
-  {"flexvert", "class",  kMjXString,    0, nullptr,  0},
-  {"flexvert", "flex",   kMjXString,    0, nullptr,  0},
-  {"flexvert", "active", kMjXEnum,      0, bool_map, 2},
-  {"flexvert", "solref", kMjXRealUpToN, 2, nullptr,  0},
-  {"flexvert", "solimp", kMjXRealUpToN, 5, nullptr,  0},
-
-  {"flexstrain", "name",   kMjXString,    0, nullptr,  0},
-  {"flexstrain", "class",  kMjXString,    0, nullptr,  0},
-  {"flexstrain", "flex",   kMjXString,    0, nullptr,  0},
-  {"flexstrain", "active", kMjXEnum,      0, bool_map, 2},
-  {"flexstrain", "solref", kMjXRealUpToN, 2, nullptr,  0},
-  {"flexstrain", "solimp", kMjXRealUpToN, 5, nullptr,  0},
-
-  //-------------------------------- <tendon> wrap subelements ------------------------------------
-  // <site site="..."/>, <geom geom="..." sidesite="..."/>
-  {"site", "site",     kMjXString, 0, nullptr, 0},
-  {"geom", "geom",     kMjXString, 0, nullptr, 0},
-  {"geom", "sidesite", kMjXString, 0, nullptr, 0},
-
-  //-------------------------------- <sensor> ------------------------------------------------------
-  // shared sensor attrs
-#define SENS_COMMON(elem) \
-  {elem, "name",     kMjXString,    0, nullptr,    0}, \
-  {elem, "nsample",  kMjXInt,       0, nullptr,    0}, \
-  {elem, "interp",   kMjXEnum,      0, interp_map, 3}, \
-  {elem, "delay",    kMjXReal,      0, nullptr,    0}, \
-  {elem, "interval", kMjXRealUpToN, 2, nullptr,    0}, \
-  {elem, "cutoff",   kMjXReal,      0, nullptr,    0}, \
-  {elem, "noise",    kMjXReal,      0, nullptr,    0}, \
-  {elem, "user",     kMjXRealVec,   0, nullptr,    0}
-
-  SENS_COMMON("touch"),         {"touch",         "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("accelerometer"), {"accelerometer", "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("velocimeter"),   {"velocimeter",   "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("gyro"),          {"gyro",          "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("force"),         {"force",         "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("torque"),        {"torque",        "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("magnetometer"),  {"magnetometer",  "site",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("camprojection"), {"camprojection", "site",     kMjXString, 0, nullptr, 0},
-                                {"camprojection", "camera",   kMjXString, 0, nullptr, 0},
-  SENS_COMMON("rangefinder"),   {"rangefinder",   "site",     kMjXString, 0, nullptr, 0},
-                                {"rangefinder",   "camera",   kMjXString, 0, nullptr, 0},
-                                {"rangefinder",   "data",     kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointpos"),      {"jointpos",      "joint",    kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointvel"),      {"jointvel",      "joint",    kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonpos"),     {"tendonpos",     "tendon",   kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonvel"),     {"tendonvel",     "tendon",   kMjXString, 0, nullptr, 0},
-  SENS_COMMON("actuatorpos"),   {"actuatorpos",   "actuator", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("actuatorvel"),   {"actuatorvel",   "actuator", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("actuatorfrc"),   {"actuatorfrc",   "actuator", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointactuatorfrc"),  {"jointactuatorfrc",  "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonactuatorfrc"), {"tendonactuatorfrc", "tendon", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("ballquat"),          {"ballquat",          "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("ballangvel"),        {"ballangvel",        "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointlimitpos"),     {"jointlimitpos",     "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointlimitvel"),     {"jointlimitvel",     "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("jointlimitfrc"),     {"jointlimitfrc",     "joint",  kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonlimitpos"),    {"tendonlimitpos",    "tendon", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonlimitvel"),    {"tendonlimitvel",    "tendon", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("tendonlimitfrc"),    {"tendonlimitfrc",    "tendon", kMjXString, 0, nullptr, 0},
-
-#define SENS_FRAME(elem) \
-  SENS_COMMON(elem), \
-  {elem, "objtype", kMjXString, 0, nullptr, 0}, \
-  {elem, "objname", kMjXString, 0, nullptr, 0}, \
-  {elem, "reftype", kMjXString, 0, nullptr, 0}, \
-  {elem, "refname", kMjXString, 0, nullptr, 0}
-
-  SENS_FRAME("framepos"),
-  SENS_FRAME("framequat"),
-  SENS_FRAME("framexaxis"),
-  SENS_FRAME("frameyaxis"),
-  SENS_FRAME("framezaxis"),
-  SENS_FRAME("framelinvel"),
-  SENS_FRAME("frameangvel"),
-  SENS_COMMON("framelinacc"), {"framelinacc", "objtype", kMjXString, 0, nullptr, 0},
-                              {"framelinacc", "objname", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("frameangacc"), {"frameangacc", "objtype", kMjXString, 0, nullptr, 0},
-                              {"frameangacc", "objname", kMjXString, 0, nullptr, 0},
-
-  SENS_COMMON("subtreecom"),    {"subtreecom",    "body", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("subtreelinvel"), {"subtreelinvel", "body", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("subtreeangmom"), {"subtreeangmom", "body", kMjXString, 0, nullptr, 0},
-
-  SENS_COMMON("insidesite"),
-  {"insidesite", "site",    kMjXString, 0, nullptr, 0},
-  {"insidesite", "objtype", kMjXString, 0, nullptr, 0},
-  {"insidesite", "objname", kMjXString, 0, nullptr, 0},
-
-  // distance/normal/fromto share the same attrs
-  SENS_COMMON("distance"),
-  {"distance", "geom1", kMjXString, 0, nullptr, 0},
-  {"distance", "geom2", kMjXString, 0, nullptr, 0},
-  {"distance", "body1", kMjXString, 0, nullptr, 0},
-  {"distance", "body2", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("normal"),
-  {"normal", "geom1", kMjXString, 0, nullptr, 0},
-  {"normal", "geom2", kMjXString, 0, nullptr, 0},
-  {"normal", "body1", kMjXString, 0, nullptr, 0},
-  {"normal", "body2", kMjXString, 0, nullptr, 0},
-  SENS_COMMON("fromto"),
-  {"fromto", "geom1", kMjXString, 0, nullptr, 0},
-  {"fromto", "geom2", kMjXString, 0, nullptr, 0},
-  {"fromto", "body1", kMjXString, 0, nullptr, 0},
-  {"fromto", "body2", kMjXString, 0, nullptr, 0},
-
-  // contact sensor
-  {"contact", "name",     kMjXString, 0, nullptr,    0},
-  {"contact", "geom1",    kMjXString, 0, nullptr,    0},
-  {"contact", "geom2",    kMjXString, 0, nullptr,    0},
-  {"contact", "body1",    kMjXString, 0, nullptr,    0},
-  {"contact", "body2",    kMjXString, 0, nullptr,    0},
-  {"contact", "subtree1", kMjXString, 0, nullptr,    0},
-  {"contact", "subtree2", kMjXString, 0, nullptr,    0},
-  {"contact", "site",     kMjXString, 0, nullptr,    0},
-  {"contact", "num",      kMjXInt,    0, nullptr,    0},
-  {"contact", "data",     kMjXString, 0, nullptr,    0},  // space-separated enum bitflags
-  {"contact", "reduce",   kMjXEnum,   0, reduce_map, 4},
-  {"contact", "nsample",  kMjXInt,    0, nullptr,    0},
-  {"contact", "interp",   kMjXEnum,   0, interp_map, 3},
-  {"contact", "delay",    kMjXReal,   0, nullptr,    0},
-  {"contact", "interval", kMjXRealUpToN, 2, nullptr, 0},
-  {"contact", "cutoff",   kMjXReal,   0, nullptr,    0},
-  {"contact", "noise",    kMjXReal,   0, nullptr,    0},
-  {"contact", "user",     kMjXRealVec,0, nullptr,    0},
-
-  SENS_COMMON("e_potential"),
-  SENS_COMMON("e_kinetic"),
-  SENS_COMMON("clock"),
-
-  {"tactile", "name",    kMjXString,  0, nullptr,    0},
-  {"tactile", "geom",    kMjXString,  0, nullptr,    0},
-  {"tactile", "mesh",    kMjXString,  0, nullptr,    0},
-  {"tactile", "nsample", kMjXInt,     0, nullptr,    0},
-  {"tactile", "interp",  kMjXEnum,    0, interp_map, 3},
-  {"tactile", "delay",   kMjXReal,    0, nullptr,    0},
-  {"tactile", "interval",kMjXRealUpToN, 2, nullptr,  0},
-  {"tactile", "user",    kMjXRealVec, 0, nullptr,    0},
-
-  {"user", "name",      kMjXString,  0, nullptr,       0},
-  {"user", "objtype",   kMjXString,  0, nullptr,       0},
-  {"user", "objname",   kMjXString,  0, nullptr,       0},
-  {"user", "datatype",  kMjXEnum,    0, datatype_map,  4},
-  {"user", "needstage", kMjXEnum,    0, stage_map,     4},
-  {"user", "dim",       kMjXInt,     0, nullptr,       0},
-  {"user", "cutoff",    kMjXReal,    0, nullptr,       0},
-  {"user", "noise",     kMjXReal,    0, nullptr,       0},
-  {"user", "user",      kMjXRealVec, 0, nullptr,       0},
-
-#undef SENS_COMMON
-#undef SENS_FRAME
-
-  //-------------------------------- <keyframe> ---------------------------------------------------
-  {"key", "name",  kMjXString,  0, nullptr, 0},
-  {"key", "time",  kMjXReal,    0, nullptr, 0},
-  {"key", "qpos",  kMjXRealVec, 0, nullptr, 0},
-  {"key", "qvel",  kMjXRealVec, 0, nullptr, 0},
-  {"key", "act",   kMjXRealVec, 0, nullptr, 0},
-  {"key", "mpos",  kMjXRealVec, 0, nullptr, 0},
-  {"key", "mquat", kMjXRealVec, 0, nullptr, 0},
-  {"key", "ctrl",  kMjXRealVec, 0, nullptr, 0},
-};
-// clang-format on
-
-const int kMjXAttrTableSize =
-    sizeof(kMjXAttrTable) / sizeof(kMjXAttrTable[0]);
 
 
 //---------------------------------- MJCF tree parser ----------------------------------------------
 
 namespace {
+
+// MJCF "body family": <body>, <frame>, <replicate> share <body>'s content
+// model but each carries its own attribute set, and <worldbody> is the name
+// <body> takes at the top level of <mujoco>. mjXSchema::NameMatch in
+// xml_util.cc encodes the same rule at parse time -- keep the two in sync.
+constexpr const char* kBodyAliases[] = {"body", "frame", "replicate"};
+constexpr const char* kWorldbody = "worldbody";
+
+bool IsBody(const char* s)      { return std::strcmp(s, "body") == 0; }
+bool IsWorldbody(const char* s) { return std::strcmp(s, kWorldbody) == 0; }
 
 struct Node {
   const char* name = nullptr;
@@ -1214,14 +91,28 @@ void Indent(std::stringstream& out, int level) {
   for (int i = 0; i < level; i++) out << "  ";
 }
 
+// O(1) lookup into kMjXAttrTable by (element, attr). All strings in the
+// table (and in MJCF[], which supplies the query) are string literals with
+// static lifetime, so storing string_view in the key is safe.
 const mjXAttr* Lookup(const char* element, const char* attr) {
-  for (int i = 0; i < kMjXAttrTableSize; i++) {
-    const mjXAttr& e = kMjXAttrTable[i];
-    if (std::string(e.element) == element && std::string(e.attr) == attr) {
-      return &e;
+  using Key = std::pair<std::string_view, std::string_view>;
+  struct KeyHash {
+    std::size_t operator()(const Key& k) const noexcept {
+      return std::hash<std::string_view>{}(k.first) * 31 +
+             std::hash<std::string_view>{}(k.second);
     }
-  }
-  return nullptr;
+  };
+  static const auto table = [] {
+    std::unordered_map<Key, const mjXAttr*, KeyHash> m;
+    m.reserve(kMjXAttrTableSize);
+    for (int i = 0; i < kMjXAttrTableSize; i++) {
+      const mjXAttr& e = kMjXAttrTable[i];
+      m.emplace(Key{e.element, e.attr}, &e);
+    }
+    return m;
+  }();
+  auto it = table.find(Key{element, attr});
+  return it == table.end() ? nullptr : it->second;
 }
 
 void CardinalityToOccurs(char type, const char** min_occurs,
@@ -1239,79 +130,108 @@ std::string EnumTypeName(const char* element, const char* attr) {
   return std::string(element) + "_" + attr + "_enum";
 }
 
-std::string ListTypeName(mjXAttrKind kind, int size) {
-  switch (kind) {
-    case kMjXIntN:      return "list_int_" + std::to_string(size);
-    case kMjXIntVec:    return "vec_int";
-    case kMjXRealN:     return "list_real_" + std::to_string(size);
-    case kMjXRealUpToN: return "uptolist_real_" + std::to_string(size);
-    case kMjXRealVec:   return "vec_real";
-    default:            return "unknown";
+// Composite list-like attribute type (int/real list, fixed/variable length,
+// optionally capped). Collected into an ordered set and emitted once per
+// distinct (kind, size) combination.
+struct ListType {
+  mjXAttrKind kind;
+  int size;  // ignored for Vec variants
+
+  bool IsReal() const {
+    return kind == kMjXRealN || kind == kMjXRealUpToN || kind == kMjXRealVec;
   }
-}
+  bool IsVariable() const { return kind == kMjXIntVec || kind == kMjXRealVec; }
+  bool IsCapped()   const { return kind == kMjXRealUpToN; }
+
+  std::string Name() const {
+    switch (kind) {
+      case kMjXIntN:      return "list_int_"      + std::to_string(size);
+      case kMjXRealN:     return "list_real_"     + std::to_string(size);
+      case kMjXRealUpToN: return "uptolist_real_" + std::to_string(size);
+      case kMjXIntVec:    return "vec_int";
+      case kMjXRealVec:   return "vec_real";
+      default:            return "unknown";
+    }
+  }
+
+  // Ordered by name so iteration over std::set<ListType> produces the same
+  // emission order as the previous string-keyed set.
+  bool operator<(const ListType& other) const {
+    return Name() < other.Name();
+  }
+};
 
 
 //---------------------------------- Emit: enum / list types ---------------------------------------
 
+// Canonical enum-type name per distinct mjMap*. Populated during CollectTypes
+// by walking MJCF[] in tree order: the first (element, attr) pair that
+// references a given map provides the name, and every subsequent attribute
+// using the same map reuses it. Dramatically shrinks the generated XSD
+// because maps like bool_map, interp_map, enable_map are referenced by many
+// attributes.
+std::unordered_map<const mjMap*, std::string>& CanonicalEnumNames() {
+  static std::unordered_map<const mjMap*, std::string> m;
+  return m;
+}
+
+std::string EnumTypeFor(const mjXAttr& info, const char* element,
+                        const char* attr) {
+  auto& map = CanonicalEnumNames();
+  auto it = map.find(info.map);
+  if (it != map.end()) return it->second;
+  // Fallback for attributes that are emitted before CollectTypes has run
+  // (e.g. direct calls from tests). Matches the pre-dedup naming scheme.
+  return EnumTypeName(element, attr);
+}
+
 void CollectTypes(
     const Node& node,
-    std::set<std::string>& list_types,
-    std::vector<std::pair<std::string, const mjXAttr*>>& enum_types,
-    std::set<std::string>& enum_seen) {
+    std::set<ListType>& list_types,
+    std::vector<std::pair<std::string, const mjXAttr*>>& enum_types) {
   for (const char* a : node.attrs) {
     const mjXAttr* info = Lookup(node.name, a);
     if (!info) continue;
 
     if (info->kind == kMjXEnum) {
-      std::string n = EnumTypeName(node.name, a);
-      if (enum_seen.insert(n).second) {
-        enum_types.emplace_back(n, info);
+      auto [it, inserted] = CanonicalEnumNames().try_emplace(
+          info->map, EnumTypeName(node.name, a));
+      if (inserted) {
+        enum_types.emplace_back(it->second, info);
       }
     } else if (info->kind == kMjXIntN || info->kind == kMjXRealN ||
                info->kind == kMjXRealUpToN || info->kind == kMjXIntVec ||
                info->kind == kMjXRealVec) {
-      list_types.insert(ListTypeName(info->kind, info->size));
+      list_types.insert(ListType{info->kind, info->size});
     }
   }
   for (const Node& child : node.children) {
-    CollectTypes(child, list_types, enum_types, enum_seen);
+    CollectTypes(child, list_types, enum_types);
   }
 }
 
-void EmitListType(std::stringstream& out, const std::string& name) {
-  const bool is_real = name.find("_real") != std::string::npos;
-  const bool is_upto = name.rfind("uptolist_", 0) == 0;
-  const bool is_vec  = name.rfind("vec_", 0) == 0;
-  int size = 0;
-  if (!is_vec) {
-    auto pos = name.find_last_of('_');
-    if (pos != std::string::npos) {
-      try {
-        size = std::stoi(name.substr(pos + 1));
-      } catch (...) { size = 0; }
-    }
-  }
-
+void EmitListType(std::stringstream& out, const ListType& t) {
   Indent(out, 1);
-  out << "<xs:simpleType name=\"" << name << "\">\n";
+  out << "<xs:simpleType name=\"" << t.Name() << "\">\n";
   Indent(out, 2);
   out << "<xs:restriction>\n";
   Indent(out, 3);
   out << "<xs:simpleType>\n";
   Indent(out, 4);
-  out << "<xs:list itemType=\"" << (is_real ? "xs:double" : "xs:int") << "\"/>\n";
+  out << "<xs:list itemType=\"" << (t.IsReal() ? "xs:double" : "xs:int")
+      << "\"/>\n";
   Indent(out, 3);
   out << "</xs:simpleType>\n";
-  if (is_vec) {
+  if (t.IsVariable()) {
     // unconstrained length
-  } else if (is_upto) {
+  } else if (t.IsCapped()) {
     Indent(out, 3);
     out << "<xs:minLength value=\"1\"/>\n";
     Indent(out, 3);
-    out << "<xs:maxLength value=\"" << size << "\"/>\n";
+    out << "<xs:maxLength value=\"" << t.size << "\"/>\n";
   } else {
     Indent(out, 3);
-    out << "<xs:length value=\"" << size << "\"/>\n";
+    out << "<xs:length value=\"" << t.size << "\"/>\n";
   }
   Indent(out, 2);
   out << "</xs:restriction>\n";
@@ -1356,14 +276,14 @@ void EmitAttribute(std::stringstream& out, int level, const char* element,
     case kMjXInt:    out << " type=\"xs:int\"/>\n";    break;
     case kMjXReal:   out << " type=\"xs:double\"/>\n"; break;
     case kMjXEnum:
-      out << " type=\"" << EnumTypeName(element, attr) << "\"/>\n";
+      out << " type=\"" << EnumTypeFor(*info, element, attr) << "\"/>\n";
       break;
     case kMjXIntN:
     case kMjXRealN:
     case kMjXRealUpToN:
     case kMjXIntVec:
     case kMjXRealVec:
-      out << " type=\"" << ListTypeName(info->kind, info->size) << "\"/>\n";
+      out << " type=\"" << ListType{info->kind, info->size}.Name() << "\"/>\n";
       break;
   }
 }
@@ -1377,7 +297,7 @@ bool IsRecursive(const Node& n) { return n.type == 'R'; }
 void EmitComplexTypeBody(std::stringstream& out, const Node& node, int level,
                          const char* effective_name) {
   if (!node.children.empty() || IsRecursive(node) ||
-      std::string(effective_name) == "body") {
+      IsBody(effective_name)) {
     Indent(out, level);
     out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
     for (const Node& child : node.children) {
@@ -1391,13 +311,13 @@ void EmitComplexTypeBody(std::stringstream& out, const Node& node, int level,
       out << "<xs:element name=\"" << effective_name << "\" type=\""
           << effective_name << "_type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
     }
-    // Body special-cases: <body> can also contain <body>/<frame>/<replicate>
-    // (per mjXSchema::NameMatch). Emit them when effective_name is body-family.
-    // Each alias points at its own named complexType so its own attributes
-    // (declared in kMjXAttrTable) are honored -- body_type would drop them.
-    if (std::string(effective_name) == "body" ||
-        std::string(effective_name) == "worldbody") {
-      for (const char* alias : {"body", "frame", "replicate"}) {
+    // Body special-cases: <body> can also contain any body-family alias
+    // (per mjXSchema::NameMatch). Each alias points at its own named
+    // complexType so its attributes (declared in kMjXAttrTable) are honored
+    // -- body_type would drop them.
+    if (IsBody(effective_name) ||
+        IsWorldbody(effective_name)) {
+      for (const char* alias : kBodyAliases) {
         Indent(out, level + 1);
         out << "<xs:element name=\"" << alias << "\" type=\"" << alias << "_type\""
             << " minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
@@ -1427,7 +347,7 @@ void EmitElementInternal(std::stringstream& out, const Node& node, int level,
 
   // Recursive elements use a named complexType so they can be self-referenced.
   const bool use_named_type = IsRecursive(node) ||
-                              std::string(node.name) == "body";
+                              IsBody(node.name);
 
   Indent(out, level);
   out << "<xs:element name=\"" << element_name << "\"";
@@ -1455,7 +375,7 @@ void EmitElementInternal(std::stringstream& out, const Node& node, int level,
 
 // Collect recursive (or body-family) nodes for named-type emission.
 void CollectNamedTypes(const Node& node, std::vector<const Node*>& out) {
-  if (IsRecursive(node) || std::string(node.name) == "body") {
+  if (IsRecursive(node) || IsBody(node.name)) {
     out.push_back(&node);
   }
   for (const Node& child : node.children) {
@@ -1484,8 +404,8 @@ void EmitAliasType(std::stringstream& out, const Node& body_node,
   for (const Node& child : body_node.children) {
     EmitElementInternal(out, child, 3, /*top_level=*/false, nullptr);
   }
-  // Body-family recursion: allow body/frame/replicate nested inside.
-  for (const char* sub : {"body", "frame", "replicate"}) {
+  // Body-family recursion: allow every alias nested inside.
+  for (const char* sub : kBodyAliases) {
     Indent(out, 3);
     out << "<xs:element name=\"" << sub << "\" type=\"" << sub << "_type\""
         << " minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n";
@@ -1514,10 +434,13 @@ void PrintSchemaXSD(std::stringstream& out) {
   Node root;
   ParseNode(0, nMJCF, root);
 
-  std::set<std::string> list_types;
+  // Reset canonical enum-name state in case this function is called more
+  // than once per process lifetime.
+  CanonicalEnumNames().clear();
+
+  std::set<ListType> list_types;
   std::vector<std::pair<std::string, const mjXAttr*>> enum_types;
-  std::set<std::string> enum_seen;
-  CollectTypes(root, list_types, enum_types, enum_seen);
+  CollectTypes(root, list_types, enum_types);
 
   // Find recursive / body-family nodes so we can emit them as named types.
   std::vector<const Node*> named_types;
@@ -1530,8 +453,8 @@ void PrintSchemaXSD(std::stringstream& out) {
 
   if (!list_types.empty()) {
     out << "\n  <!-- List types -->\n";
-    for (const std::string& n : list_types) {
-      EmitListType(out, n);
+    for (const ListType& t : list_types) {
+      EmitListType(out, t);
     }
   }
 
@@ -1548,14 +471,14 @@ void PrintSchemaXSD(std::stringstream& out) {
     const Node* body_node = nullptr;
     for (const Node* n : named_types) {
       EmitNamedType(out, *n);
-      if (std::string(n->name) == "body") body_node = n;
+      if (IsBody(n->name)) body_node = n;
     }
-    // <frame> and <replicate> are body-family aliases handled outside MJCF[]
-    // (see mjXSchema::NameMatch). They share body's content model but each
+    // Non-canonical body-family aliases share body's content model but each
     // has its own attribute set in kMjXAttrTable; emit dedicated types so
     // those attrs are actually applied when validating.
     if (body_node) {
-      for (const char* alias : {"frame", "replicate"}) {
+      for (const char* alias : kBodyAliases) {
+        if (IsBody(alias)) continue;
         EmitAliasType(out, *body_node, alias);
       }
     }
@@ -1588,8 +511,7 @@ void PrintSchemaXSD(std::stringstream& out) {
   Indent(out, 3);
   out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
   for (const Node& child : root.children) {
-    const char* override_name =
-        (std::string(child.name) == "body") ? "worldbody" : nullptr;
+    const char* override_name = IsBody(child.name) ? kWorldbody : nullptr;
     EmitElementInternal(out, child, 4, /*top_level=*/false, override_name);
   }
   Indent(out, 4);

--- a/src/xml/xml_native_schema.cc
+++ b/src/xml/xml_native_schema.cc
@@ -20,7 +20,7 @@
 // Release pipeline (regenerating doc/mjcf.xsd):
 //   $ cmake --build build --target xmlschema
 //   $ ./build/bin/xmlschema /tmp/raw.xsd
-//   $ python3 doc/mjcf_schema_enrich.py --in /tmp/raw.xsd \
+//   $ ./doc/mjcf_schema_enrich.py --in /tmp/raw.xsd \
 //         --rst doc/XMLreference.rst --out doc/mjcf.xsd --strict --report
 
 #include "xml/xml_native_schema.h"

--- a/src/xml/xml_native_schema.cc
+++ b/src/xml/xml_native_schema.cc
@@ -20,8 +20,8 @@
 // Release pipeline (regenerating doc/mjcf.xsd):
 //   $ cmake --build build --target xmlschema
 //   $ ./build/bin/xmlschema /tmp/raw.xsd
-//   $ ./doc/mjcf_schema_enrich.py --in /tmp/raw.xsd \
-//         --rst doc/XMLreference.rst --out doc/mjcf.xsd --strict --report
+//   $ ./doc/mjcf_schema_enrich.py --in /tmp/raw.xsd --rst doc/XMLreference.rst
+//       --out doc/mjcf.xsd --strict --report
 
 #include "xml/xml_native_schema.h"
 

--- a/src/xml/xml_native_schema.cc
+++ b/src/xml/xml_native_schema.cc
@@ -291,6 +291,9 @@ void EmitAttribute(std::stringstream& out, int level, const char* element,
 // Is this node recursive? ('R' cardinality)
 bool IsRecursive(const Node& n) { return n.type == 'R'; }
 
+void EmitElementInternal(std::stringstream& out, const Node& node, int level,
+                         bool top_level, const char* name_override);
+
 // Emit the body of a complexType (choice + attributes) for a given element.
 // Separated from EmitElement so it can be reused for named types that are
 // referenced from multiple places.
@@ -301,8 +304,6 @@ void EmitComplexTypeBody(std::stringstream& out, const Node& node, int level,
     Indent(out, level);
     out << "<xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">\n";
     for (const Node& child : node.children) {
-      extern void EmitElementInternal(std::stringstream&, const Node&, int,
-                                       bool, const char*);
       EmitElementInternal(out, child, level + 1, /*top_level=*/false, nullptr);
     }
     // Recursive self-reference for 'R' elements.

--- a/src/xml/xml_native_schema.h
+++ b/src/xml/xml_native_schema.h
@@ -17,44 +17,10 @@
 
 #include <sstream>
 
-#include "xml/xml_util.h"
-
 namespace mujoco {
 
-// Kind of data accepted in an attribute value. Mirrors the ReadAttr* / MapValue
-// calls performed by mjXReader::OneX() parsers.
-enum mjXAttrKind {
-  kMjXString = 0,   // arbitrary string
-  kMjXInt,          // single int
-  kMjXIntN,         // exactly N ints        (fixed-length list)
-  kMjXIntVec,       // variable-length int list
-  kMjXReal,         // single real
-  kMjXRealN,        // exactly N reals       (fixed-length list)
-  kMjXRealUpToN,    // up to N reals         (variable, capped)
-  kMjXRealVec,      // variable-length real list
-  kMjXEnum,         // keyword from an mjMap
-};
-
-// One (element, attribute) binding. The generator looks up entries by
-// (element, attr) to decide which xs:simpleType to reference.
-// `map`/`map_size` are only used for kMjXEnum.
-struct mjXAttr {
-  const char* element;
-  const char* attr;
-  mjXAttrKind kind;
-  int size;                  // for kMjXIntN / kMjXRealN / kMjXRealUpToN
-  const mjMap* map;          // for kMjXEnum
-  int map_size;              // for kMjXEnum
-};
-
-// Flat table of typed bindings. The generator walks MJCF[] for tree structure
-// and consults this table for the type of each (element, attr) pair.
-// Any pair present in MJCF[] but missing here is emitted as xs:string with a
-// warning comment in the output.
-extern const mjXAttr kMjXAttrTable[];
-extern const int kMjXAttrTableSize;
-
 // Emit an XSD document describing the MJCF format to `out`.
+// The attribute type metadata comes from kMjXAttrTable in xml_native_reader.cc.
 void PrintSchemaXSD(std::stringstream& out);
 
 }  // namespace mujoco

--- a/src/xml/xml_native_schema.h
+++ b/src/xml/xml_native_schema.h
@@ -1,0 +1,62 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUJOCO_SRC_XML_XML_NATIVE_SCHEMA_H_
+#define MUJOCO_SRC_XML_XML_NATIVE_SCHEMA_H_
+
+#include <sstream>
+
+#include "xml/xml_util.h"
+
+namespace mujoco {
+
+// Kind of data accepted in an attribute value. Mirrors the ReadAttr* / MapValue
+// calls performed by mjXReader::OneX() parsers.
+enum mjXAttrKind {
+  kMjXString = 0,   // arbitrary string
+  kMjXInt,          // single int
+  kMjXIntN,         // exactly N ints        (fixed-length list)
+  kMjXIntVec,       // variable-length int list
+  kMjXReal,         // single real
+  kMjXRealN,        // exactly N reals       (fixed-length list)
+  kMjXRealUpToN,    // up to N reals         (variable, capped)
+  kMjXRealVec,      // variable-length real list
+  kMjXEnum,         // keyword from an mjMap
+};
+
+// One (element, attribute) binding. The generator looks up entries by
+// (element, attr) to decide which xs:simpleType to reference.
+// `map`/`map_size` are only used for kMjXEnum.
+struct mjXAttr {
+  const char* element;
+  const char* attr;
+  mjXAttrKind kind;
+  int size;                  // for kMjXIntN / kMjXRealN / kMjXRealUpToN
+  const mjMap* map;          // for kMjXEnum
+  int map_size;              // for kMjXEnum
+};
+
+// Flat table of typed bindings. The generator walks MJCF[] for tree structure
+// and consults this table for the type of each (element, attr) pair.
+// Any pair present in MJCF[] but missing here is emitted as xs:string with a
+// warning comment in the output.
+extern const mjXAttr kMjXAttrTable[];
+extern const int kMjXAttrTableSize;
+
+// Emit an XSD document describing the MJCF format to `out`.
+void PrintSchemaXSD(std::stringstream& out);
+
+}  // namespace mujoco
+
+#endif  // MUJOCO_SRC_XML_XML_NATIVE_SCHEMA_H_


### PR DESCRIPTION
Draft stacked follow-up for #3237, based on the MJCF XSD generator work from @julien-blanchon.

This branch is rebased onto current `origin/main`, includes #3237's schema generator commits, and adds one final metadata patch for concrete validation misses reported in the #3237 thread. It is not meant to take credit for or replace the original schema PR; it is a proof/patch branch maintainers can use if they want these fixes folded into #3237.

Fixes in the final commit:
- adds `compiler conflict` to the XSD metadata table using `conflict_map`
- adds `replicate prefix` as a string attribute
- changes top-level `composite size` from exact 3 values to up-to-3 values, matching `ReadAttr(..., exact=false)`

Also verified after rebasing that `flexcomp dof="2d"` is now covered via the current `fdof_map` from `origin/main`.

Local validation:
- `git diff --check`
- `cmake -S . -B /tmp/mujoco-pr3237-build -DMUJOCO_BUILD_TESTS=OFF -DMUJOCO_TEST_PYTHON_UTIL=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/mujoco-pr3237-build --target xmlschema -j2`
- `/tmp/mujoco-pr3237-build/bin/xmlschema /tmp/mujoco-pr3237-raw.xsd`
- `xmllint --noout --schema /tmp/mujoco-pr3237-raw.xsd -` with a snippet covering `compiler conflict="merge"`, `replicate prefix`, `composite size="1"`, and `flexcomp dof="2d"`
- `python3 doc/mjcf_schema_enrich.py --in /tmp/mujoco-pr3237-raw.xsd --rst doc/XMLreference.rst --out /tmp/mujoco-pr3237-enriched.xsd --report`

Note: the enrichment script succeeds without `--strict`; `--strict --report` exits nonzero on pre-existing documentation drift unrelated to this patch.
