### PR TITLE
Validate legacy MSH headers before parsing

### DIFF
--- a/python/mujoco/msh2obj.py
+++ b/python/mujoco/msh2obj.py
@@ -42,10 +42,16 @@ class Msh:
       raise FileNotFoundError(f"{file} does not exist.")
 
     with open(file, "rb") as f:
-      nvertex = np.fromfile(f, dtype=np.int32, count=1)[0]
-      nnormal = np.fromfile(f, dtype=np.int32, count=1)[0]
-      ntexcoord = np.fromfile(f, dtype=np.int32, count=1)[0]
-      nface = np.fromfile(f, dtype=np.int32, count=1)[0]
+      header = np.fromfile(f, dtype=np.int32, count=4)
+      if header.size != 4:
+        raise ValueError(
+            f"Invalid MSH header: expected 4 counts, got {header.size}."
+        )
+      if np.any(header < 0):
+        raise ValueError(
+            f"Invalid MSH header: counts must be nonnegative, got {header}."
+        )
+      nvertex, nnormal, ntexcoord, nface = header
       vertex_positions = np.fromfile(f, dtype=np.float32, count=3 * nvertex)
       vertex_normals = np.fromfile(f, dtype=np.float32, count=3 * nnormal)
       vertex_texcoords = np.fromfile(f, dtype=np.float32, count=2 * ntexcoord)
@@ -62,7 +68,7 @@ class Msh:
     if vertex_texcoords.size != 2 * ntexcoord:
       raise ValueError(
           f"Invalid number of texcoords: {vertex_texcoords.size} != "
-          "2*{ntexcoord}."
+          f"2*{ntexcoord}."
       )
     if face_vertex_indices.size != 3 * nface:
       raise ValueError(

--- a/python/mujoco/msh2obj_test.py
+++ b/python/mujoco/msh2obj_test.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 """Tests for msh2obj.py."""
 
+import pathlib
 
 from absl.testing import absltest
 from etils import epath
-import mujoco
-from mujoco import msh2obj
 import numpy as np
 
+import mujoco
+from mujoco import msh2obj
 
 _MESH_FIELDS = (
     "mesh_vertadr",
@@ -53,6 +54,36 @@ _XML = """
 
 
 class MshTest(absltest.TestCase):
+
+  def test_rejects_truncated_header(self) -> None:
+    for header in ([], [1, 0]):
+      with self.subTest(header=header):
+        msh_path = pathlib.Path(self.create_tempfile().full_path)
+        np.asarray(header, dtype=np.int32).tofile(msh_path)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Invalid MSH header: expected 4 counts, got {len(header)}.",
+        ):
+          msh2obj.Msh.create(msh_path)
+
+  def test_rejects_negative_count(self) -> None:
+    msh_path = pathlib.Path(self.create_tempfile().full_path)
+    np.asarray([-1, 0, 0, 0], dtype=np.int32).tofile(msh_path)
+
+    with self.assertRaisesRegex(
+        ValueError, "Invalid MSH header: counts must be nonnegative"
+    ):
+      msh2obj.Msh.create(msh_path)
+
+  def test_reports_texcoord_count(self) -> None:
+    msh_path = pathlib.Path(self.create_tempfile().full_path)
+    np.asarray([0, 0, 1, 0], dtype=np.int32).tofile(msh_path)
+
+    with self.assertRaisesRegex(
+        ValueError, r"Invalid number of texcoords: 0 != 2\*1\."
+    ):
+      msh2obj.Msh.create(msh_path)
 
   def test_obj_model_matches_msh_model(self) -> None:
     test_path = epath.resource_path("mujoco") / "testdata"


### PR DESCRIPTION
## Summary
- read the four legacy MSH header counts together and reject truncated headers
- reject negative counts before passing them to NumPy data reads
- report the actual expected texcoord count instead of the literal placeholder
- add regression coverage for empty, truncated, negative-count, and incomplete-texcoord files

Previously, empty or truncated files leaked an internal `IndexError`, while negative counts reached `np.fromfile` where `-1` has special read-to-EOF semantics. These inputs now fail consistently with a descriptive `ValueError`.

## Testing
- `msh2obj_test.py`: 4 tests passed, including the existing MSH-to-OBJ model equivalence test
- `pyink --check` on both changed Python files
- `isort --check-only` on both changed Python files
- `git diff --check`