### PR TITLE
mjx: preserve varying-axis metadata across Warp FFI calls

### DIFF
--- a/mjx/mujoco/mjx/warp/ffi.py
+++ b/mjx/mujoco/mjx/warp/ffi.py
@@ -141,7 +141,37 @@ def jax_callable_variadic_tuple(
     )
 
     flat_args, in_tree = jax.tree.flatten(args)
-    return my_callable(*flat_args, **kwargs)
+    result = my_callable(*flat_args, **kwargs)
+
+    # Warp derives its FFI output types from plain shape/dtype descriptors,
+    # which carry no manual-axis metadata, so every value returned by
+    # `ffi_call` has an empty varying set. Under `shard_map(check_vma=True)`
+    # that is unsound: genuinely per-device data is reported as replicated.
+    # The call still succeeds, but a downstream `lax.scan` rejects the
+    # resulting carry-type mismatch. Restore the union of the inputs' varying
+    # axes, which is JAX's standard propagation rule for an opaque op --
+    # over-marking as varying is always sound, under-marking is not.
+    # TODO(mujoco #3426): remove once upstream Warp propagates this itself.
+    # `jax.lax.pcast` requires JAX >= 0.10; on older versions leave the
+    # result untouched rather than fail at import.
+    if not hasattr(jax.lax, 'pcast'):
+      return result
+
+    input_vma = frozenset().union(
+        *(jax.typeof(x).manual_axis_type.varying for x in flat_args)
+    )
+
+    def propagate_vma(x):
+      # Cast only the axes that are missing: `pcast` has no varying ->
+      # varying rule, so casting an already-varying axis raises. `sorted`
+      # keeps the traced axis order stable across processes, since
+      # frozenset iteration order depends on per-process string hashing.
+      missing = input_vma - jax.typeof(x).manual_axis_type.varying
+      if not missing:
+        return x
+      return jax.lax.pcast(x, tuple(sorted(missing)), to='varying')
+
+    return jax.tree.map(propagate_vma, result)
 
   return callable_wrapper
 

--- a/mjx/mujoco/mjx/warp/ffi_test.py
+++ b/mjx/mujoco/mjx/warp/ffi_test.py
@@ -1,0 +1,182 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for MJX-Warp FFI helpers."""
+
+import os
+import tempfile
+
+# Two devices are needed to build a sharded mesh; fake them on CPU so this
+# runs under ordinary CI. Must precede the first JAX import.
+os.environ.setdefault(
+    'XLA_FLAGS',
+    os.environ.get('XLA_FLAGS', '') + ' --xla_force_host_platform_device_count=2',
+)
+
+from absl.testing import absltest  # pylint: disable=g-import-not-at-top
+import jax
+from jax import numpy as jp
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+import mujoco.mjx.warp as mjxw
+import numpy as np
+
+if mjxw.WARP_INSTALLED:
+  from mujoco.mjx.third_party.warp._src.jax import ffi as warp_ffi  # pylint: disable=g-import-not-at-top
+  from mujoco.mjx.warp import ffi  # pylint: disable=g-import-not-at-top
+  from mujoco.mjx.warp import warp as wp  # pylint: disable=g-import-not-at-top
+
+
+class FfiVmaTest(absltest.TestCase):
+  """Varying-axis metadata must survive an FFI call (mujoco #3426)."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    if not mjxw.WARP_INSTALLED:
+      return
+    cls.tempdir = tempfile.TemporaryDirectory()
+    wp.config.kernel_cache_dir = cls.tempdir.name
+
+    def copy(
+        x: wp.array(dtype=wp.float32, ndim=1),
+        out: wp.array(dtype=wp.float32, ndim=1),
+    ):
+      wp.copy(out, x)
+
+    @wp.kernel
+    def add_kernel(
+        x: wp.array(dtype=wp.float32),
+        y: wp.array(dtype=wp.float32),
+        out: wp.array(dtype=wp.float32),
+    ):
+      i = wp.tid()
+      out[i] = x[i] + y[i]
+
+    def add(
+        x: wp.array(dtype=wp.float32, ndim=1),
+        y: wp.array(dtype=wp.float32, ndim=1),
+        out: wp.array(dtype=wp.float32, ndim=1),
+    ):
+      wp.launch(add_kernel, dim=x.shape[0], inputs=[x, y], outputs=[out])
+
+    # staticmethod: a bare function on the class would bind `self` as the
+    # first FFI input.
+    graph_mode = warp_ffi.JaxCallableGraphMode.NONE
+    cls.copy_ffi = staticmethod(
+        ffi.jax_callable_variadic_tuple(copy, graph_mode=graph_mode)
+    )
+    cls.add_ffi = staticmethod(
+        ffi.jax_callable_variadic_tuple(add, graph_mode=graph_mode)
+    )
+
+  @classmethod
+  def tearDownClass(cls):
+    super().tearDownClass()
+    if hasattr(cls, 'tempdir'):
+      cls.tempdir.cleanup()
+
+  def setUp(self):
+    super().setUp()
+    if not mjxw.WARP_INSTALLED:
+      self.skipTest('Warp not installed.')
+    if not hasattr(jax.lax, 'pcast'):
+      self.skipTest('JAX version does not support manual-axis casting.')
+    if len(jax.devices()) < 2:
+      self.skipTest('Test requires at least two JAX devices.')
+
+    self.mesh = Mesh(np.array(jax.devices()[:2]), ('replicas',))
+
+  def test_single_call_preserves_varying_axes(self):
+    """A lone FFI call must not silently downgrade varying data."""
+    observed = {}
+
+    @jax.shard_map(
+        mesh=self.mesh,
+        in_specs=P('replicas'),
+        out_specs=P('replicas'),
+        check_vma=True,
+    )
+    def run(x):
+      out = self.copy_ffi(x)[0]
+      observed['out'] = jax.typeof(out).manual_axis_type.varying
+      return out
+
+    x = jp.arange(4, dtype=jp.float32)
+    np.testing.assert_array_equal(run(x), x)
+    # Asserts the mechanism, not a downstream symptom: without the fix this
+    # is frozenset() while the call still returns the correct numbers.
+    self.assertEqual(observed['out'], frozenset({'replicas'}))
+
+  def test_varying_axes_survive_scan_carry(self):
+    """The originally reported failure: scan carry types must match."""
+
+    @jax.shard_map(
+        mesh=self.mesh,
+        in_specs=P('replicas'),
+        out_specs=P('replicas'),
+        check_vma=True,
+    )
+    def scan_copy(x):
+      def body(carry, _):
+        return self.copy_ffi(carry)[0], None
+
+      return jax.lax.scan(body, x, None, length=2)[0]
+
+    x = jp.arange(4, dtype=jp.float32)
+    np.testing.assert_array_equal(scan_copy(x), x)
+
+  def test_replicated_input_stays_replicated(self):
+    """With no varying inputs there is nothing to propagate."""
+    observed = {}
+
+    @jax.shard_map(
+        mesh=self.mesh, in_specs=P(), out_specs=P(), check_vma=True
+    )
+    def run(x):
+      out = self.copy_ffi(x)[0]
+      observed['out'] = jax.typeof(out).manual_axis_type.varying
+      return out
+
+    x = jp.arange(4, dtype=jp.float32)
+    np.testing.assert_array_equal(run(x), x)
+    self.assertEqual(observed['out'], frozenset())
+
+  def test_mixed_inputs_take_union_of_varying_axes(self):
+    """One varying and one replicated input must yield a varying output."""
+    observed = {}
+
+    @jax.shard_map(
+        mesh=self.mesh,
+        in_specs=(P('replicas'), P()),
+        out_specs=P('replicas'),
+        check_vma=True,
+    )
+    def run(x, y):
+      out = self.add_ffi(x, y)[0]
+      observed['x'] = jax.typeof(x).manual_axis_type.varying
+      observed['y'] = jax.typeof(y).manual_axis_type.varying
+      observed['out'] = jax.typeof(out).manual_axis_type.varying
+      return out
+
+    x = jp.arange(4, dtype=jp.float32)
+    y = jp.ones(2, dtype=jp.float32)
+    np.testing.assert_array_equal(run(x, y), x + 1.0)
+    self.assertEqual(observed['x'], frozenset({'replicas'}))
+    self.assertEqual(observed['y'], frozenset())
+    self.assertEqual(observed['out'], frozenset({'replicas'}))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Fixes #3426.

Credit for finding and diagnosing this goes to @danielpmorton, who filed the issue with a
minimal repro and a working fork. This PR builds directly on that patch; he is credited as
co-author on the commit. Happy to close this in favour of a PR from him if he'd prefer to
land it himself.

## Root cause

Warp derives its FFI output types in `get_jax_output_type()` from plain shape/dtype
descriptors, which carry no manual-axis metadata. Those go to `jax.ffi.ffi_call`, so every
value coming back has an empty varying set.

Under `shard_map(..., check_vma=True)` that is unsound rather than merely cosmetic: data that
is genuinely per-device is reported as replicated. The call still succeeds and returns
correct numbers — which is what makes it easy to miss. `lax.scan` is only where it becomes
fatal, because its carry-type equality check is the first thing to compare the two:

```
The input carry has type float32[2]{V:replicas} but the corresponding output carry
component has type float32[2], so the manual axis types do not match.
```

## Approach

The fix restores the union of the inputs' varying axes onto the outputs — JAX's standard
propagation rule for an opaque op. Over-marking as varying is sound; under-marking is not.
One visible consequence worth calling out: code that declared `out_specs=P()` expecting
replication will now get an error where it previously got silently-wrong results.

This is applied in `jax_callable_variadic_tuple` rather than in the vendored Warp tree.
Every MJX Warp call funnels through that wrapper (`bvh.py`, `smooth.py`, `render.py`,
`forward.py`, `collision_driver.py`, and the generated shim), so it covers MJX's whole
surface, and a patch to `mjx/mujoco/mjx/third_party/warp/` would be reverted on the next
sync. The proper permanent home is upstream Warp, which would also cover `jax_kernel`; the
`TODO` in the code marks the removal condition.

Two details in the implementation that are load-bearing and easy to "simplify" into bugs:

- **Only the missing axes are cast.** `_pcast_funcs` has no `varying -> varying` entry, so
  a blanket `pcast` over all outputs raises `Unsupported pcast`.
- **The axis tuple is sorted.** It is derived from a `frozenset`, and `frozenset` iteration
  order depends on per-process string hashing. Under multi-controller SPMD each host traces
  independently, so an unsorted tuple can produce divergent jaxprs across hosts.

## Tests

`ffi_test.py` fakes a two-device mesh on CPU via
`--xla_force_host_platform_device_count=2`, so this runs under ordinary CI instead of
skipping without a GPU. This works because the vendored Warp registers a `Host` FFI target;
released `warp-lang==1.14.0` registers CUDA only.

| Test | Before | After |
| --- | --- | --- |
| `test_single_call_preserves_varying_axes` | fail | pass |
| `test_varying_axes_survive_scan_carry` (reported symptom) | fail | pass |
| `test_mixed_inputs_take_union_of_varying_axes` | fail | pass |
| `test_replicated_input_stays_replicated` (control) | pass | pass |

The first asserts the mechanism directly (`manual_axis_type.varying`) rather than relying on
`scan`'s carry check, so it keeps testing this bug even if `scan` changes. The control
passes in both states, showing the fix doesn't over-apply. I also confirmed the change is a
no-op under eager, `jit`, and non-sharded `scan`.

## Open questions for reviewers

- **JAX version floor.** `jax.lax.pcast` needs JAX >= 0.10, and `mjx/pyproject.toml`
  declares a bare `jax`. I used a `hasattr` guard rather than adding a floor, since MJX
  otherwise uses no JAX >= 0.10 APIs and a floor would constrain all users for a
  multi-device edge case. I did not establish whether the bug manifests on JAX 0.9 under the
  older `.vma`/`pvary` spelling — if it does, the guard skips silently there. Happy to
  switch to a version floor if you'd prefer.
- **Verified on a CPU-faked mesh only**, not on real multi-GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
