### PR TITLE
Check collision pair arena allocation result

### DIFF
--- a/src/engine/engine_collision_driver.c
+++ b/src/engine/engine_collision_driver.c
@@ -519,7 +519,7 @@ static void filterFlexContacts(mjData* d, int ncon_before) {
 static void pushPairArena(mjData* d, mjcPair* pair) {
   // allocate geom pair on the arena
   mjcPair* new_pair = (mjcPair*) mj_arenaAllocByte(d, sizeof(mjcPair), _Alignof(mjcPair));
-  if (!pair) {
+  if (!new_pair) {
     mjERROR("arena too small to allocate geom pair");
   }
   *new_pair = *pair;


### PR DESCRIPTION
## Summary

Fix the null check after allocating a candidate collision pair from the MuJoCo arena.

`pushPairArena` stores the allocation result in `new_pair`, but currently checks the input `pair` pointer instead. The callers pass a valid source pair, so that condition does not detect arena allocation failure. If `mj_arenaAllocByte` returns null, the function then dereferences `new_pair` while copying the pair.

This change checks `new_pair` before dereferencing it, so arena exhaustion reaches the existing `arena too small to allocate geom pair` error path as intended.

## Validation

- Based directly on current upstream `main` (`80d1b0d81148e4f85b0260bc0d5f0ca92ca52113`).
- Final branch contains one commit (`735b08d6c81ecc6b554b80864da927d08aea7257`) and changes one line in `src/engine/engine_collision_driver.c`.
- `git diff --check` passes.
- A full native MuJoCo test build was not run in this environment, so no test pass is claimed.