### PR TITLE
Allow a compile-time additional Simulate plugin directory

### DIFF
--- a/simulate/CMakeLists.txt
+++ b/simulate/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 
 option(SIMULATE_BUILD_EXECUTABLE "Build the simulate executable binary." ON)
 option(SIMULATE_GLFW_DYNAMIC_SYMBOLS "Whether to resolve GLFW symbols dynamically." OFF)
+set(SIMULATE_ADDITIONAL_PLUGIN_DIR "" CACHE PATH
+    "Additional directory scanned by the simulate executable for plugin libraries."
+)
 
 # Check if we are building as standalone project.
 set(SIMULATE_STANDALONE OFF)
@@ -140,6 +143,11 @@ if(SIMULATE_BUILD_EXECUTABLE)
 
   add_executable(simulate main.cc array_safety.h ${SIMULATE_RESOURCE_FILES})
   target_compile_options(simulate PUBLIC ${MUJOCO_SIMULATE_COMPILE_OPTIONS})
+  if(SIMULATE_ADDITIONAL_PLUGIN_DIR)
+    target_compile_definitions(
+      simulate PRIVATE MUJOCO_ADDITIONAL_PLUGIN_DIR="${SIMULATE_ADDITIONAL_PLUGIN_DIR}"
+    )
+  endif()
   if(WIN32)
     add_custom_command(
       TARGET simulate

--- a/simulate/main.cc
+++ b/simulate/main.cc
@@ -165,6 +165,13 @@ void scanPluginLibraries() {
     for (int i = 0; i < nplugin; ++i) { std::printf("    %s\n", mjp_getPluginAtSlot(i)->name); }
   }
 
+  auto register_plugins = +[](const char* filename, int first, int count) {
+    std::printf("Plugins registered by library '%s':\n", filename);
+    for (int i = first; i < first + count; ++i) {
+      std::printf("    %s\n", mjp_getPluginAtSlot(i)->name);
+    }
+  };
+
   // define platform-specific strings
 #if defined(_WIN32) || defined(__CYGWIN__)
   const std::string sep = "\\";
@@ -177,17 +184,14 @@ void scanPluginLibraries() {
   // ${EXECDIR} is the directory containing the simulate binary itself
   // MUJOCO_PLUGIN_DIR is the MUJOCO_PLUGIN_DIR preprocessor macro
   const std::string executable_dir = getExecutableDir();
-  if (executable_dir.empty()) { return; }
+  if (!executable_dir.empty()) {
+    const std::string plugin_dir = executable_dir + sep + MUJOCO_PLUGIN_DIR;
+    mj_loadAllPluginLibraries(plugin_dir.c_str(), register_plugins);
+  }
 
-  const std::string plugin_dir = getExecutableDir() + sep + MUJOCO_PLUGIN_DIR;
-  mj_loadAllPluginLibraries(
-      plugin_dir.c_str(),
-      +[](const char* filename, int first, int count) {
-        std::printf("Plugins registered by library '%s':\n", filename);
-        for (int i = first; i < first + count; ++i) {
-          std::printf("    %s\n", mjp_getPluginAtSlot(i)->name);
-        }
-      });
+#ifdef MUJOCO_ADDITIONAL_PLUGIN_DIR
+  mj_loadAllPluginLibraries(MUJOCO_ADDITIONAL_PLUGIN_DIR, register_plugins);
+#endif
 }
 
 
@@ -499,7 +503,6 @@ __attribute__((used, visibility("default"))) extern "C" void _mj_rosettaError(co
 
 // run event loop
 int main(int argc, char** argv) {
-
   // display an error if running on macOS under Rosetta 2
 #if defined(__APPLE__) && defined(__AVX__)
   if (rosetta_error_msg) {
@@ -527,12 +530,11 @@ int main(int argc, char** argv) {
   mjv_defaultPerturb(&pert);
 
   // simulate object encapsulates the UI
-  auto sim = std::make_unique<mj::Simulate>(
-          std::make_unique<mj::GlfwAdapter>(),
-      &cam,
-      &opt,
-      &pert,
-      /* is_passive = */ false);
+  auto sim = std::make_unique<mj::Simulate>(std::make_unique<mj::GlfwAdapter>(),
+                                            &cam,
+                                            &opt,
+                                            &pert,
+                                            /* is_passive = */ false);
 
   const char* filename = nullptr;
   if (argc > 1) { filename = argv[1]; }


### PR DESCRIPTION
## Summary

Add an opt-in CMake path that lets custom Simulate builds scan one additional plugin directory outside `${EXECDIR}/mujoco_plugin`.

This follows the approach discussed in #3357. The issue asked for runtime configurability, but the maintainer raised a security concern about allowing an environment variable or command-line value to make the distributed `simulate` binary silently load arbitrary DSOs, and explicitly indicated that a compile-time CMake option would be acceptable.

This change:
- adds `SIMULATE_ADDITIONAL_PLUGIN_DIR` as an empty-by-default CMake cache `PATH`
- injects the path only into custom builds where it is explicitly configured
- keeps the existing `${EXECDIR}/mujoco_plugin` scan unchanged
- scans the configured directory in addition to the built-in location
- does not add an environment variable or runtime command-line DSO search path

Example:
```sh
cmake -S simulate -B build \
  -DSIMULATE_ADDITIONAL_PLUGIN_DIR=/opt/my_mujoco_plugins
```

Addresses #3357.

## Validation

The final branch is based directly on current `main` and contains one focused commit rebased onto current `main`.

Final diff:
- `simulate/CMakeLists.txt`: 8 additions
- `simulate/main.cc`: 13 additions, 10 deletions

A full native Simulate build was not available in this execution environment, so no local build/test pass is claimed. The default build path is unchanged because the new CMake option is empty unless explicitly configured.