### PR TITLE
Store broadphase pair indices as uint32_t to fix out-of-bounds read

### DIFF
--- a/src/engine/engine_collision_driver.c
+++ b/src/engine/engine_collision_driver.c
@@ -15,6 +15,7 @@
 #include "engine/engine_collision_driver.h"
 
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #include <mujoco/mjdata.h>
@@ -618,7 +619,7 @@ void mj_collision(const mjModel* m, mjData* d) {
   // broadphase collision detector
   TM_START;
   int nmaxpairs = (nbodyflex*(nbodyflex - 1))/2;
-  int* broadphasepair = mjSTACKALLOC(d, nmaxpairs, int);
+  uint32_t* broadphasepair = mjSTACKALLOC(d, nmaxpairs, uint32_t);
   int nbfpair = mj_broadphase(m, d, broadphasepair, nmaxpairs);
   unsigned int last_signature = -1;
   TM_END(mjTIMER_COL_BROAD);
@@ -634,11 +635,11 @@ void mj_collision(const mjModel* m, mjData* d) {
 
   for (int i=0; i < nbfpair; i++) {
     // reconstruct bodyflex pair ids
-    int bf1 = (broadphasepair[i]>>16) & 0xFFFF;
+    int bf1 = broadphasepair[i] >> 16;
     int bf2 = broadphasepair[i] & 0xFFFF;
 
     // compute signature for this bodyflex pair
-    unsigned int signature = (bf1<<16) + bf2;
+    unsigned int signature = ((uint32_t)bf1<<16) + bf2;
     // pairs come sorted by signature, but may not be unique
     // if signature is repeated, skip it
     if (signature == last_signature) {
@@ -1350,7 +1351,7 @@ static void makeAAMM(const mjModel* m, mjData* d,
 
 // add bodyflex pair in buffer; do not filter if m is NULL
 static void add_pair(const mjModel* m, int bf1, int bf2,
-                     int* npair, int* pair, int maxpair) {
+                     int* npair, uint32_t* pair, int maxpair) {
   // add pair if there is room in buffer
   if ((*npair) < maxpair) {
     // contact filtering if m is not NULL
@@ -1394,9 +1395,9 @@ static void add_pair(const mjModel* m, int bf1, int bf2,
 
     // add pair
     if (bf1 < bf2) {
-      pair[*npair] = (bf1<<16) + bf2;
+      pair[*npair] = ((uint32_t)bf1 << 16) | (uint32_t)bf2;
     } else {
-      pair[*npair] = (bf2<<16) + bf1;
+      pair[*npair] = ((uint32_t)bf2 << 16) | (uint32_t)bf1;
     }
     (*npair)++;
   } else {
@@ -1432,9 +1433,9 @@ mjSORT(SAPsort, mjtSAP, SAPcmp);
 
 
 // given list of axis-aligned bounding boxes in AAMM (min[3], max[3]) format,
-// return list of pairs (i, j) in format (i<<16 + j) that can collide,
+// return list of pairs (i, j) in format (i<<16 | j) that can collide,
 // using sweep-and-prune along specified x axis (0, 1 or 2).
-static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, int* pair, int maxpair) {
+static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, uint32_t* pair, int maxpair) {
   // check inputs
   if (n >= 0x10000 || axis_x < 0 || axis_x > 2 || maxpair < 1) {
     return -1;
@@ -1500,7 +1501,7 @@ static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, int* pair, i
         }
 
         // add pair, check buffer size
-        pair[npair++] = (id1<<16) + id2;
+        pair[npair++] = ((uint32_t)id1 << 16) | (uint32_t)id2;
         if (npair >= maxpair) {
           return maxpair;
         }
@@ -1552,8 +1553,8 @@ static void updateCov(mjtNum cov[9], const mjtNum vec[3], const mjtNum cen[3]) {
 
 
 // comparison function for unsigned ints
-static inline int uintcmp(int* i, int* j, void* context) {
-  if ((unsigned) *i < (unsigned) *j) {
+static inline int uintcmp(uint32_t* i, uint32_t* j, void* context) {
+  if (*i < *j) {
     return -1;
   } else if (*i == *j) {
     return 0;
@@ -1563,11 +1564,11 @@ static inline int uintcmp(int* i, int* j, void* context) {
 }
 
 // define bfsort function for sorting bodyflex pairs
-mjSORT(bfsort, int, uintcmp);
+mjSORT(bfsort, uint32_t, uintcmp);
 
 
 // broadphase collision detector
-int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
+int mj_broadphase(const mjModel* m, mjData* d, uint32_t* bfpair, int maxpair) {
   int npair = 0, nbody = m->nbody, ngeom = m->ngeom;
   int nvert = m->nflexvert, nflex = m->nflex, nbodyflex = m->nbody + m->nflex;
   int dsbl_filterparent = mjDISABLED(mjDSBL_FILTERPARENT);
@@ -1679,7 +1680,7 @@ int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
 
     // call SAP
     int maxsappair = ncollide*(ncollide-1)/2;
-    int* sappair = mjSTACKALLOC(d, maxsappair, int);
+    uint32_t* sappair = mjSTACKALLOC(d, maxsappair, uint32_t);
     int nsappair = mj_SAP(d, aamm, ncollide, 0, sappair, maxsappair);
     if (nsappair < 0) {
       mjERROR("SAP failed");
@@ -1723,7 +1724,7 @@ int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
 
   // sort bodyflex pairs by signature
   if (npair > 1) {
-    int* buf = mjSTACKALLOC(d, npair, int);
+    uint32_t* buf = mjSTACKALLOC(d, npair, uint32_t);
     bfsort(bfpair, buf, npair, NULL);
   }
 
@@ -2349,7 +2350,7 @@ void mj_collideFlexSAP(const mjModel* m, mjData* d, int f) {
 
   // call SAP; hard limit on number of pairs to avoid out-of-memory
   int maxsappair = mjMIN(nactive*(nactive-1)/2, 1000000);
-  int* sappair = mjSTACKALLOC(d, maxsappair, int);
+  uint32_t* sappair = mjSTACKALLOC(d, maxsappair, uint32_t);
   int nsappair = mj_SAP(d, aamm, nactive, axis, sappair, maxsappair);
   if (nsappair < 0) {
     mjERROR("SAP failed");

--- a/src/engine/engine_collision_driver.c
+++ b/src/engine/engine_collision_driver.c
@@ -618,7 +618,7 @@ void mj_collision(const mjModel* m, mjData* d) {
 
   // broadphase collision detector
   TM_START;
-  int nmaxpairs = (nbodyflex*(nbodyflex - 1))/2;
+  int nmaxpairs = (size_t)nbodyflex*(nbodyflex - 1)/2;
   uint32_t* broadphasepair = mjSTACKALLOC(d, nmaxpairs, uint32_t);
   int nbfpair = mj_broadphase(m, d, broadphasepair, nmaxpairs);
   unsigned int last_signature = -1;
@@ -1679,7 +1679,7 @@ int mj_broadphase(const mjModel* m, mjData* d, uint32_t* bfpair, int maxpair) {
     }
 
     // call SAP
-    int maxsappair = ncollide*(ncollide-1)/2;
+    int maxsappair = (size_t)ncollide*(ncollide-1)/2;
     uint32_t* sappair = mjSTACKALLOC(d, maxsappair, uint32_t);
     int nsappair = mj_SAP(d, aamm, ncollide, 0, sappair, maxsappair);
     if (nsappair < 0) {
@@ -2349,7 +2349,7 @@ void mj_collideFlexSAP(const mjModel* m, mjData* d, int f) {
   int axis = (bvh[3] > bvh[4] && bvh[3] > bvh[5]) ? 0 : (bvh[4] > bvh[5] ? 1 : 2);
 
   // call SAP; hard limit on number of pairs to avoid out-of-memory
-  int maxsappair = mjMIN(nactive*(nactive-1)/2, 1000000);
+  int maxsappair = mjMIN((size_t)nactive*(nactive-1)/2, 1000000);
   uint32_t* sappair = mjSTACKALLOC(d, maxsappair, uint32_t);
   int nsappair = mj_SAP(d, aamm, nactive, axis, sappair, maxsappair);
   if (nsappair < 0) {

--- a/src/engine/engine_collision_driver.h
+++ b/src/engine/engine_collision_driver.h
@@ -15,6 +15,8 @@
 #ifndef MUJOCO_SRC_ENGINE_ENGINE_COLLISION_DRIVER_H_
 #define MUJOCO_SRC_ENGINE_ENGINE_COLLISION_DRIVER_H_
 
+#include <stdint.h>
+
 #include <mujoco/mjdata.h>
 #include <mujoco/mjexport.h>
 #include <mujoco/mjmodel.h>
@@ -45,7 +47,7 @@ MJAPI int mj_collideOBB(const mjtNum aabb1[6], const mjtNum aabb2[6],
 MJAPI int mj_isElemActive(const mjModel* m, int f, int e);
 
 // broad phase collision detection; return list of bodyflex pairs
-int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair);
+int mj_broadphase(const mjModel* m, mjData* d, uint32_t* bfpair, int maxpair);
 
 // test active element self-collisions with SAP
 void mj_collideFlexSAP(const mjModel* m, mjData* d, int f);

--- a/test/engine/engine_collision_driver_test.cc
+++ b/test/engine/engine_collision_driver_test.cc
@@ -474,5 +474,61 @@ TEST_F(MjCollisionTest, MaxContact) {
   EXPECT_EQ(mj_maxContact(m.get(), cylinder, mesh, -1), 4);
 }
 
+TEST_F(MjCollisionTest, FlexSapElementIndexAboveSignBit) {
+  // Element indices above 0x7FFF used to sign-extend when the SAP broadphase
+  // decoded the high half of its packed (id1<<16)|id2 pair, indexing the
+  // element list out of bounds.
+  constexpr int kNumVert = 32769;
+  std::string body, vertex, element;
+  for (int i = 0; i < kNumVert; i++) {
+    body += "b0 ";
+    vertex += std::to_string(i) + " 0 0 ";
+    if (i) element += std::to_string(i - 1) + " " + std::to_string(i) + " ";
+  }
+
+  // The only colliding pair: two capsules of radius .2 overlapping by .1, on
+  // different bodies so they are not filtered out. They are last in the
+  // element list, putting their indices above the sign bit, and leftmost in
+  // space, so one of them lands in the high half of the packed pair.
+  body += "b0 b0 b1 b1 ";
+  vertex += "-100 0 0  -99 0 0  -100 .1 0  -99 .1 0 ";
+  for (int i = kNumVert; i < kNumVert + 4; i++) {
+    element += std::to_string(i) + " ";
+  }
+
+  std::string xml = R"(
+  <mujoco>
+    <worldbody>
+      <body name="b0"/>
+      <body name="b1"/>
+    </worldbody>
+    <deformable>
+      <flex name="chain" dim="1" radius=".2" body=")" + body +
+      R"(" vertex=")" + vertex + R"(" element=")" + element + R"(">
+        <contact selfcollide="sap" internal="false"/>
+      </flex>
+    </deformable>
+  </mujoco>
+  )";
+  char error[1024];
+  mock_warning_handler.ExpectWarnings("is not rigid");
+  MjModelPtr m = LoadModelFromString(xml, error, sizeof(error));
+  ASSERT_THAT(m.get(), NotNull()) << error;
+  ASSERT_EQ(m->flex_elemnum[0], kNumVert + 1);
+  ASSERT_EQ(m->flex_selfcollide[0], mjFLEXSELF_SAP);
+  MjDataPtr d = MakeData(m);
+  ASSERT_THAT(d, NotNull());
+
+  mj_forward(m.get(), d.get());
+
+  // A sign-extended index reads a different element, or segfaults.
+  ASSERT_EQ(d->ncon, 2);
+  for (int i = 0; i < d->ncon; i++) {
+    EXPECT_EQ(d->contact[i].elem[0], kNumVert - 1);
+    EXPECT_EQ(d->contact[i].elem[1], kNumVert);
+    EXPECT_NEAR(d->contact[i].dist, -.3, 1e-9);
+  }
+}
+
 }  // namespace
 }  // namespace mujoco

--- a/test/engine/engine_collision_driver_test.cc
+++ b/test/engine/engine_collision_driver_test.cc
@@ -477,8 +477,9 @@ TEST_F(MjCollisionTest, MaxContact) {
 TEST_F(MjCollisionTest, FlexSapElementIndexAboveSignBit) {
   // Element indices above 0x7FFF used to sign-extend when the SAP broadphase
   // decoded the high half of its packed (id1<<16)|id2 pair, indexing the
-  // element list out of bounds.
-  constexpr int kNumVert = 32769;
+  // element list out of bounds. With 46342 elements, n*(n-1)/2 also used to
+  // overflow int.
+  constexpr int kNumVert = 46341;
   std::string body, vertex, element;
   for (int i = 0; i < kNumVert; i++) {
     body += "b0 ";


### PR DESCRIPTION
Fixes #3535

`mj_SAP` and `add_pair` both pack a pair of item indices into a 32-bit word as `(id1<<16) | id2`, but the buffers holding those words were signed `int`. Once `id1 >= 32768` the shift moves a set bit into the sign position, which is undefined behavior, and the packed value comes back out negative. Two call sites decode the high half with a plain arithmetic shift, which then sign-extends instead of recovering the original index:

```c
int bf1 = bfid[sappair[i] >> 16];   // body broadphase
int e1  = elid[sappair[i] >> 16];   // flex self-collision
```

producing a negative array index and an out-of-bounds read that reliably segfaults once a model has more than 32768 mutually-collidable bodies, or a 2D/1D flex with more than 32768 elements and `selfcollide="auto"`.

Masking the decode would fix the read but leave the shift that creates the bad value undefined, so this makes the packed representation `uint32_t` end-to-end instead. `mj_SAP` already rejects `n >= 0x10000`, so seems like the packing is meant to carry a full 16 bits per id.
The decode sites above are correct now that the buffers are unsigned, so they need no mask, and `uintcmp` no longer has to cast its operands to compare them.

Review found a second overflow in the same path: `n*(n-1)/2` is computed in `int` at three sites and overflows from `n = 46342`, although the result fits for every `n` that `mj_SAP` accepts. At the flex site this kills any 1D/2D flex with 46342–65535 elements and `selfcollide=auto`. The product is now computed in size_t.

A regression test is included, covering the flex self-collision path: a 46342-element `dim="1"` flex whose only colliding pair is last in the element list and leftmost in space, so element 46340 is packed into the high half. This covers both the original overflow, and the second overflow from `n*(n-1)/2`. It asserts the decoded element ids and the contact distance exactly, so a sign-extended index fails the test even where the out-of-bounds read does not fault. It fails on the parent commit and adds 0.8 s to the suite. The body broadphase path packs through the same line in `mj_SAP`, but reaching index 32768 there needs a model with more than 32768 collidable bodies, which is too slow to compile in a test.

Verified with UBSan, which on the old code with a 32770 element flex reports `left shift of 32768 by 16 places cannot be represented in type 'int'` at the pack site, and a follow-on `signed integer overflow` where the sign-extended index is scaled into an element offset. With the 46342-element test model it instead reports `signed integer overflow: 46341 * 46342` at the pair-count multiply, before reaching the packing.
Clean after the changes. Behavior and performance are unchanged: pairs keep the same unsigned sort order, `qpos`/`qvel` and contact output are identical across tests, and `mjTIMER_COL_BROAD` is unchanged on 100 humanoids (median 512.9 us, 3% spread, both before and after, over interleaved A/B runs).
Full suite passes (2091/2091).