### PR TITLE
Expose mjtSize array fields as Int32Array in the WASM bindings

### DIFF
--- a/wasm/codegen/generated/bindings.h
+++ b/wasm/codegen/generated/bindings.h
@@ -5263,7 +5263,12 @@ struct MjModel {
     return emscripten::val(emscripten::typed_memory_view(ptr_->ntex, ptr_->tex_nchannel));
   }
   emscripten::val tex_adr() const {
-    return emscripten::val(emscripten::typed_memory_view(ptr_->ntex, ptr_->tex_adr));
+    int size = ptr_->ntex;
+    emscripten::val result = emscripten::val::global("Int32Array").new_(size);
+    for (int i = 0; i < size; ++i) {
+      result.set(i, static_cast<int>(ptr_->tex_adr[i]));
+    }
+    return result;
   }
   emscripten::val tex_data() const {
     return emscripten::val(emscripten::typed_memory_view(ptr_->ntexdata, ptr_->tex_data));

--- a/wasm/codegen/generators/structs.py
+++ b/wasm/codegen/generators/structs.py
@@ -295,12 +295,29 @@ def _generate_field_data(
         array_size_str = parse_array_extent(extent, w, f.name)
 
       builder = code_builder.CodeBuilder()
-      with builder.function(f"emscripten::val {f.name}() const"):
-        builder.line(
-            "return"
-            f" emscripten::val(emscripten::typed_memory_view({array_size_str},"
-            f" {ptr_field_expr}));"
-        )
+      if inner_type_name == "mjtSize":
+        # A typed_memory_view over `mjtSize` would surface as a BigInt64Array,
+        # whose elements cannot mix with JS numbers. The wasm heap is 32-bit
+        # addressed so the values always fit an int; return an Int32Array copy,
+        # consistent with the scalar `mjtSize` handling above.
+        with builder.function(f"emscripten::val {f.name}() const"):
+          builder.line(f"int size = {array_size_str};")
+          builder.line(
+              "emscripten::val result ="
+              ' emscripten::val::global("Int32Array").new_(size);'
+          )
+          with builder.block("for (int i = 0; i < size; ++i)"):
+            builder.line(
+                f"result.set(i, static_cast<int>({ptr_field_expr}[i]));"
+            )
+          builder.line("return result;")
+      else:
+        with builder.function(f"emscripten::val {f.name}() const"):
+          builder.line(
+              "return"
+              f" emscripten::val(emscripten::typed_memory_view({array_size_str},"
+              f" {ptr_field_expr}));"
+          )
       return WrappedFieldData(
           declaration=builder.to_string(),
           typename=_get_field_struct_type(f, s),  # pyrefly: ignore[bad-argument-type]

--- a/wasm/tests/bindings_test.ts
+++ b/wasm/tests/bindings_test.ts
@@ -1640,6 +1640,7 @@ describe('MuJoCo WASM Bindings', () => {
       expect(model).toBeDefined();
       expect(model!.tex_height).toEqual(new Int32Array([512]));
       expect(model!.tex_width).toEqual(new Int32Array([512]));
+      expect(model!.tex_adr).toEqual(new Int32Array([0]));
     } finally {
       model?.delete();
       unlinkXMLFile(texFilename);


### PR DESCRIPTION
`MjModel.tex_adr` is `mjtSize*` (int64_t), and the generated binding exposes it through `typed_memory_view`, which surfaces it in JS as a `BigInt64Array`. Any arithmetic on its elements then throws: `Cannot mix BigInt and other types` in Chrome, `can't convert BigInt to number` in Firefox. That is the error behind #3496: the reporter's texture stage reads `tex_adr`, throws, and their material setup aborts, so the geom renders with the wrong color.

Scalar `mjtSize` fields already avoid this by casting to int in the generator, with a comment explaining that bigint does not fit the JS number model. This extends the same policy to pointer fields: the generator now emits an accessor that returns an `Int32Array` copy instead of a 64-bit view. The wasm heap is 32-bit addressed, so the values always fit. `tex_adr` is currently the only `mjtSize*` field in the public headers, so the regenerated `bindings.h` changes just that one accessor.

Before, against a two-texture model:

```
model.tex_adr          // BigInt64Array [ 0n, 786432n ]
model.tex_adr[1] * 3   // throws
```

After:

```
model.tex_adr          // Int32Array [ 0, 786432 ]
model.tex_adr[1] * 3   // 2359296
```

Added an assertion to the existing texture test that fails on main and passes with this change. Full wasm suite: 175 specs, 0 failures.

Fixes #3496
