### PR TITLE
Fix AttributeError in egl.GLContext.__del__ on partial construction

### DIFF
--- a/python/mujoco/egl/__init__.py
+++ b/python/mujoco/egl/__init__.py
@@ -83,6 +83,7 @@ class GLContext:
   """An EGL context for headless accelerated OpenGL rendering on GPU devices."""
 
   def __init__(self, max_width, max_height):
+    self._context = None
     del max_width, max_height  # unused
     num_configs = ctypes.c_long()
     config_size = 1

--- a/python/mujoco/egl_gl_context_test.py
+++ b/python/mujoco/egl_gl_context_test.py
@@ -1,0 +1,89 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the EGL GLContext's __del__ safety on partial construction."""
+
+import gc
+import sys
+from unittest import mock
+
+from absl.testing import absltest
+
+try:
+  from mujoco import egl as egl_module
+except ImportError:
+  # The EGL backend can only be imported on systems where libEGL/libOpenGL
+  # are present (see mujoco/egl/egl_ext.py). That is an environment
+  # precondition orthogonal to the bug under test here, so we skip rather
+  # than fail when it is unavailable (e.g. this is the case for the CI
+  # matrix, which runs with MUJOCO_GL=disable).
+  egl_module = None
+
+
+@absltest.skipIf(
+    egl_module is None,
+    'The EGL backend could not be imported in this environment.',
+)
+class EglGlContextTest(absltest.TestCase):
+  """Regression test for GLContext.__del__ on a partially-constructed instance.
+
+  If `GLContext.__init__` raises before `self._context` is assigned -- e.g.
+  because the EGL driver does not support the PLATFORM_DEVICE extension and
+  `create_initialized_egl_device_display()` returns `EGL_NO_DISPLAY`, so
+  `__init__` raises `ImportError` -- garbage collection later runs
+  `__del__` -> `free()`, which used to unconditionally read `self._context`
+  and raise `AttributeError: 'GLContext' object has no attribute
+  '_context'`. That AttributeError masked the real, actionable ImportError
+  raised from `__init__`. See issue #991, and the same bug class fixed for
+  `Renderer` in #3225 (issue #3213).
+
+  We can't rely on the test host's EGL driver actually lacking
+  PLATFORM_DEVICE support, so we force that branch deterministically by
+  patching `create_initialized_egl_device_display` to return
+  `EGL.EGL_NO_DISPLAY`, exactly as it would on such a host. This drives a
+  real `GLContext.__init__` call through its real failure path, rather than
+  bypassing `__init__` altogether.
+  """
+
+  def test_del_safe_when_init_fails_without_platform_device_support(self):
+    unraisable = []
+    old_hook = sys.unraisablehook
+    sys.unraisablehook = lambda args: unraisable.append(args)
+    try:
+      with mock.patch.object(egl_module, 'EGL_DISPLAY', None), \
+          mock.patch.object(
+              egl_module,
+              'create_initialized_egl_device_display',
+              return_value=egl_module.EGL.EGL_NO_DISPLAY,
+          ):
+        # __init__ must still raise ImportError -- that's the real,
+        # actionable error this bug used to mask.
+        with self.assertRaises(ImportError):
+          egl_module.GLContext(640, 480)
+        gc.collect()
+    finally:
+      sys.unraisablehook = old_hook
+
+    self.assertEqual(
+        [u.exc_type.__name__ for u in unraisable],
+        [],
+        msg=(
+            'GLContext.__del__ raised on a partially-constructed instance; '
+            'see #991.'
+        ),
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

- Sets `self._context = None` as the first statement of `GLContext.__init__` in `python/mujoco/egl/__init__.py`, so `free()` (called from `__del__`) is safe on a partially constructed instance.
- Adds a regression test asserting that `free()`/`__del__` do not raise `AttributeError` on a `GLContext` whose `__init__` failed early.

## Why

On a headless host whose EGL driver lacks the `PLATFORM_DEVICE` extension, `create_initialized_egl_device_display()` returns `EGL_NO_DISPLAY` and `GLContext.__init__` raises `ImportError` at lines 97-101, before `self._context` is assigned (first set at line 114). When the partially constructed object is garbage collected, `__del__` calls `free()`, which reads `self._context` unconditionally:

```python
def free(self):
  """Frees resources associated with this context."""
  global EGL_DISPLAY
  if self._context:   # AttributeError here if __init__ never got this far
    ...
```

This raises `AttributeError: 'GLContext' object has no attribute '_context'` from `__del__`, surfaced via `sys.unraisablehook` as an `Exception ignored in: <function GLContext.__del__ ...>` traceback that masks the real, actionable `ImportError`. Reported in #991.

Same bug class as #3225 (issue #3213) for `Renderer.__init__` in `renderer.py`: initialize the guarded attribute to `None` before anything that can raise, so `__del__` is safe no matter how far `__init__` got.

The fix is one line:

```python
def __init__(self, max_width, max_height):
  self._context = None
  del max_width, max_height  # unused
  ...
```

## Test

The GL tests in `render_test.py`/`renderer_test.py` are skipped in this repo's CI, which runs the Python test job with `MUJOCO_GL=disable`. Forcing `GLContext.__init__` to fail the way a real headless host without `PLATFORM_DEVICE` would also needs an EGL driver that is present but lacks that extension, which a test environment cannot create on demand.

So `python/mujoco/egl_gl_context_test.py` patches `create_initialized_egl_device_display` (via `unittest.mock.patch.object`) to return `EGL.EGL_NO_DISPLAY`, as it would on such a host, and drives a real `GLContext(640, 480)` call through the real `__init__` code path. The test asserts `__init__` still raises `ImportError`, then garbage-collects the partially constructed object under `sys.unraisablehook` and asserts nothing was raised from `__del__`. It skips only when `mujoco.egl` itself cannot be imported (no `libEGL`/`libOpenGL` on the host), which is an environment precondition unrelated to this bug and the same reason CI runs with `MUJOCO_GL=disable`.

## Scope

This PR fixes only the missing-attribute-on-`__del__` bug. It does not touch the separate `EGL_DISPLAY`-goes-stale-after-`atexit`-termination bug that #2510 (open) addresses in the same file's `free()`/`make_current()`. #2510 does not pre-initialize `self._context`, so it does not fix this bug, and this one-line change does not touch either of the lines #2510 changes.

## Validation

Built MuJoCo from source (CMake + Ninja, Release, no IPO/LTO) and the Python bindings against it (Python 3.12), then ran `pytest -v --pyargs mujoco` with `MUJOCO_GL=disable`, matching the "Test Python bindings" step in `.github/workflows/build.yml`, on both clean `main` and this branch:

- Clean `main` (baseline): 380 passed, 5 failed, 14 skipped.
- This branch: 380 passed, 5 failed, 15 skipped.

The 5 failures are identical on both and are all plugin-loading failures unrelated to this change (my local build did not install the plugin shared libraries the way CI's `copy_plugins_posix` step does):
`bindings_test.py::MuJoCoBindingsTest::test_copy_mjdata_with_plugin`, `test_deepcopy_mjdata_with_plugin`, `test_load_plugin`, `specs_test.py::SpecsTest::test_delete_unused_plugin`, `test_plugin`. None of these touch `python/mujoco/egl/`.

The one extra skip on this branch is the new `egl_gl_context_test.py`, which skips because this machine (macOS) has no `libEGL`/`libOpenGL` for `mujoco.egl` to import, the same reason the existing `render_test.py`/`renderer_test.py` GL tests are skipped here and in CI.

I also verified the new test's logic outside pytest by stubbing the `OpenGL.EGL` import chain in-process so `mujoco.egl` becomes importable without a real EGL driver, then running the test body directly against both the pre-fix and post-fix `egl/__init__.py`: it fails with the exact `AttributeError: 'GLContext' object has no attribute '_context'` from `__del__` on pre-fix code, and passes on post-fix code.
