### PR TITLE
Restore CGL-to-GLFW fallback on macOS

### DIFF
--- a/python/mujoco/rendering/classic/gl_context.py
+++ b/python/mujoco/rendering/classic/gl_context.py
@@ -23,7 +23,7 @@ import platform
 _SYSTEM = platform.system()
 _MUJOCO_GL = os.environ.get('MUJOCO_GL', '').lower().strip()
 if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
-  _VALID_MUJOCO_GL = ('enable', 'enabled', 'on', 'true', '1' , 'glfw', '')
+  _VALID_MUJOCO_GL = ('enable', 'enabled', 'on', 'true', '1', 'glfw', '')
   if _SYSTEM == 'Linux':
     _VALID_MUJOCO_GL += ('glx', 'egl', 'osmesa')
   elif _SYSTEM == 'Windows':
@@ -41,7 +41,15 @@ if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
     from mujoco.egl import GLContext as _GLContext
     GLContext = _GLContext
   elif _SYSTEM == 'Darwin':
-    from mujoco.cgl import GLContext as _GLContext
+    if _MUJOCO_GL == 'glfw':
+      from mujoco.glfw import GLContext as _GLContext
+    elif _MUJOCO_GL == 'cgl':
+      from mujoco.cgl import GLContext as _GLContext
+    else:
+      try:
+        from mujoco.cgl import GLContext as _GLContext
+      except (AttributeError, OSError):
+        from mujoco.glfw import GLContext as _GLContext
     GLContext = _GLContext
   else:
     from mujoco.glfw import GLContext as _GLContext


### PR DESCRIPTION
## Summary

On current `main`, Darwin always imports the CGL backend for classic rendering. If Apple's OpenGL framework does not expose `CGLSetCurrentContext`, that import fails even when the default backend selection could use GLFW.

This restores fallback only for default backend selection: explicit `MUJOCO_GL=cgl` still surfaces the CGL failure, while explicit `MUJOCO_GL=glfw` uses GLFW directly.

## Context

This revives the substance of closed, unmerged PRs #3312/#3313 with stricter explicit-backend semantics.

## Validation

- Based on current `main`
- Final diff changes one file
- macOS runtime validation was not run in this environment