### PR TITLE
enable multiccd by default in Unity

### DIFF
--- a/unity/Runtime/Components/MjGlobalSettings.cs
+++ b/unity/Runtime/Components/MjGlobalSettings.cs
@@ -92,7 +92,7 @@ public struct MjcfOptionFlag {
     Override = EnableDisableFlag.disable,
     Energy = EnableDisableFlag.disable,
     FwdInv = EnableDisableFlag.disable,
-    MultiCCD = EnableDisableFlag.disable
+    MultiCCD = EnableDisableFlag.enable
   };
 
   public void FromMjcf(XmlElement mjcf) {
@@ -135,7 +135,11 @@ public struct MjcfOptionFlag {
     mjcf.SetAttribute("override", Override.ToString());
     mjcf.SetAttribute("energy", Energy.ToString());
     mjcf.SetAttribute("fwdinv", FwdInv.ToString());
-    mjcf.SetAttribute("multiccd", MultiCCD.ToString());
+    // MultiCCD is enabled by default, so the flag is only written when it deviates from the
+    // default, i.e. when it's disabled.
+    if (MultiCCD != MjcfOptionFlag.Default.MultiCCD) {
+      mjcf.SetAttribute("multiccd", MultiCCD.ToString());
+    }
   }
 }
 

--- a/unity/Tests/Editor/Importer/MjcfImporterTests.cs
+++ b/unity/Tests/Editor/Importer/MjcfImporterTests.cs
@@ -286,6 +286,58 @@ public class MjcfImporterTests {
   }
 
   [Test]
+  public void MultiCcdEnabledFlagIsOmittedFromCompiledXml() {
+    var mjcfString = @"<mujoco>
+      <option>
+        <flag multiccd='enable'/>
+      </option>
+      <worldbody/>
+    </mujoco>";
+    _sceneRoot = _importer.ImportString(
+        name: string.Empty, mjcfString: mjcfString);
+    var settings = _sceneRoot.GetComponentInChildren<MjGlobalSettings>();
+    Assert.That(settings.GlobalOptions.Flag.MultiCCD, Is.EqualTo(EnableDisableFlag.enable));
+
+    var doc = new XmlDocument();
+    var mujocoRoot = (XmlElement)doc.AppendChild(doc.CreateElement("mujoco"));
+    settings.GlobalsToMjcf(mujocoRoot);
+    // MultiCCD is enabled by default, so the compiled XML contains no multiccd flag.
+    Assert.That(doc.OuterXml, Does.Not.Contain("multiccd"));
+  }
+
+  [Test]
+  public void MultiCcdDisabledFlagIsPreservedInCompiledXml() {
+    var mjcfString = @"<mujoco>
+      <option>
+        <flag multiccd='disable'/>
+      </option>
+      <worldbody/>
+    </mujoco>";
+    _sceneRoot = _importer.ImportString(
+        name: string.Empty, mjcfString: mjcfString);
+    var settings = _sceneRoot.GetComponentInChildren<MjGlobalSettings>();
+    Assert.That(settings.GlobalOptions.Flag.MultiCCD, Is.EqualTo(EnableDisableFlag.disable));
+
+    var doc = new XmlDocument();
+    var mujocoRoot = (XmlElement)doc.AppendChild(doc.CreateElement("mujoco"));
+    settings.GlobalsToMjcf(mujocoRoot);
+    Assert.That(doc.OuterXml, Does.Contain(@"multiccd=""disable"""));
+  }
+
+  [Test]
+  public void MultiCcdDefaultsToEnabledWhenFlagAbsent() {
+    var mjcfString = @"<mujoco>
+      <option/>
+      <worldbody/>
+    </mujoco>";
+    _sceneRoot = _importer.ImportString(
+        name: string.Empty, mjcfString: mjcfString);
+    var settings = _sceneRoot.GetComponentInChildren<MjGlobalSettings>();
+    Assert.That(settings, Is.Not.Null);
+    Assert.That(settings.GlobalOptions.Flag.MultiCCD, Is.EqualTo(EnableDisableFlag.enable));
+  }
+
+  [Test]
   public void ParsedActuatorsAddedToDedicatedGameObjectAggregate() {
     var mjcfString = @"<mujoco>
       <worldbody>


### PR DESCRIPTION
Hi,

I am trying to use mujoco in Unity but found an issue about multiccd flag.

Set multiccd flag enable by default in Unity.

In my case, the multiccd flag was disable in GlobalSettings  when '<option> <flag multiccd="enable" /> </option>'  describe in xml. Because multiccd is enable by default, so after compiled, this flag will dismiss. but the default value in Unity still keep disable that cause problem.