### PR TITLE
Fix convex inertia for unreferenced meshes

### DIFF
--- a/src/user/user_mesh.cc
+++ b/src/user/user_mesh.cc
@@ -318,6 +318,9 @@ void mjCMesh::CopyFromSpec() {
   texcoord_ = spec_texcoord_;
   facetexcoord_ = spec_facetexcoord_;
   maxhullvert_ = spec.maxhullvert;
+  if (inertia == mjMESH_INERTIA_CONVEX) {
+    needhull_ = true;
+  }
   plugin.active = spec.plugin.active;
   plugin.element = spec.plugin.element;
   plugin.plugin_name = spec.plugin.plugin_name;

--- a/test/user/user_mesh_test.cc
+++ b/test/user/user_mesh_test.cc
@@ -960,6 +960,22 @@ TEST_F(MjCMeshTest, ExactConcaveInertia) {
   mj_deleteModel(model);
 }
 
+TEST_F(MjCMeshTest, UnreferencedConvexInertiaMesh) {
+  static constexpr char xml[] = R"(
+    <mujoco>
+      <asset>
+        <mesh name="orphan" inertia="convex"
+              vertex="0 0 1  1 0 0  0 1 0  -1 0 0  0 -1 0"
+              face="0 1 2  0 2 3  0 3 4  0 4 1  1 4 3  1 3 2"/>
+      </asset>
+    </mujoco>
+  )";
+  char error[1024];
+  MjModelPtr model = LoadModelFromString(xml, error, sizeof(error));
+  ASSERT_THAT(model.get(), NotNull()) << error;
+  EXPECT_EQ(model->nmesh, 1);
+}
+
 TEST_F(MjCMeshTest, ExactConvexInertia) {
   const std::string xml_path = GetTestDataFilePath(kConvexInertiaPath);
   std::array<char, 1024> error;


### PR DESCRIPTION
Fixes #3431.

Meshes using `inertia="convex"` require a convex-hull graph for volume and inertia calculations. An unreferenced mesh can skip the existing geom-driven hull marking, leaving its graph uninitialized before convex inertia is computed.

This change makes each convex-inertia mesh mark itself as requiring a hull when its spec is copied, before cache lookup and mesh processing.

Adds a regression test that compiles the orphan convex-inertia mesh from #3431.