### PR TITLE
Fix least_squares result when xtol is reached

### DIFF
--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -416,6 +416,8 @@ def least_squares(
 
     # Check termination condition on step norm.
     if dx_norm < xtol * (xtol + np.linalg.norm(x)):
+      x = xnew
+      r = rnew
       status = Status.DX_TOL
       break
 

--- a/python/mujoco/minimize_test.py
+++ b/python/mujoco/minimize_test.py
@@ -45,6 +45,17 @@ class MinimizeTest(absltest.TestCase):
     self.assertIn('norm(gradient) < tol', out.getvalue())
     self.assertIn('exact minimum found', out.getvalue())
 
+  def test_xtol_returns_accepted_candidate(self) -> None:
+    def residual(x):
+      return x - 1.0
+
+    out = io.StringIO()
+    x, _ = minimize.least_squares(
+        np.array([0.0]), residual, xtol=2.0, gtol=0.0, output=out
+    )
+    np.testing.assert_array_equal(x, np.array([1.0]))
+    self.assertIn('norm(dx) < tol', out.getvalue())
+
   def test_jac_callback(self) -> None:
     def residual(x):
       return np.stack([1 - x[0, :], 10 * (x[1, :] - x[0, :] ** 2)])


### PR DESCRIPTION
## Summary

- accept the Armijo-approved candidate before terminating on `xtol`
- add a regression test ensuring `least_squares` returns that accepted candidate

## Problem

When an accepted step satisfies the relative step-size tolerance, `least_squares` sets `DX_TOL` and exits before assigning `xnew` and `rnew`. It therefore returns the previous, higher-objective iterate and records that stale iterate in the final trace.

## Testing

- focused `test_xtol_returns_accepted_candidate`: passed
- complete `python/mujoco/minimize_test.py` module: 16 tests passed
- `trailing-whitespace`: passed
- `end-of-file-fixer`: passed
- `git diff --check`: passed