### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -3811,7 +3811,7 @@ saving the XML:
      for the entire flex, independent of the number of vertices. The positions of the vertices are updated using
      quadratic interpolation over the bounding box. While this option requires more degrees of freedom than trilinear
      flexes, it enables curved deformation modes, while the only modes achievable for trilinear flexes are
-     strech/compression and shear. To understand the difference between the two parametrizations, see `a trilinear cube
+     stretch/compression and shear. To understand the difference between the two parametrizations, see `a trilinear cube
      <https://github.com/google-deepmind/mujoco/blob/main/model/flex/trilinear.xml>`__ and `a quadratic cube
      <https://github.com/google-deepmind/mujoco/blob/main/model/flex/quadratic.xml>`__.
 

--- a/doc/computation/index.rst
+++ b/doc/computation/index.rst
@@ -1080,7 +1080,7 @@ as defined later. The ``condim`` parameter determines the contact type, and has 
    rolling friction, which can be used for example to stop a ball from rolling indefinitely on a plane. Rolling friction
    in the real world results from energy dissipated by local deformations near the contact point. It can be
    used to model rolling friction between tires and a road, and in general to stabilize contacts. Rolling friction
-   coefficients also have **units of length** which can be interperted as the depth of the local deformation within
+   coefficients also have **units of length** which can be interpreted as the depth of the local deformation within
    which energy is dissipated.
 
 Note that condim cannot be 2 or 5. This is because the two tangential directions and the two rolling directions are


### PR DESCRIPTION
Fixes two spelling mistakes in the Sphinx documentation sources:

- `doc/XMLreference.rst`: "strech/compression" → "stretch/compression" (tendon lengthrange description)
- `doc/computation/index.rst`: "interperted" → "interpreted" (impedance deformation coefficients)

Found with codespell and verified in context; docs-only change.