### PR TITLE
Fix Unity error message interpolation

### DIFF
--- a/unity/Runtime/Components/MjScene.cs
+++ b/unity/Runtime/Components/MjScene.cs
@@ -355,7 +355,7 @@ public class MjScene : MonoBehaviour {
     }
     if (Data->warning2.number > 0) {
       Data->warning2.number = 0;
-      throw new PhysicsRuntimeException("CNSTRFULL: njmax {Model.njmax} isn't sufficient.");
+      throw new PhysicsRuntimeException($"CNSTRFULL: njmax {Model.njmax} isn't sufficient.");
     }
     if (Data->warning3.number > 0) {
       Data->warning3.number = 0;

--- a/unity/Runtime/Tools/MjEngineTool.cs
+++ b/unity/Runtime/Tools/MjEngineTool.cs
@@ -310,7 +310,7 @@ public static class MjEngineTool {
       if ((toPoint - fromPoint).magnitude < _fromToValidityTolerance) {
         throw new ArgumentException(
             $"{nodeName}: 'fromto' produces a vector that's too short. {fromto} has magnitude " +
-            "{fromto.magnitude} lower than the tolerance {_fromToValidityTolerance}");
+            $"{(toPoint - fromPoint).magnitude} lower than the tolerance {_fromToValidityTolerance}");
       }
       return true;
     } else {


### PR DESCRIPTION
## Summary

Fix two Unity error paths that currently expose literal `{...}` placeholders instead of the values that are meant to help diagnose the failure.

The changes:
- interpolate the measured `fromto` vector magnitude and tolerance in `MjEngineTool.ParseFromToMjcf`
- interpolate `Model.njmax` in the `CNSTRFULL` `PhysicsRuntimeException`

There is no behavioural change outside the diagnostic text.

## Validation

- Based directly on current upstream `main` (`80d1b0d81148e4f85b0260bc0d5f0ca92ca52113`).
- Final branch contains one commit (`5b4c0eb6dcd05da67247f955c654adec70c0bdbc`) and changes exactly two C# lines.
- `git diff --check` passes.
- Unity EditMode tests were not executed locally, so no Unity test pass is claimed.