### PR TITLE
Warn when sysid parameters have no modifier

### DIFF
--- a/python/mujoco/sysid/_src/model_modifier.py
+++ b/python/mujoco/sysid/_src/model_modifier.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 
+from absl import logging
 import mujoco
 from mujoco.sysid._src.parameter import InertiaType
 from mujoco.sysid._src.parameter import ModifierFn
@@ -60,6 +61,26 @@ def _get_obj_or_raise(spec: mujoco.MjSpec, obj_type: str, obj_name: str) -> Any:
 def apply_param_modifiers_spec(
     params: ParameterDict, spec: mujoco.MjSpec
 ) -> mujoco.MjSpec:
+  # A non-frozen parameter participates in the optimizer's decision vector. If
+  # it has no modifier, applying the parameter set to an MjSpec silently leaves
+  # that decision variable disconnected from the model and produces a zero
+  # gradient. Warn once per ParameterDict so repeated residual evaluations do
+  # not flood the log.
+  if not getattr(params, "_sysid_warned_none_modifier", False):
+    missing = [
+        param.name
+        for param in params.values()
+        if not param.frozen and param.modifier is None
+    ]
+    if missing:
+      logging.warning(
+          "Non-frozen sysid parameters have modifier=None and will not affect "
+          "the MjSpec: %s. Check that modifier factories return their inner "
+          "modifier function.",
+          ", ".join(missing),
+      )
+      setattr(params, "_sysid_warned_none_modifier", True)
+
   for key in params.keys():
     param = params[key]
     if not param.frozen:

--- a/python/mujoco/sysid/tests/test_none_modifier_warning.py
+++ b/python/mujoco/sysid/tests/test_none_modifier_warning.py
@@ -1,0 +1,50 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for unapplied sysid parameters."""
+
+import logging
+
+import mujoco
+from mujoco.sysid._src import model_modifier
+from mujoco.sysid._src import parameter
+
+
+def test_nonfrozen_none_modifier_warns_once(caplog):
+  params = parameter.ParameterDict()
+  params.add(parameter.Parameter('unapplied', 1.0, 0.0, 2.0))
+  spec = mujoco.MjSpec()
+
+  with caplog.at_level(logging.WARNING, logger='absl'):
+    model_modifier.apply_param_modifiers_spec(params, spec.copy())
+
+  assert any(
+      'unapplied' in record.message and 'modifier=None' in record.message
+      for record in caplog.records
+  )
+
+  caplog.clear()
+  with caplog.at_level(logging.WARNING, logger='absl'):
+    model_modifier.apply_param_modifiers_spec(params, spec.copy())
+  assert not any('modifier=None' in record.message for record in caplog.records)
+
+
+def test_frozen_none_modifier_does_not_warn(caplog):
+  params = parameter.ParameterDict()
+  params.add(parameter.Parameter('frozen', 1.0, 0.0, 2.0, frozen=True))
+
+  with caplog.at_level(logging.WARNING, logger='absl'):
+    model_modifier.apply_param_modifiers_spec(params, mujoco.MjSpec())
+
+  assert not any('modifier=None' in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Make a silent sysid configuration failure visible when a non-frozen `Parameter` participates in the decision vector but has `modifier=None`.

This is the failure mode behind #3286: a modifier factory can accidentally return `None`, leaving the optimized value disconnected from the `MjSpec`. The optimizer then sees a zero gradient and can terminate immediately without explaining why.

This change:
- checks non-frozen parameters when `apply_param_modifiers_spec` is used
- emits a warning naming any parameter whose modifier is `None`
- emits that warning only once per `ParameterDict`, avoiding log spam during repeated residual evaluations
- keeps frozen parameters silent
- does not change custom build-model workflows unless they explicitly use `apply_param_modifiers_spec`
- adds regression coverage for the warned and frozen cases

Addresses #3286.

## Validation

The final branch is based directly on current `main` and contains one focused commit changing only `model_modifier.py` plus regression tests.

The full sysid test environment was not executed locally here, so no local test pass is claimed.