### PR TITLE
Fix mjSpec signature ignoring the first equality constraint

### DIFF
--- a/python/mujoco/specs_test.py
+++ b/python/mujoco/specs_test.py
@@ -2360,5 +2360,26 @@ class SpecsTest(absltest.TestCase):
       )
 
 
+  def test_bind_rejects_stale_model_after_first_equality(self):
+    spec = mujoco.MjSpec()
+    for name in ('a', 'b'):
+      body = spec.worldbody.add_body(name=name)
+      body.add_geom(size=[1, 0, 0])
+      body.add_freejoint()
+    model = spec.compile()
+
+    # the first equality must invalidate the compiled model for bind
+    equality = spec.add_equality(
+        type=mujoco.mjtEq.mjEQ_WELD,
+        objtype=mujoco.mjtObj.mjOBJ_BODY,
+        name1='a',
+        name2='b',
+    )
+    with self.assertRaisesRegex(ValueError, 'does not match'):
+      model.bind(equality)
+
+    model = spec.compile()
+    self.assertEqual(model.bind(equality).id, 0)
+
 if __name__ == '__main__':
   absltest.main()

--- a/src/user/user_model.cc
+++ b/src/user/user_model.cc
@@ -5520,7 +5520,7 @@ uint64_t mjCModel::Signature() {
   for (unsigned int i = 0; i < materials_.size(); ++i) { tree << "<material/>\n"; }
   for (unsigned int i = 0; i < pairs_.size(); ++i) { tree << "<pair/>\n"; }
   for (unsigned int i = 0; i < excludes_.size(); ++i) { tree << "<exclude/>\n"; }
-  for (unsigned int i = 1; i < equalities_.size(); ++i) { tree << "<equality/>\n"; }
+  for (unsigned int i = 0; i < equalities_.size(); ++i) { tree << "<equality/>\n"; }
   for (unsigned int i = 0; i < tendons_.size(); ++i) { tree << "<tendon/>\n"; }
   for (unsigned int i = 0; i < actuators_.size(); ++i) { tree << "<actuator/>\n"; }
   for (unsigned int i = 0; i < sensors_.size(); ++i) {

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -774,6 +774,70 @@ TEST_F(MujocoTest, ReplicateExplicitPlugin) {
   mj_deleteModel(model);
 }
 
+TEST_F(MujocoTest, SignatureChangesWhenAddingElements) {
+  mjSpec* spec = mj_makeSpec();
+  mjsBody* body = mjs_addBody(mjs_findBody(spec, "world"), 0);
+  mjsGeom* geom = mjs_addGeom(body, 0);
+  geom->size[0] = 1;
+
+  mjModel* model = mj_compile(spec, 0);
+  ASSERT_THAT(model, NotNull()) << mjs_getError(spec);
+  EXPECT_EQ(spec->element->signature, model->signature);
+
+  // every add must change the signature, including the first element of a
+  // type, otherwise bind would accept a spec that no longer matches the model
+  uint64_t previous = spec->element->signature;
+  auto expect_changed = [&](const char* what) {
+    EXPECT_NE(spec->element->signature, previous) << what;
+    EXPECT_NE(spec->element->signature, model->signature) << what;
+    previous = spec->element->signature;
+  };
+
+  mjs_addEquality(spec, 0);
+  expect_changed("first equality");
+  mjs_addEquality(spec, 0);
+  expect_changed("second equality");
+  mjs_addTendon(spec, 0);
+  expect_changed("tendon");
+  mjs_addActuator(spec, 0);
+  expect_changed("actuator");
+  mjs_addSensor(spec);
+  expect_changed("sensor");
+  mjs_addPair(spec, 0);
+  expect_changed("pair");
+  mjs_addExclude(spec);
+  expect_changed("exclude");
+  mjs_addFlex(spec);
+  expect_changed("flex");
+  mjs_addMesh(spec, 0);
+  expect_changed("mesh");
+  mjs_addHField(spec);
+  expect_changed("hfield");
+  mjs_addSkin(spec);
+  expect_changed("skin");
+  mjs_addTexture(spec);
+  expect_changed("texture");
+  mjs_addMaterial(spec, 0);
+  expect_changed("material");
+  mjs_addKey(spec);
+  expect_changed("key");
+  mjs_addBody(body, 0);
+  expect_changed("body");
+  mjs_addGeom(body, 0);
+  expect_changed("geom");
+  mjs_addJoint(body, 0);
+  expect_changed("joint");
+  mjs_addSite(body, 0);
+  expect_changed("site");
+  mjs_addCamera(body, 0);
+  expect_changed("camera");
+  mjs_addLight(body, 0);
+  expect_changed("light");
+
+  mj_deleteModel(model);
+  mj_deleteSpec(spec);
+}
+
 TEST_F(MujocoTest, RecompileFails) {
   mjSpec* spec = mj_makeSpec();
   mjsBody* body = mjs_addBody(mjs_findBody(spec, "world"), 0);

--- a/test/user/user_api_test.cc
+++ b/test/user/user_api_test.cc
@@ -3791,19 +3791,18 @@ TEST_F(MujocoTest, AttachPreservesJointOrder) {
   // Export and re-import to test round-trip preservation
   std::string exported_xml = SaveAndReadXml(parent);
 
-  mjSpec* reimported =
-      mj_parseXMLString(exported_xml.c_str(), nullptr, error.data(),
-                        error.size());
+  mjSpec* reimported = mj_parseXMLString(exported_xml.c_str(), nullptr,
+                                         error.data(), error.size());
   ASSERT_THAT(reimported, NotNull()) << error.data();
 
   mjModel* reimported_model = mj_compile(reimported, nullptr);
   ASSERT_THAT(reimported_model, NotNull());
 
   // Verify joint order is preserved after round-trip
-  int reimported_slide_id = mj_name2id(reimported_model, mjOBJ_JOINT,
-                                       "child_slide_joint");
-  int reimported_free_id = mj_name2id(reimported_model, mjOBJ_JOINT,
-                                      "child_free_joint");
+  int reimported_slide_id =
+      mj_name2id(reimported_model, mjOBJ_JOINT, "child_slide_joint");
+  int reimported_free_id =
+      mj_name2id(reimported_model, mjOBJ_JOINT, "child_free_joint");
   ASSERT_GE(reimported_slide_id, 0);
   ASSERT_GE(reimported_free_id, 0);
   EXPECT_EQ(reimported_slide_id, slide_id)


### PR DESCRIPTION
The equality loop in mjCModel::Signature() starts at i=1, so a spec with one equality hashes the same as a spec with none. Adding the first equality to an already compiled spec leaves spec and model signatures equal, and bind passes its check instead of asking for a recompile:

    spec = mujoco.MjSpec(); ... ; model = spec.compile()
    weld = spec.add_equality(...)
    model.bind(weld)   # IndexError: Invalid index 0. Valid indices from 0 to -1
                       # expected: ValueError: The mjSpec does not match mjModel...

Every other list in Signature() starts at 0 and nothing pushes a placeholder into equalities_, so this looks like a copy-paste slip from cc2f57d8. Fix is the loop bound; the new test compiles a spec and then adds one of each element type, asserting the signature changes every time. It fails on "first equality" without the fix.

Second commit is clang-format on a few pre-existing lines in the same file, otherwise the lint hook fails on any PR touching it.

Found while reading Signature() for #3397. I don't need git attribution if importing directly is easier.
