### PR TITLE
Fix Unity hinge reference import for radian models

### DIFF
--- a/unity/Runtime/Components/Joints/MjHingeJoint.cs
+++ b/unity/Runtime/Components/Joints/MjHingeJoint.cs
@@ -76,6 +76,9 @@ namespace Mujoco {
       }
 
       Configuration = mjcf.GetFloatAttribute("ref", 0.0f);
+      if (!MjSceneImportSettings.AnglesInDegrees) {
+        Configuration *= Mathf.Rad2Deg;
+      }
 
       Settings.FromMjcf(mjcf);
     }

--- a/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
+++ b/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
@@ -107,5 +107,19 @@ public class MjHingeJointTests {
     Assert.That(element.GetVector3Attribute("axis", Vector3.zero),
                 Is.EqualTo(MjEngineTool.MjVector3Up).Using(_comparer));
   }
+
+  [Test]
+  public void ParsingReferenceConvertsRadiansToDegrees() {
+    var previous = MjSceneImportSettings.AnglesInDegrees;
+    MjSceneImportSettings.AnglesInDegrees = false;
+    try {
+      var jointElement = (XmlElement)_doc.AppendChild(_doc.CreateElement("joint"));
+      jointElement.SetAttribute("ref", "1.57079632679");
+      _joint.ParseMjcf(jointElement);
+      Assert.That(_joint.Configuration, Is.EqualTo(90.0f).Within(1e-3f));
+    } finally {
+      MjSceneImportSettings.AnglesInDegrees = previous;
+    }
+  }
 }
 }


### PR DESCRIPTION
## Summary

Fix Unity import of hinge joint `ref` values when the MJCF compiler uses radians.

`MjHingeJoint` already converts hinge ranges from radians to the degree-valued Unity fields, but `ref` was copied directly into `Configuration`, which is also stored and exposed in degrees. A model using `angle="radian"` therefore imported the reference angle with the wrong unit.

This change:
- converts hinge `ref` from radians to degrees when `MjSceneImportSettings.AnglesInDegrees` is false
- preserves existing degree-mode behaviour
- adds focused regression coverage using a pi/2 reference and checking for 90 degrees

## Validation

The branch is based directly on current `main`, is one commit ahead, and changes only `MjHingeJoint.cs` and its existing test file.

The Unity EditMode suite was not executed in this environment, so no local Unity test pass is claimed.