### PR TITLE
Fix size_t atomic add on 32-bit MSVC

### DIFF
--- a/src/engine/engine_crossplatform.h
+++ b/src/engine/engine_crossplatform.h
@@ -82,8 +82,13 @@
 // Atomics helper for size_t.
 #if defined(_MSC_VER) && !defined(__clang__)
   #include <intrin.h>
-  #define mj_atomic_add_size_t(ptr, val) \
-      (size_t)_InterlockedExchangeAdd64((__int64 volatile*)(ptr), (__int64)(val))
+  #if defined(_WIN64)
+    #define mj_atomic_add_size_t(ptr, val) \
+        (size_t)_InterlockedExchangeAdd64((__int64 volatile*)(ptr), (__int64)(val))
+  #else
+    #define mj_atomic_add_size_t(ptr, val) \
+        (size_t)_InterlockedExchangeAdd((long volatile*)(ptr), (long)(val))
+  #endif
 #else
   #define mj_atomic_add_size_t(ptr, val) \
       __atomic_fetch_add(ptr, val, __ATOMIC_RELAXED)


### PR DESCRIPTION
## Summary

Use the width-appropriate MSVC interlocked intrinsic for `size_t`.

`engine_crossplatform.h` currently maps `mj_atomic_add_size_t` to `_InterlockedExchangeAdd64` for every non-Clang MSVC build. That is correct on 64-bit Windows, but 32-bit Windows uses a 32-bit `size_t` and the x86 build can fail to link with an unresolved `__InterlockedExchangeAdd64`.

This keeps `_InterlockedExchangeAdd64` on `_WIN64` and uses `_InterlockedExchangeAdd` on 32-bit MSVC.

This revives the still-relevant fix from closed, unmerged PR #3358 by @BillyONeal, rebased onto current `main`.

## Validation

Final diff is one file and one commit. The 64-bit branch is unchanged; the new branch is selected only for 32-bit MSVC.

An x86 MSVC toolchain is not available in this environment, so the Windows build was not run locally.