### PR TITLE
Fix MJX jac_dot for free-joint translational dofs

### DIFF
--- a/mjx/mujoco/mjx/_src/support.py
+++ b/mjx/mujoco/mjx/_src/support.py
@@ -176,7 +176,7 @@ def jac_dot(
   jnt_type = m.jnt_type[m.dof_jntid]
   dof_adr = m.jnt_dofadr[m.dof_jntid]
   is_quat = (jnt_type == JointType.BALL) | (
-      jnt_type == JointType.FREE & (np.arange(m.nv) >= dof_adr + 3)
+      (jnt_type == JointType.FREE) & (np.arange(m.nv) >= dof_adr + 3)
   )
 
   # compute cdof_dot for quaternion (use current body cvel)

--- a/mjx/mujoco/mjx/_src/support_test.py
+++ b/mjx/mujoco/mjx/_src/support_test.py
@@ -85,6 +85,29 @@ class SupportTest(parameterized.TestCase):
     np.testing.assert_almost_equal(jacp, jacp_expected.T, 6)
     np.testing.assert_almost_equal(jacr, jacr_expected.T, 6)
 
+  @parameterized.parameters('constraints.xml', 'pendula.xml')
+  def test_jac_dot(self, fname):
+    np.random.seed(0)
+
+    m = test_util.load_test_file(fname)
+    d = mujoco.MjData(m)
+    # give the system a little kick to ensure we have non-zero velocities
+    d.qvel = np.random.random(m.nv)
+    mujoco.mj_step(m, d, 10)  # let dynamics get state significantly non-zero
+    mujoco.mj_forward(m, d)
+    mx = mjx.put_model(m)
+    dx = mjx.put_data(m, d)
+    point = np.random.randn(3)
+    jac_dot = jax.jit(support.jac_dot)
+
+    for body in range(m.nbody):
+      jacp, jacr = jac_dot(mx, dx, point, body)
+
+      jacp_expected, jacr_expected = np.zeros((3, m.nv)), np.zeros((3, m.nv))
+      mujoco.mj_jacDot(m, d, jacp_expected, jacr_expected, point, body)
+      np.testing.assert_allclose(jacp, jacp_expected.T, atol=5e-5, rtol=5e-5)
+      np.testing.assert_allclose(jacr, jacr_expected.T, atol=5e-5, rtol=5e-5)
+
   def test_xfrc_accumulate(self):
     """Tests that xfrc_accumulate ouput matches mj_xfrcAccumulate."""
     np.random.seed(0)


### PR DESCRIPTION
## Summary

- Parenthesize the `jnt_type == JointType.FREE` comparison in `support.jac_dot` so that only the rotational dofs of a free joint get the quaternion `cdof_dot`, matching `mj_jacDot`.
- Add `test_jac_dot`, comparing `jac_dot` against `mujoco.mj_jacDot` for every body of `constraints.xml` and `pendula.xml`.

## Problem

`jac_dot` builds its quaternion-dof mask with `jnt_type == JointType.FREE & (np.arange(m.nv) >= dof_adr + 3)`. Since `&` binds tighter than `==` and `JointType.FREE == 0`, this evaluates to `jnt_type == 0`, selecting all six dofs of every free joint. The three translational dofs then replace their true `cdof_dot` (zero, as `com_vel` stores it) with `motion_cross(cvel, cdof) = [0, w x e_i]`, whereas `mj_jacDot` only recomputes `cdof_dot` for `i >= dofadr + 3`.

`jac_dot` feeds `tendon_dot` and `tendon_bias`, so for a spatial tendon with armature attached to a free-floating body with angular velocity, `qfrc_bias` (and hence `qacc` and `mjx.step`) diverge from MuJoCo. On a one-body example with `armature="123"` and `qvel = [0.1, -0.2, 0.3, 1.0, 2.0, -0.5]`, `qfrc_bias` differed from `mj_forward` by 14.08; after the change the difference is 7e-15.

## Testing

- `python -m mujoco.mjx._src.support_test -- -k test_jac_dot`: fails on main (`Max absolute difference 1.122` / `0.669`, the 3x3 translational block of the first free joint), passes with the fix.
- Full `support_test` passes with the change.
- Verified against the compiled `mujoco 3.12.0` / `mujoco-mjx 3.12.0` wheels with the repo's `mjx/mujoco/mjx` source linked into site-packages (CPU only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
