### PR TITLE
Fix dear_imgui SDL2 backend target creation order in Studio builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,14 @@ if(NOT EMSCRIPTEN AND NOT MUJOCO_USE_FILAMENT_MJR_COMPAT)
 endif()
 add_subdirectory(src/render/noop)
 
+# Studio's platform layer (src/experimental/platform) uses dear_imgui's SDL2
+# backend, which is only defined if SDL2::SDL2-static exists when dear_imgui is
+# first fetched — and that happens in src/render/filament below. Set up SDL2
+# first so the backend target gets created.
+if(MUJOCO_BUILD_STUDIO)
+  include(third_party_deps/sdl2)
+endif()
+
 if(MUJOCO_USE_FILAMENT)
   add_subdirectory(src/render/filament)
   add_subdirectory(src/experimental/filament)

--- a/cmake/third_party_deps/dear_imgui/CMakeLists.txt
+++ b/cmake/third_party_deps/dear_imgui/CMakeLists.txt
@@ -29,11 +29,9 @@ target_sources(dear_imgui
 )
 
 # SDL2 backend
-# TODO: I don't know how to correctly check for dependencies in cmake. This
-# assumes that SDL2 is pulled in _before_ dear_imgui, but that seems fragile.
-# For now, we'll just assume SDL2 is available as dear_imgui is only being used
-# in contexts which depend on SDL2.
-#if(TARGET SDL2)
+# Only defined when SDL2 was pulled in before dear_imgui; e.g. Filament builds
+# use their own vendored SDL2 (target `sdl2`) and don't need this backend.
+if(TARGET SDL2::SDL2-static)
   add_library(dear_imgui_SDL2 STATIC)
   target_include_directories(dear_imgui_SDL2
     PUBLIC
@@ -46,7 +44,7 @@ target_sources(dear_imgui
   target_link_libraries(dear_imgui_SDL2
     SDL2::SDL2-static
   )
-#endif()
+endif()
 
 # OpenGL3 backend
 add_library(dear_imgui_OpenGL3 STATIC)

--- a/src/experimental/platform/CMakeLists.txt
+++ b/src/experimental/platform/CMakeLists.txt
@@ -94,9 +94,12 @@ target_include_directories(${MUJOCO_PLATFORM_TARGET_NAME}
         ${PROJECT_SOURCE_DIR}/src
 )
 
+# SDL2 must come before dear_imgui so that the dear_imgui_SDL2 backend target
+# gets created (usually a no-op: both are already set up by the top-level
+# CMakeLists.txt before src/render/filament).
+include(third_party_deps/sdl2)
 include(third_party_deps/dear_imgui)
 include(third_party_deps/implot)
-include(third_party_deps/sdl2)
 include(third_party_deps/libwebp)
 
 target_link_libraries(${MUJOCO_PLATFORM_TARGET_NAME}


### PR DESCRIPTION
The dear_imgui_SDL2 backend target is only created if SDL2::SDL2-static exists when dear_imgui is first fetched, but SDL2 was previously pulled in after dear_imgui (and the target check was commented out with a TODO, unconditionally creating the backend). Restore the if(TARGET) guard and set up SDL2 before dear_imgui: in the top-level CMakeLists.txt under MUJOCO_BUILD_STUDIO, and in src/experimental/platform. Filament builds use their own vendored SDL2 (target 'sdl2') and don't need this backend.