### PR TITLE
Fix MJX forward, passive, and sensor parity with native MuJoCo

### DIFF
--- a/mjx/mujoco/mjx/_src/forward.py
+++ b/mjx/mujoco/mjx/_src/forward.py
@@ -89,8 +89,12 @@ def fwd_velocity(m: Model, d: Data) -> Data:
   if not isinstance(m._impl, ModelJAX) or not isinstance(d._impl, DataJAX):
     raise ValueError('fwd_velocity requires JAX backend implementation.')
 
+  actuator_velocity = d._impl.actuator_moment @ d.qvel
+  if m.opt.disableflags & DisableBit.ACTUATION:
+    # Match native mj_fwdVelocity: zero actuator velocity when actuation is off.
+    actuator_velocity = jp.zeros((m.nu,))
   d = d.tree_replace({  # pyrefly: ignore[bad-assignment]
-      '_impl.actuator_velocity': d._impl.actuator_moment @ d.qvel,
+      '_impl.actuator_velocity': actuator_velocity,
       '_impl.ten_velocity': d._impl.ten_J @ d.qvel,
   })
   d = smooth.com_vel(m, d)
@@ -106,9 +110,11 @@ def fwd_actuation(m: Model, d: Data) -> Data:
   if not isinstance(d._impl, DataJAX):
     raise ValueError('fwd_actuation requires JAX backend implementation.')
   if not m.nu or m.opt.disableflags & DisableBit.ACTUATION:
+    # Match native mj_fwdActuation: clear actuator_force as well as qfrc.
     return d.replace(
         act_dot=jp.zeros((m.na,)),
         qfrc_actuator=jp.zeros((m.nv,)),
+        actuator_force=jp.zeros((m.nu,)),
     )
 
   ctrl = d.ctrl
@@ -446,7 +452,11 @@ def forward(m: Model, d: Data) -> Data:
   d = fwd_acceleration(m, d)
 
   if d._impl.efc_J.size == 0:
+    # No constraints: qacc equals unconstrained acceleration, but
+    # acceleration-stage sensors (actuatorfrc, touch, frameacc, ...) must still
+    # run — matching native mj_forward.
     d = d.replace(qacc=d.qacc_smooth)
+    d = sensor.sensor_acc(m, d)
     return d
 
   d = named_scope(solver.solve)(m, d)

--- a/mjx/mujoco/mjx/_src/forward_test.py
+++ b/mjx/mujoco/mjx/_src/forward_test.py
@@ -177,6 +177,66 @@ class ForwardTest(absltest.TestCase):
 
     np.testing.assert_allclose(dx.qvel, 1 + m.opt.timestep)
 
+  def test_constraint_free_actuatorfrc_sensor(self):
+    """Acceleration-stage sensors must run even when efc_J is empty."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <worldbody>
+          <body>
+            <joint name="j"/>
+            <geom size=".1" contype="0" conaffinity="0"/>
+          </body>
+        </worldbody>
+        <actuator><motor name="m" joint="j"/></actuator>
+        <sensor><actuatorfrc actuator="m"/></sensor>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    d.ctrl[0] = 2.0
+    mujoco.mj_forward(m, d)
+
+    mx = mjx.put_model(m)
+    dx = mjx.make_data(mx).replace(ctrl=jp.array([2.0]))
+    dx = jax.jit(mjx.forward)(mx, dx)
+
+    self.assertEqual(dx._impl.efc_J.size, 0)
+    _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+
+  def test_disable_actuation_zeros_actuator_velocity(self):
+    """mjDSBL_ACTUATION must zero actuator_velocity and actuator_force."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <option><flag actuation="disable"/></option>
+        <worldbody>
+          <body>
+            <joint name="j"/>
+            <geom size=".1"/>
+          </body>
+        </worldbody>
+        <actuator><motor name="m" joint="j"/></actuator>
+        <sensor>
+          <actuatorvel actuator="m"/>
+          <actuatorfrc actuator="m"/>
+        </sensor>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    d.qvel[0] = 1.0
+    d.ctrl[0] = 3.0
+    mujoco.mj_forward(m, d)
+
+    mx = mjx.put_model(m)
+    dx = mjx.make_data(mx).replace(
+        qvel=jp.array([1.0]), ctrl=jp.array([3.0])
+    )
+    dx = jax.jit(mjx.forward)(mx, dx)
+
+    _assert_eq(
+        d.actuator_velocity, dx._impl.actuator_velocity, 'actuator_velocity'
+    )
+    _assert_eq(d.actuator_force, dx.actuator_force, 'actuator_force')
+    _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+
   def test_where(self):
     m = mujoco.MjModel.from_xml_string("""
         <mujoco>

--- a/mjx/mujoco/mjx/_src/passive.py
+++ b/mjx/mujoco/mjx/_src/passive.py
@@ -139,7 +139,11 @@ def passive(m: Model, d: Data) -> Data:
   ):
     raise ValueError('passive requires JAX backend implementation.')
 
-  if m.opt.disableflags & (DisableBit.SPRING | DisableBit.DAMPER):
+  # Match native mj_passive: skip all passive forces only when BOTH spring and
+  # damper are disabled. _spring_damper already honors each flag independently.
+  if (m.opt.disableflags & DisableBit.SPRING) and (
+      m.opt.disableflags & DisableBit.DAMPER
+  ):
     return d.replace(qfrc_passive=jp.zeros(m.nv), qfrc_gravcomp=jp.zeros(m.nv))
 
   qfrc_passive = _spring_damper(m, d)

--- a/mjx/mujoco/mjx/_src/passive_test.py
+++ b/mjx/mujoco/mjx/_src/passive_test.py
@@ -19,6 +19,7 @@ import jax
 import mujoco
 from mujoco import mjx
 from mujoco.mjx._src import test_util
+from jax import numpy as jp
 import numpy as np
 
 # tolerance for difference between MuJoCo and MJX passive calculations - mostly
@@ -81,6 +82,28 @@ class PassiveTest(absltest.TestCase):
     )
     dx = jax.jit(mjx.passive)(mx, mjx.put_data(m, d))
     np.testing.assert_allclose(dx.qfrc_passive, 0)
+
+  def test_disable_spring_keeps_damper(self):
+    """Disabling only springs must leave damping forces intact."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <option><flag spring="disable"/></option>
+        <worldbody>
+          <body>
+            <joint name="j" damping="2"/>
+            <geom size=".1"/>
+          </body>
+        </worldbody>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    d.qvel[0] = 1.0
+    mujoco.mj_forward(m, d)
+
+    mx = mjx.put_model(m)
+    dx = jax.jit(mjx.forward)(mx, mjx.make_data(mx).replace(qvel=jp.array([1.0])))
+
+    _assert_eq(d.qfrc_passive, dx.qfrc_passive, 'qfrc_passive')
 
 
 if __name__ == '__main__':

--- a/mjx/mujoco/mjx/_src/sensor.py
+++ b/mjx/mujoco/mjx/_src/sensor.py
@@ -129,11 +129,11 @@ def sensor_pos(m: Model, d: Data) -> Data:
         # https://en.wikipedia.org/wiki/3D_projection#Mathematical_formula
         pixel_coord_hom = proj @ pos_hom
 
-        # avoid dividing by tiny numbers
+        # avoid dividing by tiny numbers (match native engine_sensor.c)
         denom = pixel_coord_hom[2]
         denom = jp.where(
             jp.abs(denom) < mujoco.mjMINVAL,
-            jp.clip(denom, -mujoco.mjMINVAL, mujoco.mjMINVAL),
+            jp.where(denom < 0, -mujoco.mjMINVAL, mujoco.mjMINVAL),
             denom,
         )
 
@@ -463,16 +463,19 @@ def sensor_acc(m: Model, d: Data) -> Data:
       (m.sensor_type[stage_acc] == SensorType.CONTACT).any()
       and (contact_maxforce | contact_dataforce | contact_datatorque)
   ):
-    # compute contact forces
+    # compute contact forces; empty contact capacity -> zero forces
     contact_force = []
     condim_ids = []
     for dim in set(d._impl.contact.dim):
       force, condim_id = support.contact_force_dim(m, d, dim)
       contact_force.append(force)
       condim_ids.append(condim_id)
-    contact_force = jp.concatenate(contact_force)[
-        np.argsort(np.concatenate(condim_ids))
-    ]
+    if contact_force:
+      contact_force = jp.concatenate(contact_force)[
+          np.argsort(np.concatenate(condim_ids))
+      ]
+    else:
+      contact_force = jp.zeros((0, 6))
 
   sensors, adrs = [], []
 
@@ -759,15 +762,18 @@ def sensor_acc(m: Model, d: Data) -> Data:
           cvel = d.cvel[bodyid]
           offset = pos - d.subtree_com[m.body_rootid[bodyid]]
 
-          sensor = _framelinacc(cvel, cacc, offset).reshape(-1)
+          sensor = _framelinacc(cvel, cacc, offset)
         elif sensor_type == SensorType.FRAMEANGACC:
-          sensor = cacc[:, :3].reshape(-1)
+          sensor = cacc[:, :3]
         else:
           raise ValueError(f'Unknown sensor type: {sensor_type}')
 
+        cutofft = cutoff[idxt]
         adrt = adr[idxt, None] + np.arange(3)[None]
 
-        sensors.append(sensor.reshape(-1))
+        sensors.append(
+            _apply_cutoff(sensor, cutofft, data_type[0]).reshape(-1)
+        )
         adrs.append(adrt.reshape(-1))
       continue  # avoid adding to sensors/adrs list a second time
     else:

--- a/mjx/mujoco/mjx/_src/sensor_test.py
+++ b/mjx/mujoco/mjx/_src/sensor_test.py
@@ -196,6 +196,94 @@ class SensorTest(parameterized.TestCase):
     with self.assertRaises(NotImplementedError):
       mjx.put_model(m)
 
+  def test_framelinacc_cutoff(self):
+    """FRAMELINACC must apply cutoff like other real-valued sensors."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <option gravity="0 0 -9.81"/>
+        <worldbody>
+          <body name="b">
+            <joint name="j" axis="0 1 0"/>
+            <geom size=".1" mass="1" contype="0" conaffinity="0"/>
+            <site name="s"/>
+          </body>
+        </worldbody>
+        <sensor>
+          <framelinacc name="a" objtype="site" objname="s" cutoff="0.05"/>
+          <accelerometer name="acc" site="s" cutoff="0.05"/>
+        </sensor>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+
+    from mujoco.mjx._src import forward as fwd
+    from mujoco.mjx._src import sensor as sensor_mod
+
+    mx = mjx.put_model(m)
+    dx = mjx.make_data(mx)
+    dx = fwd.fwd_position(mx, dx)
+    dx = sensor_mod.sensor_pos(mx, dx)
+    dx = fwd.fwd_velocity(mx, dx)
+    dx = sensor_mod.sensor_vel(mx, dx)
+    dx = fwd.fwd_actuation(mx, dx)
+    dx = fwd.fwd_acceleration(mx, dx)
+    dx = dx.replace(qacc=dx.qacc_smooth)
+    dx = sensor_mod.sensor_acc(mx, dx)
+
+    _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+    # Gravity (~9.81) must be clipped to cutoff on both sensors.
+    np.testing.assert_allclose(dx.sensordata[2], 0.05, atol=1e-6)
+    np.testing.assert_allclose(dx.sensordata[5], 0.05, atol=1e-6)
+
+  def test_touch_with_empty_contact_capacity(self):
+    """TOUCH must return zero when the model has no contact pairs."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <worldbody>
+          <body>
+            <joint name="j"/>
+            <geom size=".1" contype="0" conaffinity="0"/>
+            <site name="s" size=".2"/>
+          </body>
+        </worldbody>
+        <sensor><touch site="s"/></sensor>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+
+    mx = mjx.put_model(m)
+    dx = jax.jit(mjx.forward)(mx, mjx.make_data(mx))
+
+    self.assertEqual(dx._impl.contact.dim.size, 0)
+    _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+
+  def test_camprojection_near_camera_plane(self):
+    """CAMPROJECTION denom guard must match native sign-preserving mjMINVAL."""
+    m = mujoco.MjModel.from_xml_string("""
+      <mujoco>
+        <worldbody>
+          <body>
+            <joint type="slide" axis="1 0 0"/>
+            <geom size=".01" contype="0" conaffinity="0"/>
+            <site name="target" pos="1 0 0"/>
+          </body>
+          <camera name="cam" pos="0 0 0" xyaxes="0 1 0 0 0 1"
+                  resolution="640 480"/>
+        </worldbody>
+        <sensor><camprojection site="target" camera="cam"/></sensor>
+      </mujoco>
+    """)
+    d = mujoco.MjData(m)
+    mujoco.mj_forward(m, d)
+
+    mx = mjx.put_model(m)
+    dx = jax.jit(mjx.forward)(mx, mjx.make_data(mx))
+
+    self.assertTrue(np.all(np.isfinite(dx.sensordata)))
+    _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Summary
- Run acceleration-stage sensors even when `efc_J` is empty (constraint-free models), matching native `mj_forward`.
- Treat spring/damper disable flags independently (`AND`, not `OR`) so disabling springs still leaves damping, gravcomp, and fluid forces.
- When actuation is disabled, zero `actuator_velocity` and `actuator_force` (not only `qfrc_actuator`).
- Apply cutoff to `FRAMELINACC` / `FRAMEANGACC`; handle empty contact capacity for touch/contact sensors; use a sign-preserving near-zero denominator guard in camprojection.

These are standalone correctness gaps (not tied to an existing issue). Each change was reproduced against native MuJoCo and covered by new parity tests.

## Test plan
- [x] `python -m mujoco.mjx._src.forward_test ForwardTest.test_constraint_free_actuatorfrc_sensor ForwardTest.test_disable_actuation_zeros_actuator_velocity`
- [x] `python -m mujoco.mjx._src.passive_test PassiveTest.test_disable_spring_keeps_damper`
- [x] `python -m mujoco.mjx._src.sensor_test SensorTest.test_framelinacc_cutoff SensorTest.test_touch_with_empty_contact_capacity SensorTest.test_camprojection_near_camera_plane`
- [x] CI MJX suite on this PR