### PR TITLE
Fix Filament crash when hiding geom groups

### DIFF
--- a/src/experimental/studio/hal/renderer_test.cc
+++ b/src/experimental/studio/hal/renderer_test.cc
@@ -68,6 +68,34 @@ TEST_F(RendererTest, OpengGlSoftware) {
   }
 }
 
+TEST_F(RendererTest, ToggleGeomGroupVisibility) {
+  mjSpec* spec = mj_makeSpec();
+  mjsGeom* geom = mjs_addGeom(mjs_findBody(spec, "world"), nullptr);
+  geom->type = mjGEOM_BOX;
+  geom->size[0] = 0.1;
+  geom->size[1] = 0.1;
+  geom->size[2] = 0.1;
+  geom->group = 2;
+  holder_ = ModelHolder::FromSpec(spec);
+  holder_->model()->vis.global.offwidth = width_;
+  holder_->model()->vis.global.offheight = height_;
+
+  FilamentRenderer renderer(nullptr, GraphicsMode::FilamentOpenGlSoftware);
+  renderer.Init(holder_->model());
+
+  mjvOption options;
+  mjv_defaultOption(&options);
+  std::vector<std::byte> pixels(width_ * height_ * 3);
+  renderer.Render(holder_->model(), holder_->data(), nullptr, nullptr, &options,
+                  width_, height_, pixels);
+  options.geomgroup[2] = 0;
+  renderer.Render(holder_->model(), holder_->data(), nullptr, nullptr, &options,
+                  width_, height_, pixels);
+  options.geomgroup[2] = 1;
+  renderer.Render(holder_->model(), holder_->data(), nullptr, nullptr, &options,
+                  width_, height_, pixels);
+}
+
 TEST_F(RendererTest, OpengGlHeadless) {
   FilamentRenderer renderer(nullptr, GraphicsMode::FilamentOpenGlHeadless);
   renderer.Init(holder_->model());

--- a/src/render/filament/core/renderable.cc
+++ b/src/render/filament/core/renderable.cc
@@ -220,6 +220,7 @@ void Renderable::RemoveFromScene(filament::Scene* scene) {
   if (assigned_scene_ != scene) {
     mju_error("Attempting to remove renderable from wrong scene.");
   }
+  SetMaterialInstance(0);
   for (Part& part : parts_) {
     scene->remove(part.entity);
   }

--- a/src/render/filament/core/renderable.h
+++ b/src/render/filament/core/renderable.h
@@ -135,7 +135,7 @@ class Renderable : public mjrfRenderable {
   // of which instance, as well as other render state, to use with each render
   // request.
   struct DrawState {
-    MaterialManager::MaterialKey material_key;
+    MaterialManager::MaterialKey material_key = 0;
     bool cast_shadows = true;
     bool receive_shadows = true;
     bool wireframe = false;


### PR DESCRIPTION
Hey!

I ran into a repeatable Studio crash with the Filament renderer when toggling a geom group visibility. The program terminated with an uncaught `utils::PreconditionPanic`.

When a geom group was hidden, its renderables were removed from the scene and no longer prepared for the next frame. Their material instances therefore appeared unused and were destroyed, even though the hidden entities still referenced them. Filament rejected that destruction and aborted.

I simply reset the renderable to Filament's default material before removing it from the scene. I also initialized the cached material key and added a test that renders a geom, hides its group, renders again, and then shows it again.