### PR TITLE
fix joint axis default value to (0, 0, 1) in Unity

### DIFF
--- a/unity/Runtime/Components/Joints/MjHingeJoint.cs
+++ b/unity/Runtime/Components/Joints/MjHingeJoint.cs
@@ -63,7 +63,7 @@ namespace Mujoco {
           MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("pos", defaultValue: Vector3.zero));
 
       var rotationAxis =
-          MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("axis", defaultValue: Vector3.right));
+          MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("axis", defaultValue: MjEngineTool.MjVector3Up));
       transform.localRotation = Quaternion.FromToRotation(Vector3.right, rotationAxis);
 
       var rangeValues = mjcf.GetFloatArrayAttribute("range", defaultValue: new float[] { 0, 0 });

--- a/unity/Runtime/Components/Joints/MjSlideJoint.cs
+++ b/unity/Runtime/Components/Joints/MjSlideJoint.cs
@@ -60,7 +60,7 @@ namespace Mujoco {
           MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("pos", defaultValue: Vector3.zero));
 
       var rotationAxis =
-          MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("axis", defaultValue: Vector3.right));
+          MjEngineTool.UnityVector3(mjcf.GetVector3Attribute("axis", defaultValue: MjEngineTool.MjVector3Up));
       transform.localRotation = Quaternion.FromToRotation(Vector3.right, rotationAxis);
 
       var rangeValues = mjcf.GetFloatArrayAttribute("range", defaultValue: new float[] { 0, 0 });

--- a/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
+++ b/unity/Tests/Editor/Components/Joints/MjHingeJointTests.cs
@@ -98,5 +98,14 @@ public class MjHingeJointTests {
     Assert.That(_joint.RangeLower, Is.EqualTo(expectedLow));
     Assert.That(_joint.RangeUpper, Is.EqualTo(expectedHigh));
   }
+
+  [Test]
+  public void ParseMissingAxisUsesMuJoCoDefaultZ() {
+    var jointElement = (XmlElement)_doc.AppendChild(_doc.CreateElement("joint"));
+    _joint.ParseMjcf(jointElement);
+    var element = _joint.GenerateMjcf("name", _doc);
+    Assert.That(element.GetVector3Attribute("axis", Vector3.zero),
+                Is.EqualTo(MjEngineTool.MjVector3Up).Using(_comparer));
+  }
 }
 }

--- a/unity/Tests/Editor/Components/Joints/MjSlideJointTests.cs
+++ b/unity/Tests/Editor/Components/Joints/MjSlideJointTests.cs
@@ -98,5 +98,14 @@ public class MjSlideJointTests {
     Assert.That(_joint.RangeLower, Is.EqualTo(expectedLow));
     Assert.That(_joint.RangeUpper, Is.EqualTo(expectedHigh));
   }
+
+  [Test]
+  public void ParseMissingAxisUsesMuJoCoDefaultZ() {
+    var jointElement = (XmlElement)_doc.AppendChild(_doc.CreateElement("joint"));
+    _joint.ParseMjcf(jointElement);
+    var element = _joint.GenerateMjcf("name", _doc);
+    Assert.That(element.GetVector3Attribute("axis", Vector3.zero),
+                Is.EqualTo(MjEngineTool.MjVector3Up).Using(_comparer));
+  }
 }
 }


### PR DESCRIPTION
## Summary

When MJCF omits `joint axis`, Play Mode compiles the wrong hinge/slide direction. `qpos` can still match; forward kinematics does not.

## Cause

`mj_saveLastXML` drops attributes equal to the engine default. For MuJoCo, omitted `axis` means `0 0 1`. The axis is still in `mjModel` after compile; it is stripped when writing XML.

The Unity plugin treats a missing `axis` as `1 0 0` (joint GameObject +X). Identity Transform therefore regenerates `axis="1 0 0"` at Play. MuJoCo would have restored Z.

This is the same pattern as other omitted-default import bugs: decompile drops the default, the importer fills in a different one.

## Fix

Parse missing `axis` as MuJoCo `(0, 0, 1)`. Generate still comes from the Transform only.

