### PR TITLE
Fix spring-damper damping regime scaling

### DIFF
--- a/src/engine/engine_util_misc.c
+++ b/src/engine/engine_util_misc.c
@@ -1603,14 +1603,17 @@ void mju_decodePyramid(mjtNum* force, const mjtNum* pyramid, const mjtNum* mu, i
 
 // integrate spring-damper analytically, return pos(t)
 mjtNum mju_springDamper(mjtNum pos0, mjtNum vel0, mjtNum k, mjtNum b, mjtNum t) {
-  mjtNum det, c1, c2, r1, r2, w;
+  mjtNum det, det_tol, c1, c2, r1, r2, w;
 
   // determinant of characteristic equation
   det = b*b - 4*k;
 
+  // scale tolerance with determinant terms to make regime selection invariant to time units
+  det_tol = mjMINVAL * mju_max(b*b, 4*mju_abs(k));
+
   // overdamping
   //  pos(t) = c1*exp(r1*t) + c2*exp(r2*t);  r12 = (-b +- sqrt(det))/2
-  if (det > mjMINVAL) {
+  if (det > det_tol) {
     // compute w = sqrt(det)/2
     w = mju_sqrt(det)/2;
 
@@ -1628,7 +1631,7 @@ mjtNum mju_springDamper(mjtNum pos0, mjtNum vel0, mjtNum k, mjtNum b, mjtNum t) 
 
   // critical damping
   //  pos(t) = exp(-b*t/2) * (c1 + c2*t)
-  else if (det <= mjMINVAL && det >= -mjMINVAL) {
+  else if (det <= det_tol && det >= -det_tol) {
     // compute coefficients
     c1 = pos0;
     c2 = vel0 + b*c1/2;

--- a/test/engine/engine_util_misc_test.cc
+++ b/test/engine/engine_util_misc_test.cc
@@ -87,6 +87,37 @@ TEST_F(UtilMiscTest, Sigmoid) {
   EXPECT_NEAR(dy_dx_0p5, expected, fd_tol);
 }
 
+TEST_F(UtilMiscTest, SpringDamperDampingRegimes) {
+  constexpr mjtNum pos0 = 1;
+  constexpr mjtNum vel0 = 0;
+  constexpr mjtNum stiffness = 1;
+  constexpr mjtNum dt = 1;
+  const mjtNum tol = MjTol(1e-14, 1e-5);
+
+  EXPECT_NEAR(mju_springDamper(pos0, vel0, stiffness, 3, dt),
+              0.7866455993033682, tol);  // overdamped
+  EXPECT_NEAR(mju_springDamper(pos0, vel0, stiffness, 2, dt),
+              0.7357588823428847, tol);  // critically damped
+  EXPECT_NEAR(mju_springDamper(pos0, vel0, stiffness, 1, dt),
+              0.6597001533917017, tol);  // underdamped
+}
+
+TEST_F(UtilMiscTest, SpringDamperInvariantToTimeUnits) {
+  constexpr mjtNum pos0 = 1;
+  constexpr mjtNum vel0 = 0.5;
+  constexpr mjtNum stiffness = 1;
+  constexpr mjtNum dt = 1;
+  constexpr mjtNum time_scale = 1e-8;
+
+  for (mjtNum damping : {3, 2, 1}) {
+    mjtNum expected = mju_springDamper(pos0, vel0, stiffness, damping, dt);
+    mjtNum scaled = mju_springDamper(pos0, time_scale*vel0,
+                                     time_scale*time_scale*stiffness,
+                                     time_scale*damping, dt/time_scale);
+    EXPECT_NEAR(scaled, expected, MjTol(1e-14, 1e-5)) << "damping=" << damping;
+  }
+}
+
 TEST_F(UtilMiscTest, SphereWrap) {
   static constexpr char xml[] = R"(
   <mujoco>


### PR DESCRIPTION
## Summary

- Scale the characteristic-discriminant tolerance by the larger discriminant term.
- Add analytical regression coverage for overdamped, critically damped, and underdamped responses.
- Verify time-unit invariance in all three damping regimes.

Fixes #3521.

## Problem

`mju_springDamper` previously compared `Kv^2 - 4*Kp` directly with the fixed absolute value `mjMINVAL`. A consistent time rescaling multiplies the discriminant by the square of the time-scale factor, so this comparison could change the selected damping regime even though the physical trajectory was unchanged.

For one equivalent overdamped pair, the unscaled call returned `0.7946142382307649`, while the time-scaled call returned `0.0404276819945128`. Both should return `0.7946142382307650`.

The updated tolerance is relative to `max(Kv^2, 4*abs(Kp))`. It therefore scales with the discriminant and retains the near-critical branch without changing the public API.

## Validation

- New spring-damper regression tests: 2/2 passed.
- Full `engine_util_misc_test` binary: 66/66 passed.
- Full CTest suite: 1376/1376 passed.
- Independent property sweep: 1080 equivalent parameterizations passed across all damping regimes and time scales from `1e-2` through `1e-12`; maximum absolute difference was `5.33e-15`.

Local environment: macOS, AppleClang 21, CMake 4.4.2, Release build with `MUJOCO_HARDEN=ON`.
