### PR TITLE
sysid: make remove_from_beginning relative to the start

### DIFF
--- a/python/mujoco/sysid/_src/timeseries.py
+++ b/python/mujoco/sysid/_src/timeseries.py
@@ -746,11 +746,11 @@ class TimeSeries:
     """
     if time_to_remove_s < 0:
       raise ValueError("time_to_remove_s must be non-negative")
-    if time_to_remove_s > self.times[-1]:
+    if time_to_remove_s > self.times[-1] - self.times[0]:
       raise ValueError(
           "time_to_remove_s is greater than the duration of the time series"
       )
-    idx = np.searchsorted(self.times, time_to_remove_s)
+    idx = np.searchsorted(self.times, self.times[0] + time_to_remove_s)
     times_shifted = self.times[idx:] - self.times[idx]
     return TimeSeries(
         times=times_shifted,

--- a/python/mujoco/sysid/tests/test_timeseries.py
+++ b/python/mujoco/sysid/tests/test_timeseries.py
@@ -200,6 +200,19 @@ def test_resample_with_target_dt(scalar_ts):
     scalar_ts.resample()
 
 
+def test_remove_from_beginning_with_nonzero_start():
+  """Removal duration is measured relative to the first timestamp."""
+  ts = TimeSeries(
+      times=np.array([10.0, 11.0, 12.0, 13.0]),
+      data=np.array([0.0, 1.0, 2.0, 3.0]),
+  )
+
+  result = ts.remove_from_beginning(2.0)
+
+  np.testing.assert_array_equal(result.times, [0.0, 1.0])
+  np.testing.assert_array_equal(result.data, [2.0, 3.0])
+
+
 # ---------------------------------------------------------------------------
 # TimeSeries factory method tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Interpret `remove_from_beginning()` arguments as durations relative to the first timestamp.

The method previously compared and searched using an absolute timestamp, which only worked for series starting at zero. Nonzero-start recordings could remove the wrong samples or fail duration validation.

## Tests

- Added coverage for a series beginning at `t=10`
- Verified the requested duration is removed and output timestamps are rebased
