### PR TITLE
Normalize Unity heightfield data before writing to MuJoCo

### DIFF
--- a/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
+++ b/unity/Runtime/Components/Shapes/MjHeightFieldShape.cs
@@ -45,6 +45,8 @@ public class MjHeightFieldShape : IMjShape {
   public int UpdateLimit;
 
   private int _updateCountdown;
+  private float _minimumHeightMapValue;
+  private float _maximumHeightMapValue;
 
   [HideInInspector]
   public float MinimumHeight { get; private set; }
@@ -102,12 +104,15 @@ public class MjHeightFieldShape : IMjShape {
     texture.ReadPixels(new Rect(0, 0, RenderTexture.active.width, RenderTexture.active.height),
         0,
         0);
-    MaximumHeight = texture.GetPixels().Select(c => c.r).Max() * HeightMapScale.y * 2;
-    var minimumHeight = texture.GetPixels().Select(c => c.r).Min() * HeightMapScale.y * 2;
+    var pixels = texture.GetPixels();
+    _maximumHeightMapValue = pixels.Max(c => c.r);
+    _minimumHeightMapValue = pixels.Min(c => c.r);
+    MaximumHeight = _maximumHeightMapValue * HeightMapScale.y * 2;
+    MinimumHeight = _minimumHeightMapValue * HeightMapScale.y * 2;
 
     RenderTexture.active = null;
     if (ExportImage) {
-      if (minimumHeight > 0.0001)
+      if (_minimumHeightMapValue > 0.0001)
         Debug.LogWarning("Due to assumptions in MuJoCo heightfields, terrains should have a " +
                          "minimum heightmap value of 0.");
       File.WriteAllBytes(FullHeightMapPath, texture.EncodeToPNG());
@@ -124,8 +129,15 @@ public class MjHeightFieldShape : IMjShape {
         0);
     RenderTexture.active = null;
 
-    float[] curData = texture.GetPixels(0, 0, texture.width, texture.height)
-        .Select(c => c.r * 2).ToArray();
+    var pixels = texture.GetPixels(0, 0, texture.width, texture.height);
+    float heightRange = _maximumHeightMapValue - _minimumHeightMapValue;
+    float[] curData;
+    if (heightRange > Mathf.Epsilon) {
+      curData = pixels.Select(
+          c => Mathf.Clamp01((c.r - _minimumHeightMapValue) / heightRange)).ToArray();
+    } else {
+      curData = new float[pixels.Length];
+    }
     int adr = MjScene.Instance.Model->hfield_adr[HeightFieldId];
     for (int i = 0; i < curData.Length; i++) {
       MjScene.Instance.Model->hfield_data[adr + i] = curData[i];


### PR DESCRIPTION
Fixes #1930.

## Summary

Unity heightfields with a maximum sample below 1 are currently scaled twice: the generated MuJoCo `hfield` size already uses the observed physical height range, while `UpdateHeightFieldData()` writes the original unnormalized samples into `hfield_data`.

This change:
- records the minimum and maximum source heightmap values during preparation;
- records `MinimumHeight` as well as `MaximumHeight`;
- normalizes programmatic `hfield_data` samples to `[0, 1]` using that source range;
- handles constant-height maps by writing zero normalized samples.

This keeps the MuJoCo heightfield data consistent with the physical range encoded in the generated `hfield` size.

## Validation

- Final diff: 1 file, +17/-5 lines, one commit, with no unrelated changes.
- Branch is based on current upstream `main` at `f7da3d295b828478e0171967a7fa3fe6bb2ec922`.
- No dedicated Unity heightfield regression test exists in the repository. Unity tests were not run locally in this environment, so upstream CI and maintainer validation are required.
