### PR TITLE
Fix segfault on a mesh with convex inertia that no geom references

### DIFF
--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -5279,9 +5279,16 @@ void mjCModel::TryCompile(mjModel*& m, mjData*& d, const mjVFS* vfs) {
     if (geoms_[i]->mesh &&
         (geoms_[i]->spec.type == mjGEOM_MESH ||
          geoms_[i]->spec.type == mjGEOM_SDF) &&
-        (geoms_[i]->spec.contype || geoms_[i]->spec.conaffinity || is_in_pair ||
-         geoms_[i]->mesh->spec.inertia == mjMESH_INERTIA_CONVEX)) {
+        (geoms_[i]->spec.contype || geoms_[i]->spec.conaffinity || is_in_pair)) {
       geoms_[i]->mesh->SetNeedHull(true);
+    }
+  }
+
+  // convex inertia is computed from the hull, so it is needed whether or not
+  // any geom references the mesh
+  for (mjCMesh* mesh : meshes_) {
+    if (mesh->spec.inertia == mjMESH_INERTIA_CONVEX) {
+      mesh->SetNeedHull(true);
     }
   }
 

--- a/test/user/user_mesh_test.cc
+++ b/test/user/user_mesh_test.cc
@@ -975,6 +975,22 @@ TEST_F(MjCMeshTest, ExactConvexInertia) {
   mj_deleteModel(model);
 }
 
+TEST_F(MjCMeshTest, UnreferencedConvexInertiaMesh) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <asset>
+      <mesh name="orphan" inertia="convex"
+            vertex="0 0 1   1 0 0   0 1 0   -1 0 0   0 -1 0"
+            face="0 1 2   0 2 3   0 3 4   0 4 1   1 4 3   1 3 2"/>
+    </asset>
+    <worldbody/>
+  </mujoco>
+  )";
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(xml, error.data(), error.size());
+  EXPECT_THAT(model.get(), NotNull()) << error.data();
+}
+
 TEST_F(MjCMeshTest, ExactShellInertia) {
   const std::string xml_path = GetTestDataFilePath(kShellInertiaPath);
   std::array<char, 1024> error;


### PR DESCRIPTION
Fixes #3431.

### What happens

A mesh declared with `inertia="convex"` that no geom references segfaults the compiler:

```xml
<mujoco>
  <asset>
    <mesh name="orphan" inertia="convex"
          vertex="0 0 1   1 0 0   0 1 0   -1 0 0   0 -1 0"
          face="0 1 2   0 2 3   0 3 4   0 4 1   1 4 3   1 3 2"/>
  </asset>
  <worldbody/>
</mujoco>
```

`mujoco.MjModel.from_xml_path("orphan.xml")` exits with SIGSEGV on 3.10.0 and on current main.

### Root cause

`mjCModel::TryCompile` decides which meshes need a convex hull by walking `geoms_`, and one of the
conditions in that loop is `geoms_[i]->mesh->spec.inertia == mjMESH_INERTIA_CONVEX`. That condition
is a property of the *mesh*, but it is only ever evaluated for meshes some geom points at. An
unreferenced mesh is never visited, so `needhull_` stays false, `mjCMesh::Compile` skips
`MakeGraph`, and `graph_` stays null. `ComputeVolume` and `ComputeInertia` then do

```cpp
int nf = (inertia == mjMESH_INERTIA_CONVEX) ? graph_[1] : nface();
const int* f = (inertia == mjMESH_INERTIA_CONVEX) ? GraphFaces() : face_.data();
```

on that null pointer, which is the crash. Note the mesh here has faces, so the `face_.empty()`
fallback that would otherwise build the hull does not fire either.

### Fix

Move the convex-inertia condition out of the geom loop and apply it to every mesh, so a mesh that
computes its inertia from its hull always gets one. The geom loop keeps the conditions that really
are about geoms (`contype`, `conaffinity`, membership in a contact pair).

The reporter asked for "a warning about unused meshes, or silence" — this gives silence, and it
matches the intent the original condition already expressed.

### Test

`MjCMeshTest.UnreferencedConvexInertiaMesh` in `test/user/user_mesh_test.cc` compiles the model
above. It dies with SIGSEGV on main and passes with this change.

Ran on macOS arm64, Release build:

- `user_mesh_test` 71/71 pass
- `user_objects_test` 90/90, `user_recompile_test` 320/320, `user_flex_test` 59/59,
  `user_composite_test` 4/4 all pass
- `user_model_test` has one failure (`MujocoTest.ResolvePluginMissingInstanceThrowsError`) and
  `user_api_test` segfaults, both of which reproduce identically on unmodified main here, so they
  are local/environmental and not from this change.

Changelog entry added under Compiler -> Bug fixes.
