### PR TITLE
Add a single-precision job to GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@
 #     no coverage.
 #   * ccache is used to wrap the compiler. PR branches fall back to main's cache, so
 #     the expensive (and pinned) Filament build is restored rather than recompiled.
+#   * Single precision (mjUSESINGLE) is covered by the dedicated `single` job
+#     below - one fast configuration rather than a matrix-wide rebuild.
 
 # TODO(matijak): Consider switching Windows to Ninja builds only, this configures slightly faster
 # and brings Windows in line with other OSes. Also we wouldn't need to specify the --config option
@@ -221,6 +223,61 @@ jobs:
         CHATMSG_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         CHATMSG_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         CHATMSG_JOB_ID: ${{ matrix.label }}
+      if: failure() && github.ref_name == 'main' && github.event_name == 'push' && env.GCHAT_API_URL != ''
+      run: bash ./.github/workflows/build_steps.sh notify_team_chat
+
+  # Single-precision canary: build the library and test suite with mjtNum
+  # defined as float (-DmjUSESINGLE) and run the C/C++ tests. Internal CI tests
+  # this configuration, but the matrix above is double-only, so PRs that break
+  # single-precision builds or tests would otherwise look green here and only
+  # fail on import. One fast configuration is enough: the failures this catches
+  # (double-only code, tolerances too tight for float32) are not
+  # compiler-specific, and a full extra matrix would double CI cost.
+  single:
+    name: "ubuntu-24.04-clang-18-single"
+    runs-on: ubuntu-24.04
+    env:
+      label: "ubuntu-24.04-clang-18-single"
+      TMPDIR: "/tmp"
+      CMAKE_ARGS: >-
+        -G Ninja
+        -DCMAKE_C_COMPILER:STRING=clang-18
+        -DCMAKE_CXX_COMPILER:STRING=clang++-18
+        -DMUJOCO_HARDEN:BOOL=ON
+        -DCMAKE_C_FLAGS:STRING=-DmjUSESINGLE
+        -DCMAKE_CXX_FLAGS:STRING=-DmjUSESINGLE
+    steps:
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+    - name: Prepare Linux
+      run: bash ./.github/workflows/build_steps.sh prepare_linux
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+      with:
+        key: ${{ env.label }}
+        max-size: "1.5G"
+
+    - name: Configure MuJoCo
+      run: bash ./.github/workflows/build_steps.sh configure_mujoco
+
+    - name: Build MuJoCo
+      working-directory: build
+      run: bash ../.github/workflows/build_steps.sh build_mujoco
+
+    - name: Test MuJoCo
+      working-directory: build
+      run: bash ../.github/workflows/build_steps.sh test_mujoco
+
+    - name: Notify team chat
+      shell: bash
+      env:
+        GCHAT_API_URL: ${{ secrets.GCHAT_API }}
+        JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        CHATMSG_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+        CHATMSG_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+        CHATMSG_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        CHATMSG_JOB_ID: ${{ env.label }}
       if: failure() && github.ref_name == 'main' && github.event_name == 'push' && env.GCHAT_API_URL != ''
       run: bash ./.github/workflows/build_steps.sh notify_team_chat
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Generate build matrix
       id: generate
       env:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Prepare Linux
       if: ${{ runner.os == 'Linux' }}
@@ -77,7 +77,7 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
       run: brew install ninja
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.11"
 
@@ -86,7 +86,7 @@ jobs:
     # keeps the venv activate fixup path untouched there).
     - name: Install uv
       if: ${{ runner.os != 'Windows' }}
-      uses: astral-sh/setup-uv@v8.2.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "python/build_requirements*.txt"
@@ -103,7 +103,7 @@ jobs:
     # isn't the bottleneck, so we skip it there.
     - name: Setup ccache
       if: ${{ runner.os != 'Windows' }}
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ${{ matrix.label }}
         max-size: "1.5G"
@@ -116,7 +116,7 @@ jobs:
 
     - name: Upload CMake Configure Log
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cmake-configure-log-${{ matrix.label }}
         path: build/CMakeFiles/CMakeConfigureLog.yaml
@@ -158,8 +158,11 @@ jobs:
       run: bash ../.github/workflows/build_steps.sh configure_samples
 
     - name: Build samples
+      shell: bash
       working-directory: sample/build
-      run: cmake --build . --config=Release ${{ matrix.cmake_build_args }}
+      env:
+        CMAKE_BUILD_ARGS: ${{ matrix.cmake_build_args }}
+      run: cmake --build . --config=Release $CMAKE_BUILD_ARGS
 
     - name: Configure simulate
       working-directory: simulate
@@ -260,11 +263,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Prepare Windows (setup MSVC)
       if: ${{ runner.os == 'Windows' }}
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
     - name: Prepare Linux
       if: ${{ runner.os == 'Linux' }}
@@ -277,7 +280,7 @@ jobs:
     # compiler invocation, so changing any build flag forces a recompile regardless.)
     - name: Setup ccache
       if: ${{ runner.os != 'Windows' }}
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ${{ matrix.label }}-filament-${{ hashFiles('cmake/third_party_deps/filament.cmake') }}
         restore-keys: ${{ matrix.label }}-filament-
@@ -316,10 +319,10 @@ jobs:
         -DCMAKE_CXX_COMPILER:STRING=clang++-18
         -DMUJOCO_HARDEN:BOOL=ON
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Setup Node.js for WASM bindings
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: '24.x'
 
@@ -328,7 +331,7 @@ jobs:
       run: bash ./.github/workflows/build_steps.sh prepare_linux
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ${{ env.label }}
         max-size: "1.5G"
@@ -371,17 +374,17 @@ jobs:
         -DMUJOCO_HARDEN:BOOL=ON
         -DMUJOCO_BUILD_TESTS:BOOL=OFF
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Prepare Linux
       run: bash ./.github/workflows/build_steps.sh prepare_linux
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.2.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "python/build_requirements*.txt"
@@ -390,7 +393,7 @@ jobs:
       run: bash ./.github/workflows/build_steps.sh prepare_python
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ubuntu-24.04-clang-18-mjx
         max-size: "1.0G"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@
 #     no coverage.
 #   * ccache is used to wrap the compiler. PR branches fall back to main's cache, so
 #     the expensive (and pinned) Filament build is restored rather than recompiled.
+#   * Single precision (mjUSESINGLE) is covered by the dedicated `single` job
+#     below - one fast configuration rather than a matrix-wide rebuild.
 
 # TODO(matijak): Consider switching Windows to Ninja builds only, this configures slightly faster
 # and brings Windows in line with other OSes. Also we wouldn't need to specify the --config option
@@ -217,6 +219,61 @@ jobs:
         CHATMSG_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
         CHATMSG_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         CHATMSG_JOB_ID: ${{ matrix.label }}
+      if: failure() && github.ref_name == 'main' && github.event_name == 'push' && env.GCHAT_API_URL != ''
+      run: bash ./.github/workflows/build_steps.sh notify_team_chat
+
+  # Single-precision canary: build the library and test suite with mjtNum
+  # defined as float (-DmjUSESINGLE) and run the C/C++ tests. Internal CI tests
+  # this configuration, but the matrix above is double-only, so PRs that break
+  # single-precision builds or tests would otherwise look green here and only
+  # fail on import. One fast configuration is enough: the failures this catches
+  # (double-only code, tolerances too tight for float32) are not
+  # compiler-specific, and a full extra matrix would double CI cost.
+  single:
+    name: "ubuntu-24.04-clang-18-single"
+    runs-on: ubuntu-24.04
+    env:
+      label: "ubuntu-24.04-clang-18-single"
+      TMPDIR: "/tmp"
+      CMAKE_ARGS: >-
+        -G Ninja
+        -DCMAKE_C_COMPILER:STRING=clang-18
+        -DCMAKE_CXX_COMPILER:STRING=clang++-18
+        -DMUJOCO_HARDEN:BOOL=ON
+        -DCMAKE_C_FLAGS:STRING=-DmjUSESINGLE
+        -DCMAKE_CXX_FLAGS:STRING=-DmjUSESINGLE
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Prepare Linux
+      run: bash ./.github/workflows/build_steps.sh prepare_linux
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ env.label }}
+        max-size: "1.5G"
+
+    - name: Configure MuJoCo
+      run: bash ./.github/workflows/build_steps.sh configure_mujoco
+
+    - name: Build MuJoCo
+      working-directory: build
+      run: bash ../.github/workflows/build_steps.sh build_mujoco
+
+    - name: Test MuJoCo
+      working-directory: build
+      run: bash ../.github/workflows/build_steps.sh test_mujoco
+
+    - name: Notify team chat
+      shell: bash
+      env:
+        GCHAT_API_URL: ${{ secrets.GCHAT_API }}
+        JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        CHATMSG_AUTHOR_NAME: ${{ github.event.head_commit.author.name }}
+        CHATMSG_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+        CHATMSG_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        CHATMSG_JOB_ID: ${{ env.label }}
       if: failure() && github.ref_name == 'main' && github.event_name == 'push' && env.GCHAT_API_URL != ''
       run: bash ./.github/workflows/build_steps.sh notify_team_chat
 


### PR DESCRIPTION
The GitHub Actions matrix builds only double precision, so changes that break `mjUSESINGLE` builds or tests pass CI, and the breakage is only discovered downstream.

This adds a dedicated `single` job (ubuntu-24.04, clang-18) that builds the library and test suite with `-DmjUSESINGLE` and runs ctest. One fast configuration is enough to catch the common breakages (`mjtNum`-vs-`double` type confusion, tests without single-precision tolerances); the job runs in parallel with the rest of the workflow, so total wall-clock time is unchanged.

Notes:
- The `mjUSESINGLE` define is passed via `CMAKE_C_FLAGS`/`CMAKE_CXX_FLAGS` so that `MujocoDependencies.cmake` also builds libccd in single precision.
- No Python/samples/install steps: the Python bindings require double precision.
- Validated on a fork run (yuvaltassa/mujoco#3): 1944 tests passed, 0 failed, 17 skipped via their `mjUSESINGLE` guards; 8m46s with a cold cache. A previous head of this PR also ran fully green here.
- Rebased onto current main. The action-pinning commit from the earlier revision was dropped: the `zizmor-output` finding on unpinned actions is pre-existing across build.yml and evidently not gating (#3008 merged with the same red check), so this PR now touches nothing beyond adding the job. Expect `zizmor-output` to be red for that pre-existing reason.