### PR TITLE
Make MuJoCo Live work on iPhones

### DIFF
--- a/.github/workflows/build_steps.sh
+++ b/.github/workflows/build_steps.sh
@@ -396,7 +396,7 @@ build_mujoco_live() {
         -DMUJOCO_BUILD_SIMULATE=OFF
     cmake --build build_host --target matc resgen cmgen mujoco_filament_assets -j$(nproc)
 
-    echo "Building WASM app..."
+    echo "Building desktop WASM app..."
     emcmake cmake -S . -B build_wasm -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DMUJOCO_BUILD_STUDIO=ON \
@@ -404,6 +404,20 @@ build_mujoco_live() {
         -DMUJOCO_BUILD_TESTS_WASM=OFF \
         -DMUJOCO_NATIVE_BUILD_DIR=$(pwd)/build_host
     cmake --build build_wasm --target mujoco_studio -j$(nproc)
+
+    # iOS WebKit cannot reliably reserve the desktop build's 4 GiB shared
+    # memory. Keep a separate non-threaded profile below its practical limit.
+    echo "Building iOS WASM app..."
+    emcmake cmake -S . -B build_wasm_ios -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DMUJOCO_BUILD_STUDIO=ON \
+        -DMUJOCO_USE_FILAMENT=ON \
+        -DMUJOCO_BUILD_TESTS_WASM=OFF \
+        -DMUJOCO_WASM_THREADS=OFF \
+        -DMUJOCO_STUDIO_WASM_INITIAL_MEMORY=256mb \
+        -DMUJOCO_STUDIO_WASM_MAXIMUM_MEMORY=512mb \
+        -DMUJOCO_NATIVE_BUILD_DIR=$(pwd)/build_host
+    cmake --build build_wasm_ios --target mujoco_studio -j$(nproc)
 }
 
 

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -30,8 +30,9 @@ jobs:
 
     - name: Prepare files for GitHub Pages
       run: |
-        mkdir -p dist/bin
+        mkdir -p dist/bin/ios
         cp -r build_wasm/bin/* dist/bin/
+        cp -r build_wasm_ios/bin/* dist/bin/ios/
         cp src/experimental/studio/live.html dist/index.html
         cp src/experimental/studio/live.css dist/live.css
         cp src/experimental/studio/live.js dist/live.js

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-upload-artifacts:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
 
     - name: Prepare Linux
       run: bash ./.github/workflows/build_steps.sh prepare_linux
@@ -43,7 +43,7 @@ jobs:
         fi
 
     - name: Upload GitHub Pages artifacts
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
       with:
         path: dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build-and-upload-artifacts:
@@ -50,6 +48,9 @@ jobs:
   deploy-pages:
     needs: build-and-upload-artifacts
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/src/experimental/studio/CMakeLists.txt
+++ b/src/experimental/studio/CMakeLists.txt
@@ -186,6 +186,17 @@ endif()
 
 # WASM Live target.
 if(EMSCRIPTEN)
+    set(
+      MUJOCO_STUDIO_WASM_INITIAL_MEMORY
+      "1024mb"
+      CACHE STRING "Initial WebAssembly memory for MuJoCo Live"
+    )
+    set(
+      MUJOCO_STUDIO_WASM_MAXIMUM_MEMORY
+      "4gb"
+      CACHE STRING "Maximum WebAssembly memory for MuJoCo Live"
+    )
+
     add_executable(mujoco_studio)
     target_sources(mujoco_studio PRIVATE emscripten.cc)
     target_compile_options(mujoco_studio PRIVATE -g)
@@ -209,8 +220,8 @@ if(EMSCRIPTEN)
         -sFETCH=1
         -sGL_PREINITIALIZED_CONTEXT=1
         -sSTACK_SIZE=32mb
-        -sINITIAL_MEMORY=1024mb
-        -sMAXIMUM_MEMORY=4gb
+        -sINITIAL_MEMORY=${MUJOCO_STUDIO_WASM_INITIAL_MEMORY}
+        -sMAXIMUM_MEMORY=${MUJOCO_STUDIO_WASM_MAXIMUM_MEMORY}
         -sASSERTIONS=1
         -fexceptions
         -g

--- a/src/experimental/studio/live.html
+++ b/src/experimental/studio/live.html
@@ -53,6 +53,5 @@
     <div id="commitHash">__COMMIT_HASH_PLACEHOLDER__</div>
     <canvas id="canvas" class="emscripten" oncontextmenu="event.preventDefault()"></canvas>
     <script src="live.js"></script>
-    <script async src="bin/mujoco_studio.js"></script>
   </body>
 </html>

--- a/src/experimental/studio/live.js
+++ b/src/experimental/studio/live.js
@@ -21,6 +21,16 @@ function hideLoading() {
   loadingOverlay.style.display = 'none';
 }
 
+function isIOSDevice() {
+  return /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+// iOS WebKit has a substantially lower WebAssembly memory ceiling than
+// desktop browsers. Select the single-threaded, lower-memory build before the
+// Emscripten runtime creates its WebAssembly.Memory object.
+const wasmRuntimeDirectory = isIOSDevice() ? 'bin/ios' : 'bin';
+
 // ---------------------------------------------------------------------------
 // Parallel asset prefetcher.
 //
@@ -124,7 +134,7 @@ var Module = {
   postRun: [],
   locateFile: function (path) {
     const baseURL = window.location.origin + window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"));
-    return baseURL + "/bin/" + path;
+    return baseURL + "/" + wasmRuntimeDirectory + "/" + path;
   },
   print: console.log,
   printErr: text => {
@@ -327,3 +337,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 });
+
+const wasmRuntimeScript = document.createElement('script');
+wasmRuntimeScript.async = true;
+wasmRuntimeScript.src = Module.locateFile('mujoco_studio.js');
+wasmRuntimeScript.onerror = () => {
+  hideLoading();
+  console.error('Failed to load MuJoCo Live runtime:', wasmRuntimeScript.src);
+};
+document.body.appendChild(wasmRuntimeScript);


### PR DESCRIPTION
Fixes #3442.

The short version: iPhone Safari was being asked to reserve desktop-sized WebAssembly memory before MuJoCo Live had a chance to initialize.

The existing Live build starts with 1 GiB of shared memory and can grow to 4 GiB. That works on desktop browsers, but exceeds what iOS WebKit can reliably reserve, causing the page to reload or crash.

This keeps the current desktop configuration and adds a smaller iOS-specific build:

- Desktop: threaded, 1 GiB initial memory, 4 GiB maximum
- iOS: single-threaded, 256 MiB initial memory, 512 MiB maximum

`live.js` selects the iOS build before Emscripten creates its WebAssembly memory. Desktop users therefore keep the existing large-model capacity, while iPhones receive a runtime that fits within WebKit limits.

I tested this with:

- Complete desktop and iOS WebAssembly builds using Emscripten 4.0.10
- Generated desktop memory verified as 16,384-65,536 pages, shared
- Generated iOS memory verified as 4,096-8,192 pages, unshared
- The linked humanoid model loading and rendering on a real iPhone in Safari
- The same model loading in desktop Chromium with no console warnings or errors

### iPhone Safari

The phone now reaches the viewer and renders the model successfully.

<p align="center">
  <img width="300" alt="MuJoCo Live downloading the humanoid model in iPhone Safari" src="https://github.com/user-attachments/assets/b1697ab0-c30e-43f8-bb6f-4482e3fe1ab7" />
  <img width="300" alt="MuJoCo Live rendering the humanoid model in iPhone Safari" src="https://github.com/user-attachments/assets/ca916712-29a1-42de-a1fd-1eb63991619d" />
</p>
<p align="center"><sub>Loading the humanoid model, then interacting with the rendered scene on iPhone Safari.</sub></p>