### PR TITLE
Mask the high half when decoding SAP pairs to avoid a negative index

### DIFF
--- a/src/engine/engine_collision_driver.c
+++ b/src/engine/engine_collision_driver.c
@@ -618,7 +618,7 @@ void mj_collision(const mjModel* m, mjData* d) {
   // broadphase collision detector
   TM_START;
   int nmaxpairs = (nbodyflex*(nbodyflex - 1))/2;
-  int* broadphasepair = mjSTACKALLOC(d, nmaxpairs, int);
+  unsigned* broadphasepair = mjSTACKALLOC(d, nmaxpairs, unsigned);
   int nbfpair = mj_broadphase(m, d, broadphasepair, nmaxpairs);
   unsigned int last_signature = -1;
   TM_END(mjTIMER_COL_BROAD);
@@ -633,12 +633,11 @@ void mj_collision(const mjModel* m, mjData* d) {
   size_t parena = alignArena(d, _Alignof(int));
 
   for (int i=0; i < nbfpair; i++) {
-    // reconstruct bodyflex pair ids
-    int bf1 = (broadphasepair[i]>>16) & 0xFFFF;
-    int bf2 = broadphasepair[i] & 0xFFFF;
+    // packed as (bf1 << 16) | bf2, bf1 < bf2
+    unsigned int signature = broadphasepair[i];
+    int bf1 = signature >> 16;
+    int bf2 = signature & 0xFFFF;
 
-    // compute signature for this bodyflex pair
-    unsigned int signature = (bf1<<16) + bf2;
     // pairs come sorted by signature, but may not be unique
     // if signature is repeated, skip it
     if (signature == last_signature) {
@@ -1350,7 +1349,7 @@ static void makeAAMM(const mjModel* m, mjData* d,
 
 // add bodyflex pair in buffer; do not filter if m is NULL
 static void add_pair(const mjModel* m, int bf1, int bf2,
-                     int* npair, int* pair, int maxpair) {
+                     int* npair, unsigned* pair, int maxpair) {
   // add pair if there is room in buffer
   if ((*npair) < maxpair) {
     // contact filtering if m is not NULL
@@ -1392,11 +1391,11 @@ static void add_pair(const mjModel* m, int bf1, int bf2,
       }
     }
 
-    // add pair
+    // add pair; pack as unsigned so the shift is defined for ids >= 0x8000
     if (bf1 < bf2) {
-      pair[*npair] = (bf1<<16) + bf2;
+      pair[*npair] = ((unsigned)bf1 << 16) | (unsigned)bf2;
     } else {
-      pair[*npair] = (bf2<<16) + bf1;
+      pair[*npair] = ((unsigned)bf2 << 16) | (unsigned)bf1;
     }
     (*npair)++;
   } else {
@@ -1434,7 +1433,7 @@ mjSORT(SAPsort, mjtSAP, SAPcmp);
 // given list of axis-aligned bounding boxes in AAMM (min[3], max[3]) format,
 // return list of pairs (i, j) in format (i<<16 + j) that can collide,
 // using sweep-and-prune along specified x axis (0, 1 or 2).
-static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, int* pair, int maxpair) {
+static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, unsigned* pair, int maxpair) {
   // check inputs
   if (n >= 0x10000 || axis_x < 0 || axis_x > 2 || maxpair < 1) {
     return -1;
@@ -1500,7 +1499,7 @@ static int mj_SAP(mjData* d, const mjtNum* aamm, int n, int axis_x, int* pair, i
         }
 
         // add pair, check buffer size
-        pair[npair++] = (id1<<16) + id2;
+        pair[npair++] = ((unsigned)id1 << 16) | (unsigned)id2;
         if (npair >= maxpair) {
           return maxpair;
         }
@@ -1552,8 +1551,8 @@ static void updateCov(mjtNum cov[9], const mjtNum vec[3], const mjtNum cen[3]) {
 
 
 // comparison function for unsigned ints
-static inline int uintcmp(int* i, int* j, void* context) {
-  if ((unsigned) *i < (unsigned) *j) {
+static inline int uintcmp(unsigned* i, unsigned* j, void* context) {
+  if (*i < *j) {
     return -1;
   } else if (*i == *j) {
     return 0;
@@ -1563,11 +1562,11 @@ static inline int uintcmp(int* i, int* j, void* context) {
 }
 
 // define bfsort function for sorting bodyflex pairs
-mjSORT(bfsort, int, uintcmp);
+mjSORT(bfsort, unsigned, uintcmp);
 
 
 // broadphase collision detector
-int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
+int mj_broadphase(const mjModel* m, mjData* d, unsigned* bfpair, int maxpair) {
   int npair = 0, nbody = m->nbody, ngeom = m->ngeom;
   int nvert = m->nflexvert, nflex = m->nflex, nbodyflex = m->nbody + m->nflex;
   int dsbl_filterparent = mjDISABLED(mjDSBL_FILTERPARENT);
@@ -1679,7 +1678,7 @@ int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
 
     // call SAP
     int maxsappair = ncollide*(ncollide-1)/2;
-    int* sappair = mjSTACKALLOC(d, maxsappair, int);
+    unsigned* sappair = mjSTACKALLOC(d, maxsappair, unsigned);
     int nsappair = mj_SAP(d, aamm, ncollide, 0, sappair, maxsappair);
     if (nsappair < 0) {
       mjERROR("SAP failed");
@@ -1723,7 +1722,7 @@ int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair) {
 
   // sort bodyflex pairs by signature
   if (npair > 1) {
-    int* buf = mjSTACKALLOC(d, npair, int);
+    unsigned* buf = mjSTACKALLOC(d, npair, unsigned);
     bfsort(bfpair, buf, npair, NULL);
   }
 
@@ -2349,7 +2348,7 @@ void mj_collideFlexSAP(const mjModel* m, mjData* d, int f) {
 
   // call SAP; hard limit on number of pairs to avoid out-of-memory
   int maxsappair = mjMIN(nactive*(nactive-1)/2, 1000000);
-  int* sappair = mjSTACKALLOC(d, maxsappair, int);
+  unsigned* sappair = mjSTACKALLOC(d, maxsappair, unsigned);
   int nsappair = mj_SAP(d, aamm, nactive, axis, sappair, maxsappair);
   if (nsappair < 0) {
     mjERROR("SAP failed");

--- a/src/engine/engine_collision_driver.h
+++ b/src/engine/engine_collision_driver.h
@@ -45,7 +45,7 @@ MJAPI int mj_collideOBB(const mjtNum aabb1[6], const mjtNum aabb2[6],
 MJAPI int mj_isElemActive(const mjModel* m, int f, int e);
 
 // broad phase collision detection; return list of bodyflex pairs
-int mj_broadphase(const mjModel* m, mjData* d, int* bfpair, int maxpair);
+int mj_broadphase(const mjModel* m, mjData* d, unsigned* bfpair, int maxpair);
 
 // test active element self-collisions with SAP
 void mj_collideFlexSAP(const mjModel* m, mjData* d, int f);


### PR DESCRIPTION
Fixes #3535.

`mj_SAP` packs a pair of item indices as `(id1<<16) + id2` into a signed `int`. Once `id1 >= 0x8000` that sets bit 31, so the packed value is negative. Two sites decode the high half with a bare arithmetic shift:

```c
int bf1 = bfid[sappair[i] >> 16];   // engine_collision_driver.c, body broadphase
int e1  = elid[sappair[i] >> 16];   // mj_collideFlexSAP
```

so the shift sign-extends and the array is indexed at a negative offset - an out-of-bounds read (SEGV in the flex path once the garbage id feeds unchecked pointer arithmetic). A third site decoding the same packing already masks it:

```c
int bf1 = (broadphasepair[i]>>16) & 0xFFFF;   // line ~639
```

This brings the other two in line with `& 0xFFFF`. Reachable with a 2D flex over ~33k elements and `selfcollide="auto"`, or a plain model with more than 32768 mutually-collidable bodies (`mj_SAP` only rejects `n >= 0x10000`).

No unit test: triggering it needs >32768 collidable bodies, and a model that size takes minutes to compile. The issue has a full AddressSanitizer trace of the pre-fix crash.
