### PR TITLE
Fix LuGre passivity in DC motor doc

### DIFF
--- a/doc/dcmotor/dcmotor.tex
+++ b/doc/dcmotor/dcmotor.tex
@@ -748,7 +748,7 @@ with exponent $\gamma$ typically 1 or 2. In steady state, $\tau_{ss}(\omega) = -
 
 \noindent The Dahl model is recovered by setting $g(\omega) = \tau_c$ and $\sigma_1 = \sigma_2 = 0$. Linearizing around $\omega = z = 0$ gives second-order dynamics $J\ddot{\theta} - (\sigma_1 + \sigma_2)\dot{\theta} - \sigma_0 \theta = \tau$ (applied torque): a spring-damper with natural frequency $\omega_n = \sqrt{\sigma_0/J}$, critically damped when $\sigma_1 = 2\sqrt{J\sigma_0}$.
 
-The LuGre model can be shown to be input-strictly-passive (the map $\omega \mapsto \tau$ dissipates energy) provided $\sigma_2 > \sigma_1 (\tau_s - \tau_c)/\tau_c$. This passivity condition limits $\sigma_1$ and can lead to underdamped micro-dynamics, motivating the following extension.
+The LuGre model can be shown to be input-strictly-passive (the map $\omega \mapsto -\tau$ dissipates energy) provided $\sigma_2 > \sigma_1 (\tau_s - \tau_c)/\tau_c$. This passivity condition limits $\sigma_1$ and can lead to underdamped micro-dynamics, motivating the following extension.
 
 %  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 \subsubsection{Velocity-Dependent Damping}


### PR DESCRIPTION
Correct the LuGre passivity description in the DC motor technical documentation.
Since `tau` is defined as the torque applied to the mechanism (eq. 9b of the pdf), the passive resisting effort is `-tau`. The documented map is therefore corrected from `omega -> tau` to `omega -> -tau`.