### PR TITLE
docs: clarify regularized friction creep and NoSlip tradeoffs

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -326,9 +326,10 @@ adjust it properly through the XML.
    This attribute determines the ratio of frictional-to-normal constraint impedance for elliptic friction cones. The
    setting of solimp determines a single impedance value for all contact dimensions, which is then modulated by this
    attribute. Settings larger than 1 cause friction forces to be "harder" than normal forces, having the general effect
-   of preventing slip, without increasing the actual friction coefficient. For pyramidal friction cones the situation is
-   more complex because the pyramidal approximation mixes normal and frictional dimensions within each basis vector; it
-   is not recommended to use high impratio values with pyramidal cones.
+   of reducing :ref:`slow slippage<CSlowSlippage>` without increasing the actual friction coefficient or guaranteeing
+   exact sticking. For pyramidal friction cones the situation is more complex because the pyramidal approximation mixes
+   normal and frictional dimensions within each basis vector; it is not recommended to use high impratio values with
+   pyramidal cones.
 
 .. _option-gravity:
 
@@ -448,9 +449,10 @@ adjust it properly through the XML.
 .. _option-noslip_iterations:
 
 :at:`noslip_iterations`: :at-val:`int, "0"`
-   Maximum number of iterations of the Noslip solver. This is a post-processing step executed after the main solver. It
+   Maximum number of iterations of the NoSlip solver. This is a post-processing step executed after the main solver. It
    uses a modified PGS method to suppress slip/drift in friction dimensions resulting from the soft-constraint model.
-   The default setting 0 disables this post-processing step.
+   The default setting 0 disables this post-processing step. See the :ref:`NoSlip solver<soNoSlip>` for its mechanics
+   and tradeoffs, and :ref:`slow slippage<CSlowSlippage>` for practical guidance.
 
 .. _option-noslip_tolerance:
 

--- a/doc/computation/index.rst
+++ b/doc/computation/index.rst
@@ -1410,6 +1410,8 @@ representations of the constraint Jacobian and related matrices.
    handle elliptic cones without approximating them. It does more work per contact, however the contact dimensionality
    is smaller, and these two factors roughly balance each other.
 
+.. _soNoSlip:
+
 **NoSlip** : post-processing pass
    This is not a standalone solver but a post-processing step, enabled by setting ``noslip_iterations`` to a positive
    value in :ref:`option <option>`. After the main solver (Newton, CG, or PGS) has converged, the NoSlip solver

--- a/doc/modeling.rst
+++ b/doc/modeling.rst
@@ -415,6 +415,8 @@ violation: :math:`r \equiv 0`. This simplifies the constraint model (see also :r
 - :math:`d_\text{width}` (:at:`solimp[1]`) still affects the damping :math:`b` as a scaling denominator
   (:eq:`eq:solref_standard`, :eq:`eq:solref_direct`), even though it does not affect the impedance.
 
+See :ref:`slow slippage<CSlowSlippage>` for the implications of this model for exact sticking and practical guidance.
+
 .. _CContact:
 
 Contact parameters
@@ -1733,16 +1735,29 @@ better visualize and understand the contact configuration and resulting forces.
   explicit damping. Use the implicit or implicitfast integrators, as documented in the
   :ref:`Numerical Integration<geIntegration>` section.
 
-**Slow slippage**
-  Unlike the above problems which lead to fast slippage, slow, gradual slippage is a property of MuJoCo's contact
-  model by design, since without it the inverse dynamics are not defined. This is discussed in detail in the
-  :ref:`softness and slip<Soft>` clarification. This type of slippage can be addressed in two ways.
+.. _CSlowSlippage:
 
-  a. Increase the :ref:`impratio<option-impratio>` parameter. This will reduce (but not entirely prevent) slow
-     slippage. Note that high impratio values work well only with :ref:`elliptic cones<option-cone>`.
-  b. Enable the NoSlip solver by increasing :ref:`noslip_iterations<option-noslip_iterations>` to a positive integer.
-     A small number (1, 2 or 3) is usually sufficient. The NoSlip post-processing solver will entirely prevent slip,
-     at the cost of making inverse dynamics ill-defined and additional computational cost.
+**Slow slippage**
+  Even when the tangential force required for static equilibrium lies strictly inside the contact friction cone,
+  MuJoCo's regularized soft-contact model does not guarantee an exact zero-velocity stick state. In the
+  recommended elliptic contact model, friction dimensions have no position residual and are purely damped, so a
+  persistent tangential load can produce a nonzero steady slip velocity. This is expected behavior; see
+  :ref:`Friction<CSolverFriction>` and the :ref:`softness and slip<Soft>` clarification.
+
+  After ruling out the faster failure modes above, slow slippage can be reduced in two ways.
+
+  a. Use :ref:`elliptic cones<option-cone>` and increase :ref:`impratio<option-impratio>`. This makes the friction
+     dimensions harder relative to the normal dimension without increasing the friction coefficient. It reduces slow
+     slippage but does not guarantee exact sticking. The slip rate also depends on contact parameters, loading,
+     geometry and dynamics, so ``impratio`` alone does not define a universal rate.
+  b. For stronger suppression, enable the NoSlip solver by setting
+     :ref:`noslip_iterations<option-noslip_iterations>` to a positive integer. A small number (1, 2 or 3) is usually
+     sufficient. In its friction-only post-processing sweep, NoSlip sets the regularizer to zero for the updated
+     friction dimensions. The degree of suppression depends on solver convergence; the iteration limit caps the work,
+     while :ref:`noslip_tolerance<option-noslip_tolerance>` is an early-termination threshold rather than a bound on
+     residual slip. Exact zero slip is not guaranteed. NoSlip also adds computational cost, makes inverse dynamics
+     ill-defined and can occasionally cause instabilities in complex multi-contact systems. See the
+     :ref:`NoSlip solver<soNoSlip>` for details.
 
 .. _CBacklash:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -859,7 +859,7 @@ two elements of ``solimp``) as well as the global ``mjModel.opt.impratio`` setti
 adjustment often requires smaller time steps to keep the simulation stable, because they make the nonlinear dynamics
 more difficult to integrate numerically. Slip is also reduced by the Newton solver which is more accurate in general.
 
-For situations where it is desirable to suppress slip completely, there is a :ref:`NoSlip <soAlgorithms>`
+For situations where stronger slip suppression is required, there is a :ref:`NoSlip <soNoSlip>`
 post-processing solver which runs after the main solver. It updates the contact forces in friction dimensions by
 disregarding constraint softness. When this option is used however, MuJoCo is no longer solving the convex optimization
 problem it was designed to solve, and the simulation may become less robust. Thus using the Newton solver with elliptic


### PR DESCRIPTION
Addresses #3328.

## Summary

- explain why an in-cone tangential load does not guarantee an exact zero-velocity stick state in MuJoCo's regularized soft-contact model
- clarify that `impratio` reduces slow slip without changing the friction coefficient or defining a universal slip rate
- document NoSlip as an iterative, friction-only hard-constraint post-pass, including early termination, computational cost, inverse-dynamics, and multi-contact robustness tradeoffs
- connect the modeling guidance, XML options, solver mechanics, and overview with focused cross-references, and remove the absolute claim that NoSlip suppresses slip completely

## Validation

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- Sphinx 7.4.7 HTML build using `doc/requirements.txt`; build succeeded and the new `CSlowSlippage` / `soNoSlip` anchors and internal links were verified in the generated HTML
  - the local build reported one unrelated optional `mujoco_warp` autodoc import warning because the full Read the Docs MJX/MuJoCo Warp stack was not installed; no warning originated from the changed files
- reproduced all seven CPU cases from #3328 on Apple Silicon macOS using MuJoCo 3.12.1 built from current `main` at `a266a9a6`

| Case | Slip rate (µm/s) |
| --- | ---: |
| elliptic, `impratio=10` | 154.99 |
| elliptic, `impratio=1` | 1551.79 |
| elliptic, `impratio=100` | 15.34 |
| pyramidal, `impratio=1` | 2269.73 |
| elliptic, `condim=6` | 153.49 |
| elliptic, stiff `solref` | 51.32 |
| elliptic, `noslip_iterations=10` | 1.41 |

The current-main results preserve the issue's central observation: higher `impratio` reduces creep without producing an exact stick state, while NoSlip suppresses the measured drift by roughly 110x but does not make it exactly zero. This PR changes documentation only; it does not propose solver behavior changes.
