### PR TITLE
Fix DC motor Vmax voltage limiting in voltage input mode (#3489)

### DIFF
--- a/src/engine/engine_forward.c
+++ b/src/engine/engine_forward.c
@@ -263,8 +263,14 @@ static mjtNum dcmotorVoltage(const mjtNum* u, int spec, mjtNum length, mjtNum ve
     if (Vmax > 0) voltage = mju_clip(voltage, -Vmax, Vmax);
   }
 
-  // raw terminal voltage input: downstream of the controller, unclamped
-  return voltage + u4[3];
+  // raw terminal voltage input
+  voltage += u4[3];
+
+  // driver supply limit on total terminal voltage
+  mjtNum Vmax = gainprm[7];
+  if (Vmax > 0) voltage = mju_clip(voltage, -Vmax, Vmax);
+
+  return voltage;
 }
 
 
@@ -731,9 +737,9 @@ void mj_fwdActuation(const mjModel* m, mjData* d) {
       // stateless: gain = K/R, force = K/R * ctrl (condition below)
       gain = (dynprm[0] > 0) ? K : K / mju_max(mjMINVAL, R);
 
-      // controller: compute voltage, override ctrl[uadr] for force computation
-      // (pure raw-voltage motor reads ctrl directly; empty block reads as 0 below)
-      if (m->actuator_ctrlspec[i] != mjINPUT_VOLTAGE && m->actuator_ctrlnum[i] > 0) {
+      // controller / voltage command: compute voltage, override ctrl[uadr] for force computation
+      // (empty block reads as 0 below)
+      if (m->actuator_ctrlnum[i] > 0) {
         mjtNum x_I = (slots.integral >= 0) ? d->act[adr + slots.integral] : 0;
         ctrl[uadr] = dcmotorVoltage(ctrl + uadr, m->actuator_ctrlspec[i],
                                     d->actuator_length[oadr],

--- a/src/engine/engine_forward.c
+++ b/src/engine/engine_forward.c
@@ -257,16 +257,12 @@ static mjtNum dcmotorVoltage(const mjtNum* u, int spec, mjtNum length, mjtNum ve
     mjtNum R = gainprm[0];
     mjtNum K = gainprm[1];
     voltage = R/K * torque + K*velocity;
-
-    // driver supply limit
-    mjtNum Vmax = gainprm[7];
-    if (Vmax > 0) voltage = mju_clip(voltage, -Vmax, Vmax);
   }
 
-  // raw terminal voltage input
+  // add raw terminal voltage input
   voltage += u4[3];
 
-  // driver supply limit on total terminal voltage
+  // driver supply limit: clamp total terminal voltage to [-Vmax, Vmax]
   mjtNum Vmax = gainprm[7];
   if (Vmax > 0) voltage = mju_clip(voltage, -Vmax, Vmax);
 

--- a/test/engine/engine_forward_test.cc
+++ b/test/engine/engine_forward_test.cc
@@ -2446,6 +2446,41 @@ TEST_F(DCMotorTest, VoltageLimit) {
   EXPECT_NEAR(data->actuator_force[0], -0.25, MjTol(1e-12, 1e-5));
 }
 
+TEST_F(DCMotorTest, VmaxVoltageInput) {
+  // verifies that controller Vmax clamps raw voltage input
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <body>
+        <joint name="joint"/>
+        <geom size="1"/>
+      </body>
+    </worldbody>
+    <actuator>
+      <dcmotor joint="joint" motorconst="0.05" resistance="2.0"
+               input="voltage" controller="0 0 0 0 0 10.0"/>
+    </actuator>
+  </mujoco>
+  )";
+  char error[1024];
+  MjModelPtr model = LoadModelFromString(xml, error, sizeof(error));
+  ASSERT_THAT(model.get(), NotNull()) << error;
+  MjDataPtr data = MakeData(model);
+
+  // Vmax = 10.0, ctrl = 20.0
+  // force = K/R * Vmax = 0.05 / 2.0 * 10.0 = 0.25
+  data->ctrl[0] = 20.0;
+  mj_forward(model.get(), data.get());
+
+  EXPECT_NEAR(data->actuator_force[0], 0.25, MjTol(1e-12, 1e-5));
+
+  // negative drive
+  data->ctrl[0] = -20.0;
+  mj_forward(model.get(), data.get());
+
+  EXPECT_NEAR(data->actuator_force[0], -0.25, MjTol(1e-12, 1e-5));
+}
+
 TEST_F(DCMotorTest, IntegralClamp) {
   // verifies that controller Imax clamps integral state
   static constexpr char xml[] = R"(


### PR DESCRIPTION
Fixes #3489

### Problem
When a `<dcmotor>` is configured with `Vmax` in voltage-commanded mode (`input="voltage"`) without an inductance state:
1. `mjGAIN_DCMOTOR` skipped `dcmotorVoltage()` due to checking `ctrlspec != mjINPUT_VOLTAGE`, leaving `ctrl[uadr]` unclamped.
2. Inside `dcmotorVoltage()`, the raw terminal voltage input `u4[3]` was added after the `Vmax` clamp, bypassing the supply voltage limit.

### Solution
1. In `dcmotorVoltage()`, add raw terminal voltage `u4[3]` and apply the `Vmax` clamp to the resulting total terminal voltage.
2. In `mjGAIN_DCMOTOR`, invoke `dcmotorVoltage()` whenever `ctrlnum > 0` so that `ctrl[uadr]` is consistently clamped by `Vmax`.
3. Added unit test `TEST_F(DCMotorTest, VmaxVoltageInput)` to verify `Vmax` enforcement for voltage-controlled DC motors.
