### PR TITLE
Serialize Unity hinge reference with invariant culture

### DIFF
--- a/unity/Runtime/Components/Joints/MjHingeJoint.cs
+++ b/unity/Runtime/Components/Joints/MjHingeJoint.cs
@@ -91,7 +91,7 @@ namespace Mujoco {
         throw new ArgumentException("Lower range value can't be bigger than Higher");
       }
       mjcf.SetAttribute("range", MjEngineTool.MakeLocaleInvariant($"{RangeLower} {RangeUpper}"));
-      mjcf.SetAttribute("ref", $"{Configuration}");
+      mjcf.SetAttribute("ref", MjEngineTool.MakeLocaleInvariant($"{Configuration}"));
 
       return mjcf;
     }

--- a/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
+++ b/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Xml;
 using NUnit.Framework;
 using UnityEngine;
@@ -66,6 +67,19 @@ public class MjHingeJointTests {
     _joint.RangeUpper = 10;
     _doc.AppendChild(_joint.GenerateMjcf("name", _doc));
     Assert.That(_doc.OuterXml, Does.Contain(@"range=""-20 10"""));
+  }
+
+  [Test]
+  public void GenerateReferenceUsesInvariantCulture() {
+    var previousCulture = CultureInfo.CurrentCulture;
+    CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+    try {
+      _joint.Configuration = 1.5f;
+      var element = _joint.GenerateMjcf("name", _doc);
+      Assert.That(element.GetAttribute("ref"), Is.EqualTo("1.5"));
+    } finally {
+      CultureInfo.CurrentCulture = previousCulture;
+    }
   }
 
   [Test]


### PR DESCRIPTION
## Summary

Make Unity-generated hinge joint `ref` values locale-independent.

`MjHingeJoint.OnGenerateMjcf` already uses `MjEngineTool.MakeLocaleInvariant` for `range`, but formats `ref` with the current process culture. On locales with a comma decimal separator, for example `fr-FR`, a reference value such as 1.5 can therefore be written as `1,5`, which is not the intended MJCF numeric representation.

This change:
- serializes hinge `ref` through `MjEngineTool.MakeLocaleInvariant`
- adds a regression test that switches the current culture to `fr-FR` and verifies the generated value remains `1.5`
- does not change parsing or runtime joint behaviour

## Validation

The branch is based directly on current `main`, is one commit ahead, and changes only `MjHingeJoint.cs` and its existing test file.

The Unity EditMode suite was not executed in this environment, so no local Unity test pass is claimed.