### PR TITLE
Avoid unsupported GLFW window position queries on Wayland

### DIFF
--- a/simulate/glfw_adapter.cc
+++ b/simulate/glfw_adapter.cc
@@ -40,6 +40,14 @@ int MaybeGlfwInit() {
 GlfwAdapter& GlfwAdapterFromWindow(GLFWwindow* window) {
   return *static_cast<GlfwAdapter*>(Glfw().glfwGetWindowUserPointer(window));
 }
+
+bool WindowPositionAvailable() {
+#if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
+  return Glfw().glfwGetPlatform() != GLFW_PLATFORM_WAYLAND;
+#else
+  return true;
+#endif
+}
 }  // namespace
 
 GlfwAdapter::GlfwAdapter() {
@@ -61,7 +69,9 @@ GlfwAdapter::GlfwAdapter() {
   if (!window_) { mju_error("could not create window"); }
 
   // save window position and size
-  Glfw().glfwGetWindowPos(window_, &window_pos_.first, &window_pos_.second);
+  if (WindowPositionAvailable()) {
+    Glfw().glfwGetWindowPos(window_, &window_pos_.first, &window_pos_.second);
+  }
   Glfw().glfwGetWindowSize(window_, &window_size_.first, &window_size_.second);
 
   // set callbacks
@@ -196,7 +206,9 @@ void GlfwAdapter::ToggleFullscreen() {
   // currently windowed: switch to full screen
   else {
     // save window data
-    Glfw().glfwGetWindowPos(window_, &window_pos_.first, &window_pos_.second);
+    if (WindowPositionAvailable()) {
+      Glfw().glfwGetWindowPos(window_, &window_pos_.first, &window_pos_.second);
+    }
     Glfw().glfwGetWindowSize(window_, &window_size_.first, &window_size_.second);
 
     // switch

--- a/simulate/glfw_dispatch.cc
+++ b/simulate/glfw_dispatch.cc
@@ -86,6 +86,9 @@ const struct Glfw& Glfw(void* dlhandle) {
     mjGLFW_INITIALIZE_SYMBOL(glfwGetKey);
     mjGLFW_INITIALIZE_SYMBOL(glfwGetMonitorPhysicalSize);
     mjGLFW_INITIALIZE_SYMBOL(glfwGetMouseButton);
+#if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
+    mjGLFW_INITIALIZE_SYMBOL(glfwGetPlatform);
+#endif
     mjGLFW_INITIALIZE_SYMBOL(glfwGetPrimaryMonitor);
     mjGLFW_INITIALIZE_SYMBOL(glfwGetTime);
     mjGLFW_INITIALIZE_SYMBOL(glfwGetVideoMode);

--- a/simulate/glfw_dispatch.h
+++ b/simulate/glfw_dispatch.h
@@ -36,6 +36,9 @@ struct Glfw {
   mjGLFW_DECLARE_SYMBOL(glfwGetKey);
   mjGLFW_DECLARE_SYMBOL(glfwGetMonitorPhysicalSize);
   mjGLFW_DECLARE_SYMBOL(glfwGetMouseButton);
+#if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4)
+  mjGLFW_DECLARE_SYMBOL(glfwGetPlatform);
+#endif
   mjGLFW_DECLARE_SYMBOL(glfwGetPrimaryMonitor);
   mjGLFW_DECLARE_SYMBOL(glfwGetTime);
   mjGLFW_DECLARE_SYMBOL(glfwGetVideoMode);


### PR DESCRIPTION
## Summary

Avoid calling `glfwGetWindowPos` when Simulate is running on Wayland.

GLFW documents that Wayland clients do not know their global window position, and the current calls generate `GLFW_FEATURE_UNAVAILABLE` warnings. In the Python passive viewer this surfaces as the warning reported in #2393 and can interfere with viewer interaction depending on the GLFW Python error callback.

This change:
- adds `glfwGetPlatform` to Simulate's dynamic GLFW dispatch table when building against GLFW 3.4+
- detects the Wayland runtime backend
- skips both window-position queries on Wayland
- preserves the existing position save/restore path on X11, Windows and macOS
- preserves previous behaviour when built with older GLFW headers where `glfwGetPlatform` is unavailable

Fixes #2393.

## Validation

The final branch is based directly on current `main` and contains one focused commit rebased onto current `main`.

Final diff:
- `simulate/glfw_adapter.cc`: 14 additions, 2 deletions
- `simulate/glfw_dispatch.cc`: 3 additions
- `simulate/glfw_dispatch.h`: 3 additions

Fresh upstream CI is running after the rebase; pre-commit and the change scanner pass. I could not run the Wayland GUI regression locally in this execution environment, so no local runtime test pass is claimed. The change follows the root cause identified in the issue discussion and preserves non-Wayland behaviour.