### PR TITLE
Document VFS lookup fallback behavior

### DIFF
--- a/doc/APIreference/functions.rst
+++ b/doc/APIreference/functions.rst
@@ -1504,6 +1504,9 @@ Unmount a previously mounted ResourceProvider; return 0: success, -1: not found 
 Add file to VFS. The directory argument is optional and can be NULL or empty. Returns 0 on success,
 2 on name collision, or -1 when an internal error occurs.
 
+VFS first attempts to match a full path. If this fails, it falls back to a case-insensitive match on
+the basename. For example, an entry named ``assets/Cube.OBJ`` can be found as ``cube.obj``.
+
 *Nullable:* ``directory``
 
 .. _mj_addBufferVFS:
@@ -1514,6 +1517,9 @@ Add file to VFS. The directory argument is optional and can be NULL or empty. Re
 .. mujoco-include:: mj_addBufferVFS
 
 Add file to VFS from buffer; return 0: success, 2: repeated name, -1: failed to load.
+
+VFS first attempts to match a full path. If this fails, it falls back to a case-insensitive match on
+the basename. For example, an entry named ``assets/Cube.OBJ`` can be found as ``cube.obj``.
 
 .. _mj_deleteFileVFS:
 

--- a/doc/APIreference/functions_override.rst
+++ b/doc/APIreference/functions_override.rst
@@ -23,7 +23,17 @@ Initialize an empty VFS, :ref:`mj_deleteVFS` must be called to deallocate the VF
 Add file to VFS. The directory argument is optional and can be NULL or empty. Returns 0 on success,
 2 on name collision, or -1 when an internal error occurs.
 
+VFS first attempts to match a full path. If this fails, it falls back to a case-insensitive match on
+the basename. For example, an entry named ``assets/Cube.OBJ`` can be found as ``cube.obj``.
+
 *Nullable:* ``directory``
+
+.. _mj_addBufferVFS:
+
+Add file to VFS from buffer; return 0: success, 2: repeated name, -1: failed to load.
+
+VFS first attempts to match a full path. If this fails, it falls back to a case-insensitive match on
+the basename. For example, an entry named ``assets/Cube.OBJ`` can be found as ``cube.obj``.
 
 .. _Assetcache:
 


### PR DESCRIPTION
## Summary

Documents VFS lookup fallback behavior for `mj_addFileVFS` and
`mj_addBufferVFS`.

The API reference now explains that VFS tries a full-path match first, then
falls back to a case-insensitive basename match.

Related to #2484.

## Testing

- `make -C doc html`