### PR TITLE
Fix strict C11 compilation of mjsan.h

### DIFF
--- a/include/mujoco/mjsan.h
+++ b/include/mujoco/mjsan.h
@@ -55,17 +55,17 @@ extern "C" {
 #endif
 
 void mj__markStack(mjData*) __attribute__((noinline));
-static inline void mj_markStack(mjData* d) __attribute__((always_inline)) {
-  asm volatile("" ::: "memory");
+__attribute__((always_inline)) static inline void mj_markStack(mjData* d) {
+  __asm__ volatile("" ::: "memory");
   mj__markStack(d);
-  asm volatile("" ::: "memory");
+  __asm__ volatile("" ::: "memory");
 }
 
 void mj__freeStack(mjData*) __attribute__((noinline));
-static inline void mj_freeStack(mjData* d) __attribute__((always_inline)) {
-  asm volatile("" ::: "memory");
+__attribute__((always_inline)) static inline void mj_freeStack(mjData* d) {
+  __asm__ volatile("" ::: "memory");
   mj__freeStack(d);
-  asm volatile("" ::: "memory");
+  __asm__ volatile("" ::: "memory");
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Make the AddressSanitizer stack instrumentation in `mjsan.h` compile under GCC's strict C11 mode.

The sanitizer-only definitions currently use two constructs rejected by the project's `-std=c11 -Wpedantic -Werror` configuration:
- bare `asm`, which is not a C11 keyword
- `__attribute__((always_inline))` after the declarator on a function definition, which GCC rejects

This moves `always_inline` before the definition and uses `__asm__ volatile` for the memory barriers. The generated semantics are unchanged, and the non-sanitizer path is untouched.

This revives the still-relevant fix from closed, unmerged PR #3458 by @teerthsharma, rebased onto current `main`.

## Validation

Focused GCC 14.2.0 compile passed:

`cc -std=c11 -Wpedantic -Werror -fsanitize=address -c <minimal translation unit including mjsan.h>`

Final diff: one file, six line substitutions, one commit.

A full MuJoCo sanitizer build was not run in this environment.