### PR TITLE
Fix `git apply` and re-enable cmake cache on Windows.

### DIFF
--- a/cmake/MujocoDependencies.cmake
+++ b/cmake/MujocoDependencies.cmake
@@ -129,7 +129,7 @@ endif()
 set(QHULL_ENABLE_TESTING OFF)
 # Patch changes in https://github.com/qhull/qhull/pull/173.patch
 set(QHULL_PATCH_COMMAND
-  git -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/qhull-support-emscripten.patch
+  git --git-dir=. -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/qhull-support-emscripten.patch
 )
 
 findorfetch(
@@ -210,7 +210,7 @@ set(CCD_HIDE_ALL_SYMBOLS ON)
 
 # Patch changes in https://github.com/danfis/libccd/pull/83.patch
 set(CCD_PATCH_COMMAND
-  git -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/ccd-support-emscripten.patch
+  git --git-dir=. -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/ccd-support-emscripten.patch
 )
 
 # update cmake_minimum_required version for compatibility with newer version of cmake
@@ -284,7 +284,7 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
   )
 
   set(ABSL_PATCH_COMMAND
-    git -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/abseil-cpp-source_location.patch
+    git --git-dir=. -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/abseil-cpp-source_location.patch
   )
   set(ABSL_BUILD_TESTING OFF)
   findorfetch(

--- a/cmake/third_party_deps/filament.cmake
+++ b/cmake/third_party_deps/filament.cmake
@@ -48,7 +48,7 @@ if(WIN32)
 endif()
 
 set(FILAMENT_PATCH_COMMAND
-  git -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/filament-allow-clang-windows.patch
+  git --git-dir=. -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/filament-allow-clang-windows.patch
 )
 
 fetchpackage(

--- a/cmake/third_party_deps/libwebp.cmake
+++ b/cmake/third_party_deps/libwebp.cmake
@@ -21,7 +21,7 @@ mark_as_advanced(MUJOCO_DEP_VERSION_libwebp)
 include(FindOrFetch)
 
 set(LIBWEBP_PATCH_COMMAND
-  git -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/libwebp-apple-float16.patch
+  git --git-dir=. -c core.autocrlf=false -c core.whitespace=cr-at-eol apply --verbose --whitespace=fix --ignore-space-change ${mujoco_SOURCE_DIR}/cmake/libwebp-apple-float16.patch
 )
 
 set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})


### PR DESCRIPTION
This forces git to treat the current directory as the git checkout to apply the patch to, which avoids issues where a non-git checkout (e.g. from an unpacked cached tarball) can cause git to find a higher-level git checkout and try to apply the patches there, which then fails when the files to patch aren't found.

DO NOT SUBMIT

PiperOrigin-RevId: 953012784
Change-Id: Ie401a207c27c67de7296ed4c70034b0f47144631