### PR TITLE
Convert Newton angular attributes to MuJoCo units

### DIFF
--- a/plugin/usd_decoder/usd_decoder.cc
+++ b/plugin/usd_decoder/usd_decoder.cc
@@ -1839,6 +1839,9 @@ void ParseMjcPhysicsJointAPI(mjsJoint* mj_joint,
   } else if (newton_damping_authored) {
     float damping;
     newton_damping_attr.Get(&damping);
+    if (mj_joint->type == mjJNT_HINGE || mj_joint->type == mjJNT_BALL) {
+      damping *= 180.0 / std::numbers::pi;
+    }
     mj_joint->damping[0] = damping;
   }
 
@@ -2180,6 +2183,9 @@ void ParseConstraint(mjSpec* spec, const pxr::UsdPrim& prim, mjsBody* body,
     if (newton_coef0 && newton_coef0.HasAuthoredValue()) {
       float val;
       newton_coef0.Get(&val);
+      if (prim.IsA<pxr::UsdPhysicsRevoluteJoint>()) {
+        val *= std::numbers::pi / 180.0;
+      }
       eq->data[0] = val;
     } else {
       eq_joint_api.GetCoef0Attr().Get(&eq->data[0]);


### PR DESCRIPTION
## Summary

Fix the two angular-unit conversion defects reported in #3472 for the Newton USD schema read path.

Newton authors `newton:damping` for angular degrees as effort-seconds per degree, while MuJoCo stores angular joint damping per radian. Newton also authors `newton:mimicCoef0` in degrees for revolute joints, while MuJoCo's `mjEQ_JOINT` constant is in radians.

This change:
- multiplies Newton damping by `180/pi` for angular MuJoCo joints
- converts `newton:mimicCoef0` from degrees to radians for USD revolute joints
- leaves slide-joint and dimensionless values unchanged
- leaves the deprecated `mjc:` paths unchanged

Addresses parts 1 and 2 of #3472. The separate `newton:mimicEnabled` defect is already being handled by #3477.

## Validation

- Based directly on current upstream `main` (`80d1b0d81148e4f85b0260bc0d5f0ca92ca52113`).
- Final branch contains one commit (`99b71edb13b25905aa5938dfe6774b31147e35fb`) and changes only `plugin/usd_decoder/usd_decoder.cc`.
- `git diff --check` passes.
- The OpenUSD decoder test environment was not built locally, so no runtime test pass is claimed.