### PR TITLE
Fix introspect on Mac: Handle clang AST loc nodes with elided 'line' in introspect codegen.

### DIFF
--- a/python/mujoco/introspect/codegen/ast_processor.py
+++ b/python/mujoco/introspect/codegen/ast_processor.py
@@ -332,9 +332,13 @@ class AstProcessor:
     )
 
   def _make_anonymous_key(self, node: ClangJsonNode) -> str:
-    line = node['loc']['line']
-    col = node['loc']['col']
-    return f'{line}:{col}'
+    loc = node['loc']
+    if 'line' not in loc:
+      # Clang elides 'line' when unchanged from the previous node. This only
+      # occurs for system-header structs never referenced by MuJoCo types, so
+      # the key merely needs to be unique.
+      return f"offset{loc.get('offset')}:{loc.get('col')}"
+    return f"{loc['line']}:{loc['col']}"
 
 
 def _traverse(node, visitor):


### PR DESCRIPTION
Apple's math.h (included directly by mujoco.h) contains an anonymous union whose clang-JSON 'loc' lacks the 'line' key (clang elides it when unchanged from the previous node), crashing AstProcessor._make_anonymous_key with a KeyError during bindings regeneration on macOS. glibc's math.h has no such union, so this never bites on Linux.

Fall back to an offset-based key for line-less nodes; these system-header structs are never referenced by MuJoCo types, so the key only needs to be unique.