### PR TITLE
translate URDF <mimic> joints to joint equality constraints

### DIFF
--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -189,9 +189,21 @@ void mjXURDF::Parse(XMLElement*        root,
   }
 
   // <mimic> -> joint equality: q_follower - q0 = offset + multiplier*(q_driver - q0)
+  auto hinge_or_slide = [&](const std::string& jnt_name) {
+    mjsElement* el  = mjs_findElement(spec, mjOBJ_JOINT, jnt_name.c_str());
+    mjsJoint*   jnt = el ? mjs_asJoint(el) : nullptr;
+    return jnt && (jnt->type == mjJNT_HINGE || jnt->type == mjJNT_SLIDE);
+  };
   for (const auto& [follower, driver, multiplier, offset] : urMimic) {
+    // mjEQ_JOINT couples two 1-dof joints; skip the mimic rather than fail the
+    // load when the target is fixed, planar, floating or missing
+    if (!hinge_or_slide(follower) || !hinge_or_slide(driver)) {
+      std::cerr << "WARNING: <mimic> on joint '" << follower
+                << "' ignored; mimic requires revolute or prismatic joints\n";
+      continue;
+    }
     mjsEquality* eq = mjs_addEquality(spec, nullptr);
-    eq->type = mjEQ_JOINT;
+    eq->type        = mjEQ_JOINT;
     mjs_setString(eq->name1, follower.c_str());
     mjs_setString(eq->name2, driver.c_str());
     eq->data[0] = offset;

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -68,6 +68,7 @@ void mjXURDF::Clear(void) {
   urMat.clear();
   urRGBA.clear();
   urGeomNames.clear();
+  urMimic.clear();
 }
 
 std::string mjXURDF::GetPrefixedName(const std::string& name) {
@@ -185,6 +186,16 @@ void mjXURDF::Parse(XMLElement*        root,
 
     // advance to next element
     elem = elem->NextSiblingElement();
+  }
+
+  // <mimic> -> joint equality: q_follower - q0 = offset + multiplier*(q_driver - q0)
+  for (const auto& [follower, driver, multiplier, offset] : urMimic) {
+    mjsEquality* eq = mjs_addEquality(spec, nullptr);
+    eq->type = mjEQ_JOINT;
+    mjs_setString(eq->name1, follower.c_str());
+    mjs_setString(eq->name2, driver.c_str());
+    eq->data[0] = offset;
+    eq->data[1] = multiplier;
   }
 
   // override the pose for the base link and add a free joint
@@ -489,6 +500,17 @@ void mjXURDF::Joint(XMLElement* joint_elem) {
       pjoint->actfrcrange[0] = -effort;
       pjoint->actfrcrange[1] = effort;
     }
+  }
+
+  // mimic: q = multiplier*q_target + offset; deferred to a joint equality since
+  // the target joint may be declared later
+  if ((elem = FindSubElem(joint_elem, "mimic"))) {
+    std::string target;
+    ReadAttrTxt(elem, "joint", target, true);
+    double multiplier = 1, offset = 0;
+    ReadAttr(elem, "multiplier", 1, &multiplier, text);
+    ReadAttr(elem, "offset", 1, &offset, text);
+    urMimic.emplace_back(jntname, GetPrefixedName(target), multiplier, offset);
   }
 }
 

--- a/src/xml/xml_urdf.h
+++ b/src/xml/xml_urdf.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
@@ -71,6 +72,9 @@ class mjXURDF : public mjXBase {
   std::vector<mjRGBA>                          urRGBA;       // material RBG value
   std::unordered_set<std::string>              urGeomNames;  // geom name
   std::map<std::string, std::vector<mjsMesh*>> meshes;       // map from name to mjsMesh
+
+  // <mimic>: (follower, driver, multiplier, offset), emitted as joint equalities
+  std::vector<std::tuple<std::string, std::string, double, double>> urMimic;
 
   std::string urPrefix;                                      // prefix to apply to all names
 };

--- a/test/xml/CMakeLists.txt
+++ b/test/xml/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 mujoco_test(xml_api_test)
 
+mujoco_test(xml_urdf_test)
+
 mujoco_test(
   xml_native_reader_test
   ADDITIONAL_LINK_LIBRARIES compare_model

--- a/test/xml/xml_urdf_test.cc
+++ b/test/xml/xml_urdf_test.cc
@@ -306,5 +306,43 @@ TEST_F(MujocoTest, RepeatedMeshName) {
   mj_deleteSpec(spec);
 }
 
+TEST_F(MujocoTest, MimicBecomesJointEquality) {
+  // gripper with mirrored fingers: right_joint = -1 * left_joint. the target
+  // joint is declared after the joint that mimics it, on purpose
+  static constexpr char urdf[] = R"(
+  <robot name="gripper">
+    <link name="base">
+      <inertial><mass value="1"/>
+        <inertia ixx="1" iyy="1" izz="1" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <link name="left_finger">
+      <inertial><mass value="0.1"/>
+        <inertia ixx="1e-4" iyy="1e-4" izz="1e-4" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <link name="right_finger">
+      <inertial><mass value="0.1"/>
+        <inertia ixx="1e-4" iyy="1e-4" izz="1e-4" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <joint name="right_joint" type="prismatic">
+      <parent link="base"/><child link="right_finger"/><axis xyz="1 0 0"/>
+      <mimic joint="left_joint" multiplier="-1" offset="0.02"/>
+    </joint>
+    <joint name="left_joint" type="prismatic">
+      <parent link="base"/><child link="left_finger"/><axis xyz="1 0 0"/>
+    </joint>
+  </robot>)";
+
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(urdf, error.data(), error.size());
+  ASSERT_THAT(model.get(), NotNull()) << error.data();
+
+  ASSERT_EQ(model->neq, 1);
+  EXPECT_EQ(model->eq_type[0], mjEQ_JOINT);
+  EXPECT_EQ(model->eq_obj1id[0], mj_name2id(model.get(), mjOBJ_JOINT, "right_joint"));
+  EXPECT_EQ(model->eq_obj2id[0], mj_name2id(model.get(), mjOBJ_JOINT, "left_joint"));
+  EXPECT_EQ(model->eq_data[0], 0.02);  // offset
+  EXPECT_EQ(model->eq_data[1], -1.0);  // multiplier
+}
+
 }  // namespace
 }  // namespace mujoco

--- a/test/xml/xml_urdf_test.cc
+++ b/test/xml/xml_urdf_test.cc
@@ -307,10 +307,11 @@ TEST_F(MujocoTest, RepeatedMeshName) {
 }
 
 TEST_F(MujocoTest, MimicBecomesJointEquality) {
-  // gripper with mirrored fingers: right_joint = -1 * left_joint. the target
-  // joint is declared after the joint that mimics it, on purpose
+  // gripper with mirrored fingers: right_joint = -1 * left_joint + 0.02. the
+  // target joint is declared after the joint that mimics it, on purpose
   static constexpr char urdf[] = R"(
   <robot name="gripper">
+    <mujoco><option gravity="0 0 0"/></mujoco>
     <link name="base">
       <inertial><mass value="1"/>
         <inertia ixx="1" iyy="1" izz="1" ixy="0" ixz="0" iyz="0"/></inertial>
@@ -325,10 +326,12 @@ TEST_F(MujocoTest, MimicBecomesJointEquality) {
     </link>
     <joint name="right_joint" type="prismatic">
       <parent link="base"/><child link="right_finger"/><axis xyz="1 0 0"/>
+      <dynamics damping="1"/>
       <mimic joint="left_joint" multiplier="-1" offset="0.02"/>
     </joint>
     <joint name="left_joint" type="prismatic">
       <parent link="base"/><child link="left_finger"/><axis xyz="1 0 0"/>
+      <dynamics damping="1"/>
     </joint>
   </robot>)";
 
@@ -338,10 +341,23 @@ TEST_F(MujocoTest, MimicBecomesJointEquality) {
 
   ASSERT_EQ(model->neq, 1);
   EXPECT_EQ(model->eq_type[0], mjEQ_JOINT);
-  EXPECT_EQ(model->eq_obj1id[0], mj_name2id(model.get(), mjOBJ_JOINT, "right_joint"));
-  EXPECT_EQ(model->eq_obj2id[0], mj_name2id(model.get(), mjOBJ_JOINT, "left_joint"));
+  int right = mj_name2id(model.get(), mjOBJ_JOINT, "right_joint");
+  int left = mj_name2id(model.get(), mjOBJ_JOINT, "left_joint");
+  EXPECT_EQ(model->eq_obj1id[0], right);
+  EXPECT_EQ(model->eq_obj2id[0], left);
   EXPECT_EQ(model->eq_data[0], 0.02);  // offset
   EXPECT_EQ(model->eq_data[1], -1.0);  // multiplier
+
+  // simulate from a driver displacement and check the follower tracks
+  // q_right = -1 * q_left + 0.02
+  MjDataPtr data = MakeData(model);
+  data->qpos[model->jnt_qposadr[left]] = 0.03;
+  while (data->time < 2) {
+    mj_step(model.get(), data.get());
+  }
+  double q_left = data->qpos[model->jnt_qposadr[left]];
+  double q_right = data->qpos[model->jnt_qposadr[right]];
+  EXPECT_NEAR(q_right, -1.0 * q_left + 0.02, 1e-4);
 }
 
 TEST_F(MujocoTest, MimicTargetingIncompatibleJointIsIgnored) {

--- a/test/xml/xml_urdf_test.cc
+++ b/test/xml/xml_urdf_test.cc
@@ -344,5 +344,37 @@ TEST_F(MujocoTest, MimicBecomesJointEquality) {
   EXPECT_EQ(model->eq_data[1], -1.0);  // multiplier
 }
 
+TEST_F(MujocoTest, MimicTargetingIncompatibleJointIsIgnored) {
+  // a <mimic> pointing at a fixed joint used to load with the mimic dropped;
+  // it must still load rather than turn into a hard failure
+  static constexpr char urdf[] = R"(
+  <robot name="robot">
+    <link name="base">
+      <inertial><mass value="1"/>
+        <inertia ixx="1" iyy="1" izz="1" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <link name="a">
+      <inertial><mass value="0.1"/>
+        <inertia ixx="1e-4" iyy="1e-4" izz="1e-4" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <link name="b">
+      <inertial><mass value="0.1"/>
+        <inertia ixx="1e-4" iyy="1e-4" izz="1e-4" ixy="0" ixz="0" iyz="0"/></inertial>
+    </link>
+    <joint name="mover" type="prismatic">
+      <parent link="base"/><child link="a"/><axis xyz="1 0 0"/>
+      <mimic joint="welded"/>
+    </joint>
+    <joint name="welded" type="fixed">
+      <parent link="a"/><child link="b"/>
+    </joint>
+  </robot>)";
+
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(urdf, error.data(), error.size());
+  ASSERT_THAT(model.get(), NotNull()) << error.data();
+  EXPECT_EQ(model->neq, 0);
+}
+
 }  // namespace
 }  // namespace mujoco


### PR DESCRIPTION
per #3527. urdf `<mimic multiplier="M" offset="O">` on a follower joint becomes an `<equality><joint>` with `polycoef = [O M 0 0 0]`. couplings are collected during joint parsing and emitted after, so the target joint can be declared later in the file.

also wired `xml_urdf_test.cc` into cmake - it wasn't referenced by any target so its tests weren't building.
