### PR TITLE
Fix Studio crash when reloading models with active decorations

### DIFF
--- a/src/experimental/studio/hal/renderer_test.cc
+++ b/src/experimental/studio/hal/renderer_test.cc
@@ -68,6 +68,26 @@ TEST_F(RendererTest, OpengGlSoftware) {
   }
 }
 
+TEST_F(RendererTest, ReinitializeWithDecorations) {
+  FilamentRenderer renderer(nullptr, GraphicsMode::FilamentOpenGlSoftware);
+  renderer.Init(holder_->model());
+
+  mjvGeom decoration;
+  mjtNum size[3] = {0.1, 0.1, 0.1};
+  mjtNum pos[3] = {0.0, 0.0, 0.0};
+  mjtNum mat[9];
+  mju_eye(mat, 3);
+  float rgba[4] = {1.0, 0.0, 0.0, 1.0};
+  mjv_initGeom(&decoration, mjGEOM_SPHERE, size, pos, mat, rgba);
+
+  std::vector<std::byte> pixels(width_ * height_ * 3);
+  renderer.Render(holder_->model(), holder_->data(), nullptr, nullptr, nullptr,
+                  width_, height_, pixels, {&decoration, 1});
+  renderer.Init(holder_->model());
+  renderer.Render(holder_->model(), holder_->data(), nullptr, nullptr, nullptr,
+                  width_, height_, pixels);
+}
+
 TEST_F(RendererTest, OpengGlHeadless) {
   FilamentRenderer renderer(nullptr, GraphicsMode::FilamentOpenGlHeadless);
   renderer.Init(holder_->model());

--- a/src/render/filament/support/model_decorations.cc
+++ b/src/render/filament/support/model_decorations.cc
@@ -40,7 +40,10 @@ ModelDecorations::ModelDecorations(mjrfContext* ctx, mjrfScene* scene,
   mjv_makeScene(model_, &mjv_scene_, 2000);
 }
 
-ModelDecorations::~ModelDecorations() { mjv_freeScene(&mjv_scene_); }
+ModelDecorations::~ModelDecorations() {
+  Clear();
+  mjv_freeScene(&mjv_scene_);
+}
 
 void ModelDecorations::Clear() {
   for (auto& iter : decorations_) {


### PR DESCRIPTION
Hey!
I ran into a repeatable Studio crash when loading a new model after enabling visualization options that add decorations:

```text
ERROR: Attempting to remove renderable from wrong scene.
```

The decoration renderables were destroyed without first being unregistered from their `SceneView`. That left registrations behind, so the later scene teardown tried to remove renderables that no longer belonged to it.

I simply added a call of `ModelDecorations::Clear()` in the destructor before freeing the scene. I also added a test that renders a decoration, reinitializes the renderer, and renders again.