### PR TITLE
sysid: avoid mutating input in apply_delay

### DIFF
--- a/python/mujoco/sysid/_src/signal_modifier.py
+++ b/python/mujoco/sysid/_src/signal_modifier.py
@@ -118,7 +118,9 @@ def apply_delay(
   )
   ts_sensor_delayed = ts_sensor.resample(ts.times - delay.value)
 
-  ts_delayed = timeseries.TimeSeries(ts.times, ts.data, ts.signal_mapping)
+  ts_delayed = timeseries.TimeSeries(
+      ts.times, ts.data.copy(), ts.signal_mapping
+  )
   ts_delayed.data[:, indices] = ts_sensor_delayed.data
 
   return ts_delayed

--- a/python/mujoco/sysid/tests/test_signal.py
+++ b/python/mujoco/sysid/tests/test_signal.py
@@ -159,6 +159,24 @@ def test_apply_bias(arm_model):
 
 
 # ===========================================================================
+# signal_modifier: apply_delay
+# ===========================================================================
+
+
+def test_apply_delay_does_not_modify_input(arm_model):
+  """Delaying a sensor leaves the input timeseries unchanged."""
+  ts = _make_arm_sensor_ts(arm_model)
+  data = ts.data.copy()
+  delay = parameter.Parameter("delay", 0.1, 0.0, 0.2)
+
+  result = signal_modifier.apply_delay(ts, "joint1_pos", delay)
+
+  np.testing.assert_array_equal(ts.data, data)
+  idx = ts.get_indices("joint1_pos")[1]
+  assert not np.array_equal(result.data[:, idx], data[:, idx])
+
+
+# ===========================================================================
 # signal_modifier: apply_delayed_ts_window
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Copy time-series data before writing delayed sensor values.

`apply_delay()` constructed its result from the input array and then modified it in place, which also changed the caller's `TimeSeries`. The result now owns a copy before delayed samples are assigned.

## Tests

- Added a regression test confirming the input remains unchanged
- Verified the returned delayed signal differs as expected
