### PR TITLE
sysid: fix weights for selected and multidimensional sensors

### DIFF
--- a/python/mujoco/sysid/_src/residual.py
+++ b/python/mujoco/sysid/_src/residual.py
@@ -335,6 +335,7 @@ def model_residual(
           measured_data=measured_sensordata.data,
           model=model,
           sensor_weights=sensor_weights,
+          signal_mapping=measured_sensordata.signal_mapping,
       )
       res = signal_modifier.normalize_residual(res, measured_sensordata.data)
 

--- a/python/mujoco/sysid/_src/signal_modifier.py
+++ b/python/mujoco/sysid/_src/signal_modifier.py
@@ -259,6 +259,7 @@ def prepare_sensor_weights(
     sensor_weights: Mapping[str, float] | np.ndarray,
     n_sensors: int,
     model: mujoco.MjModel,
+    signal_mapping: timeseries.SignalMappingType | None = None,
 ) -> np.ndarray:
   """Prepare sensor weights array from a dict or numpy array.
 
@@ -266,6 +267,14 @@ def prepare_sensor_weights(
     sensor_weights: Mapping from sensor name to weight, or a flat array.
     n_sensors: Total number of sensor columns.
     model: MuJoCo model for resolving sensor names to indices.
+    signal_mapping: Optional mapping from sensor names to their data columns.
+      If provided, every weighted sensor must be present and map to an
+      ``MjSensor`` signal.
+
+  Raises:
+    ValueError: If the weights array has the wrong shape, or a weighted sensor
+      is missing from ``signal_mapping`` or does not map to an ``MjSensor``
+      signal.
   """
   if isinstance(sensor_weights, np.ndarray):
     if sensor_weights.ndim != 1 or sensor_weights.shape[0] != n_sensors:
@@ -276,9 +285,16 @@ def prepare_sensor_weights(
     return sensor_weights
   else:
     weights = np.ones(n_sensors)
-    ids = get_sensor_indices(model, list(sensor_weights.keys()))
-    for i, w in zip(ids, sensor_weights.values(), strict=True):
-      weights[i] = w
+    for name, weight in sensor_weights.items():
+      if signal_mapping is None:
+        indices = get_sensor_indices(model, name)
+      else:
+        if name not in signal_mapping:
+          raise ValueError(f"Sensor not found in signal_mapping: {name}")
+        signal_type, indices = signal_mapping[name]
+        if signal_type != timeseries.SignalType.MjSensor:
+          raise ValueError(f"Weighted signal must be an MjSensor: {name}")
+      weights[indices] = weight
     return weights
 
 
@@ -287,6 +303,7 @@ def weighted_diff(
     measured_data: np.ndarray,
     model: mujoco.MjModel | None = None,
     sensor_weights: Mapping[str, float] | np.ndarray | None = None,
+    signal_mapping: timeseries.SignalMappingType | None = None,
 ) -> np.ndarray:
   """Compute the weighted difference between measured and predicted data.
 
@@ -300,16 +317,25 @@ def weighted_diff(
       is not None.
     sensor_weights: An optional dict mapping sensor name to weight. Unspecified
       sensors are assumed to have a weight of 1.
+    signal_mapping: Optional mapping from sensor names to their data columns.
+      If provided, every name in ``sensor_weights`` must be present and map to
+      an ``MjSensor`` signal.
 
   Returns:
     A numpy array of the weighted difference.
+
+  Raises:
+    ValueError: If sensor weights require a model, have the wrong shape, or
+      refer to a missing or non-sensor entry in ``signal_mapping``.
   """
   res = measured_data - predicted_data
   if sensor_weights is None:
     return res
   if model is None:
     raise ValueError("model is required if sensor_weights is provided")
-  return res * prepare_sensor_weights(sensor_weights, res.shape[-1], model)
+  return res * prepare_sensor_weights(
+      sensor_weights, res.shape[-1], model, signal_mapping
+  )
 
 
 def normalize_residual(

--- a/python/mujoco/sysid/_src/signal_transform.py
+++ b/python/mujoco/sysid/_src/signal_transform.py
@@ -279,6 +279,7 @@ class SignalTransform:
         measured_data=sensordata_measured.data,
         model=model,
         sensor_weights=weights,
+        signal_mapping=sensordata_measured.signal_mapping,
     )
 
     # 6. Normalize.

--- a/python/mujoco/sysid/tests/test_signal.py
+++ b/python/mujoco/sysid/tests/test_signal.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for signal_modifier and SignalTransform."""
 
+import mujoco
 from mujoco.sysid._src import parameter
 from mujoco.sysid._src import signal_modifier
 from mujoco.sysid._src import timeseries
@@ -201,6 +202,106 @@ def test_weighted_diff_with_weights(arm_model):
   np.testing.assert_allclose(result[:, idx], 0.5)
   other = [i for i in range(n) if i not in idx]
   np.testing.assert_allclose(result[:, other], 1.0)
+
+
+def test_weighted_diff_weights_all_sensor_components():
+  """A sensor's weight applies to each component of its output."""
+  model = mujoco.MjModel.from_xml_string("""
+    <mujoco>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="sphere" size="1"/>
+          <site name="site"/>
+        </body>
+      </worldbody>
+      <sensor>
+        <clock name="time"/>
+        <framepos name="position" objtype="site" objname="site"/>
+      </sensor>
+    </mujoco>
+  """)
+  predicted = np.zeros((1, model.nsensordata))
+  measured = np.ones((1, model.nsensordata))
+
+  result = signal_modifier.weighted_diff(
+      predicted, measured, model, {"position": 0.5}
+  )
+
+  np.testing.assert_array_equal(result, [[1.0, 0.5, 0.5, 0.5]])
+
+
+@pytest.mark.parametrize(
+    ("names", "expected"),
+    [
+        (["position"], [[0.5, 0.5, 0.5]]),
+        (["position", "time"], [[0.5, 0.5, 0.5, 1.0]]),
+    ],
+)
+def test_weighted_diff_uses_observation_layout(names, expected):
+  """Weights follow compact and reordered observation columns."""
+  model = mujoco.MjModel.from_xml_string("""
+    <mujoco>
+      <worldbody>
+        <body>
+          <freejoint/>
+          <geom type="sphere" size="1"/>
+          <site name="site"/>
+        </body>
+      </worldbody>
+      <sensor>
+        <clock name="time"/>
+        <framepos name="position" objtype="site" objname="site"/>
+      </sensor>
+    </mujoco>
+  """)
+  measured = np.ones((1, len(expected[0])))
+  observations = timeseries.TimeSeries.from_names(
+      np.array([0.0]), measured, model, names
+  )
+
+  result = signal_modifier.weighted_diff(
+      np.zeros_like(measured),
+      measured,
+      model,
+      {"position": 0.5},
+      observations.signal_mapping,
+  )
+
+  np.testing.assert_array_equal(result, expected)
+
+
+def test_weighted_diff_rejects_weight_missing_from_observation_layout(
+    arm_model,
+):
+  mapping = timeseries.TimeSeries.compute_all_sensor_mapping(arm_model)
+  del mapping["joint1_pos"]
+
+  with pytest.raises(
+      ValueError, match="Sensor not found in signal_mapping: joint1_pos"
+  ):
+    signal_modifier.weighted_diff(
+        np.zeros((1, arm_model.nsensordata)),
+        np.ones((1, arm_model.nsensordata)),
+        arm_model,
+        {"joint1_pos": 0.5},
+        mapping,
+    )
+
+
+def test_weighted_diff_rejects_non_sensor_mapping(arm_model):
+  mapping = {"joint1_pos": (timeseries.SignalType.CustomObs, np.array([0]))}
+
+  with pytest.raises(
+      ValueError, match="Weighted signal must be an MjSensor: joint1_pos"
+  ):
+    signal_modifier.weighted_diff(
+        np.zeros((1, 1)),
+        np.ones((1, 1)),
+        arm_model,
+        {"joint1_pos": 0.5},
+        mapping,
+    )
 
 
 def test_normalize_residual():


### PR DESCRIPTION
## Summary

Apply named sensor weights to every sensor component and resolve them against the actual observation layout.

The previous implementation zipped flattened component indices with one value per sensor, which failed for multidimensional sensors. It also used full `sensordata` offsets when residual observations contained a compact or reordered sensor subset.

Weights are now assigned per sensor and use the measured signal mapping when available. Missing or non-sensor mapping entries raise a clear `ValueError`.

## Tests

- Covered multidimensional sensor weights
- Covered compact and reordered observation layouts
- Covered invalid mapped sensor names and signal types
