### PR TITLE
Make mjsan.h compile under strict C11 with GCC

### DIFF
--- a/include/mujoco/mjsan.h
+++ b/include/mujoco/mjsan.h
@@ -55,17 +55,17 @@ extern "C" {
 #endif
 
 void mj__markStack(mjData*) __attribute__((noinline));
-static inline void mj_markStack(mjData* d) __attribute__((always_inline)) {
-  asm volatile("" ::: "memory");
+__attribute__((always_inline)) static inline void mj_markStack(mjData* d) {
+  __asm__ volatile("" ::: "memory");
   mj__markStack(d);
-  asm volatile("" ::: "memory");
+  __asm__ volatile("" ::: "memory");
 }
 
 void mj__freeStack(mjData*) __attribute__((noinline));
-static inline void mj_freeStack(mjData* d) __attribute__((always_inline)) {
-  asm volatile("" ::: "memory");
+__attribute__((always_inline)) static inline void mj_freeStack(mjData* d) {
+  __asm__ volatile("" ::: "memory");
   mj__freeStack(d);
-  asm volatile("" ::: "memory");
+  __asm__ volatile("" ::: "memory");
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

`mjsan.h` replaces `mj_markStack` and `mj_freeStack` with sanitizer-aware definitions, so it is compiled only when a sanitizer is enabled. Two constructs in those definitions are rejected by GCC in strict C11 mode, which the project selects with `-std=c11 -Wpedantic -Werror`.

The attribute follows the declarator in a function definition, which GCC rejects with *"attributes should be specified before the declarator in a function definition"*. The barrier uses the bare keyword `asm`, which is not reserved in strict C11; GCC requires `__asm__` there.

Both move to the accepted spelling. Generated code is unchanged: `always_inline` still applies, and `__asm__ volatile` is the same barrier. Six lines, one file. There is no API, semantics, or non-sanitizer build change.

## Reproduction

On `f9a00bd5`, Ubuntu 26.04, GCC 15.2.0:

```
gcc -std=c11 -Wpedantic -Werror -fsanitize=address \
    -Iinclude -Isrc -c src/engine/engine_collision_box.c -o /dev/null
```

| | exit | diagnostics |
| --- | ---: | --- |
| before | 1 | `mjsan.h:58` and `mjsan.h:65`, attributes should be specified before the declarator |
| after | 0 | none |

Any translation unit reaching `mj_markStack` or `mj_freeStack` fails identically, so an ASan build of the library does not get past its first engine source file.

## Coverage

Measured after the change, same host and flags:

| configuration | exit |
| --- | ---: |
| GCC 15.2.0, `-fsanitize=address` | 0 |
| clang 21.1.8, `-fsanitize=address` | 0 |
| GCC 15.2.0, no sanitizer | 0 |

The third row is the control: without a sanitizer the header takes its other branch, so it confirms the ordinary build path is untouched.

## Limits

Verified on Linux x86-64 with GCC 15.2.0 and clang 21.1.8 only. Older GCC accepts the trailing-attribute form, so this is a portability fix rather than a correctness fix, and it is invisible unless a sanitizer is enabled. Windows and macOS were not exercised, though neither construct is compiler-specific in the direction that would newly break them.
