### PR TITLE
Remove quadratic scan from convex hull graph construction

### DIFF
--- a/src/user/user_mesh.cc
+++ b/src/user/user_mesh.cc
@@ -1947,20 +1947,24 @@ void mjCMesh::MakeGraph(const double* dvert) {
     }
 
     // replace global ids with local ids in edge data
-    for (int i=0; i < numvert+3*numface; i++) {
-      if (edge_localid[i] >= 0) {
-        // search vert_globalid for match
-        int adr;
-        for (adr=0; adr < numvert; adr++) {
-          if (vert_globalid[adr] == edge_localid[i]) {
-            edge_localid[i] = adr;
-            break;
-          }
-        }
+    else {
+      // invert vert_globalid: point id -> hull vertex index, -1 if not on hull.
+      // every vert_globalid entry was range-checked above, so the index is safe.
+      std::vector<int> hullid(nvert(), -1);
+      for (int adr=0; adr < numvert; adr++) {
+        hullid[vert_globalid[adr]] = adr;
+      }
 
-        // make sure we found a match: SHOULD NOT OCCUR
-        if (adr >= numvert) {
-          mju_error("Vertex id not found in convex hull");
+      for (int i=0; i < numvert+3*numface; i++) {
+        if (edge_localid[i] >= 0) {
+          int adr = hullid[edge_localid[i]];
+
+          // make sure we found a match: SHOULD NOT OCCUR
+          if (adr < 0) {
+            mju_error("Vertex id not found in convex hull");
+          }
+
+          edge_localid[i] = adr;
         }
       }
     }


### PR DESCRIPTION
## Summary

`mjCMesh::MakeGraph` rewrites each convex-hull neighbour reference from a global
mesh point id to a local hull index by linear-searching `vert_globalid`. This
change inverts `vert_globalid` once into a point-id table and makes a single
pass. The `!ok` branch, which frees `graph_` while `edge_localid` still points
into it, now skips the remap instead of walking the freed block.

Hull graph contents, error diagnostic, and public API are unchanged.

## Cost

A convex hull is a closed triangulated 2-sphere, so `V` fixes every count:
`F = 2V - 4`, `E = 3V - 6`, `edge_localid` length `L = V + 3F = 7V - 12`, of
which `V` are separators. Lookups are `6V - 12 = 2E`, one per directed edge.
Probe counters compiled into the loop on `main` at `b475bb6f`:

| `V` | lookups | `6V-12` | probes | `3V^2-6V` | ratio | mean scan | `V/2` |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 642 | 3,840 | 3,840 | 1,233,560 | 1,232,640 | 1.0007 | 321.24 | 321 |
| 2,562 | 15,360 | 15,360 | 19,677,493 | 19,676,160 | 1.00007 | 1,281.09 | 1,281 |
| 10,242 | 61,440 | 61,440 | 314,643,317 | 314,635,200 | 1.000026 | 5,121.15 | 5,121 |

Lookups match the closed form exactly at every size; probes agree with
`3V^2 - 6V` to five significant figures by `V = 10,242`. The mean scan is `V/2`,
so qhull's emission order carries no locality the linear search exploits. The
replacement costs `8V - 12`; the ratio is `3V/8`, or 15,361x fewer probes at
`V = 40,962`.

## End-to-end

Paired `mj_loadXML` through the public API, identical driver source for both
arms, only `libmujoco` differing. Windows 11 x86-64, MSVC 19.44.35207, Release,
PR head on `main` at `b475bb6f`. Corpus is subdivided icosahedra projected to
the unit sphere, so every vertex is extreme and `nmeshvert == numvert`. Compiled
mesh assets are cached by content, so each cold load is preceded by
`mj_clearCache(mj_getCache())`; the warm column omits that clear and is the
control for the path this change does not touch. Medians of 5 loads after 2
warmups.

| `V` | `F` | main cold ms | this PR cold ms | speedup | main warm | this PR warm | graph checksum |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 42 | 80 | 1.156 | 1.105 | 1.05x | 0.813 | 0.793 | `f768510d3c10e06b` |
| 162 | 320 | 1.954 | 2.006 | 0.97x | 0.955 | 0.981 | `98410c92e65ec1d3` |
| 642 | 1,280 | 5.406 | 4.784 | 1.13x | 1.217 | 1.069 | `5f024bf041318fa3` |
| 2,562 | 5,120 | 20.768 | 17.907 | 1.16x | 1.903 | 2.525 | `54c18f48a3b49a13` |
| 10,242 | 20,480 | 134.400 | 71.163 | 1.89x | 5.591 | 6.110 | `27d59d18d0c36c79` |
| 40,962 | 81,920 | 1,354.388 | 321.908 | 4.21x | 21.840 | 22.361 | `d6185ad74759210d` |

The checksum is FNV-1a over `mjModel.mesh_graph[0 .. nmeshgraph)`, the array the
loop writes. It is identical between the two builds at all six sizes.

## Validation

- Windows 11 x86-64, MSVC 19.44.35207, Release: full serial CTest suite passed
  1,339/1,339 entries, 0 failed. Two entries reported `Skipped` status
  (`RecompileCompareTest.RecompileCompare`, `WriteReadCompareTest.WriteReadCompare`).
- Ubuntu 24.04 (WSL2), Clang 21.1.8, RelWithDebInfo + AddressSanitizer with
  `ASAN_OPTIONS=detect_leaks=1`: all 70 `MjCMeshTest` cases passed, and 321/321
  `RecompileCompareTest` entries passed (14 entries skipped, models whose asset
  paths do not resolve in that build tree). No sanitizer report of any kind.
- Adverse case, since the inverse table is sized by `nvert()` rather than by hull
  size: a large mesh with the hull capped by `maxhullvert`, where the previous
  scan is over a tiny `numvert`. At `nvert = 40,962`, `maxhullvert = 8`, cold
  load is 139.111 ms and the table is 164 KB, roughly 16 us to zero-fill — an
  order of magnitude below the 1.4 ms spread already present between
  `maxhullvert` 8 and 64 at the same `nvert`.

Reaching an ASAN build at all required two local workarounds for
`include/mujoco/mjsan.h`, both inside the `mjUSEASAN` block that
`engine_crossplatform.h:78` auto-enables: `asm volatile` at `mjsan.h:59,61,66,68`
is not a keyword under the `-std=c11` the build uses (Clang 21:
`use of undeclared identifier 'asm'`; `__asm__` works in both modes), and
`__attribute__((always_inline))` at `mjsan.h:58,65` sits after the parameter list
of a definition, which is a hard error on GCC 15 and a `-Wgcc-compat` warning
that `-Werror` promotes on Clang 21. Neither is touched by this PR.

## Limits

The corpus is generated: no bundled model has a convex mesh near 40,962 hull
vertices, so 4.21x describes large authored or scanned collision meshes rather
than anything in the repository. Below `V` around 2,500 the difference is within
noise, including the 0.97x at `V = 162`; the two arms run identical code outside
the patched loop. Warm-column differences are noise for the same reason, since a
cache hit skips `MakeGraph` entirely. Timings are single-machine,
single-compiler, medians of 5.

Fixes #3449.
