### PR TITLE
Avoid cancellation in overdamped spring-damper roots

### DIFF
--- a/src/engine/engine_util_misc.c
+++ b/src/engine/engine_util_misc.c
@@ -1617,9 +1617,14 @@ mjtNum mju_springDamper(mjtNum pos0, mjtNum vel0, mjtNum k, mjtNum b, mjtNum t) 
     // compute w = sqrt(det)/2
     w = mju_sqrt(det)/2;
 
-    // compute r1,r2
-    r1 = -b/2 + w;
-    r2 = -b/2 - w;
+    // avoid cancellation: compute the root of larger magnitude, then use r1*r2 = k
+    if (b >= 0) {
+      r2 = -b/2 - w;
+      r1 = k/r2;
+    } else {
+      r1 = -b/2 + w;
+      r2 = k/r1;
+    }
 
     // compute coefficients
     c1 = (pos0*r2-vel0) / (r2-r1);

--- a/test/engine/engine_util_misc_test.cc
+++ b/test/engine/engine_util_misc_test.cc
@@ -118,6 +118,37 @@ TEST_F(UtilMiscTest, SpringDamperInvariantToTimeUnits) {
   }
 }
 
+TEST_F(UtilMiscTest, SpringDamperStrongOverdamping) {
+  constexpr mjtNum damping = 1e9;
+  const mjtNum tol = MjTol(1e-14, 1e-6);
+
+  // At t = damping with k = 1, the fast mode has decayed and the slow mode
+  // contributes exp(-1) to within O(1/damping^2) for either initial condition.
+  EXPECT_NEAR(mju_springDamper(1, 0, 1, damping, damping), mju_exp(-1), tol);
+  EXPECT_NEAR(mju_springDamper(0, damping, 1, damping, damping), mju_exp(-1),
+              tol);
+}
+
+TEST_F(UtilMiscTest, SpringDamperZeroStiffness) {
+  constexpr mjtNum pos0 = 1;
+  constexpr mjtNum vel0 = 0.5;
+  constexpr mjtNum dt = 0.5;
+
+  for (mjtNum damping : {-3, 3}) {
+    mjtNum expected = pos0 + vel0 * (1 - mju_exp(-damping * dt)) / damping;
+    EXPECT_NEAR(mju_springDamper(pos0, vel0, 0, damping, dt), expected,
+                MjTol(1e-14, 1e-6));
+  }
+}
+
+TEST_F(UtilMiscTest, SpringDamperNonpositiveDamping) {
+  // Roots 1 and 2: x(0) = x'(0) = 1 selects exp(t).
+  EXPECT_NEAR(mju_springDamper(1, 1, 2, -3, 1), mju_exp(1), MjTol(1e-14, 1e-6));
+
+  // Roots -1 and 1: the same initial conditions select exp(t).
+  EXPECT_NEAR(mju_springDamper(1, 1, -1, 0, 1), mju_exp(1), MjTol(1e-14, 1e-6));
+}
+
 TEST_F(UtilMiscTest, SphereWrap) {
   static constexpr char xml[] = R"(
   <mujoco>


### PR DESCRIPTION
Fixes #3551.

`mju_springDamper(1, 0, 1, 1e9, 1e9)` returns `1.0` instead of approximately `0.3678794411714423`: subtracting nearly equal terms rounds the slow characteristic root to zero. Compute the root with larger magnitude first, choosing the expression by the sign of damping, and recover the other from `r1*r2 = k`.

Adds regression coverage for strong overdamping with position- and velocity-driven initial conditions, zero stiffness, and nonpositive damping. The existing regime-selection tolerance and critical/underdamped formulas are unchanged.

### Validation

- The new strong-overdamping test fails before the fix in both double and single precision.
- `engine_util_misc_test`: 69/69 passed in each precision mode.
- Full double-precision CTest run: 1,449 registered entries, zero failures. Two parameterized entries are reported as skipped because the existing `gripper_trilinear.xml` and `strain.xml` models hit unsupported flex/integrator combinations; their other cases pass.
- Repository pre-commit hooks passed on both changed files.

Local environment: macOS arm64, AppleClang 21, CMake 4.4.2, Release with `MUJOCO_HARDEN=ON`; single precision uses `-DmjUSESINGLE` for C and C++. The builds emit existing macOS linker/deployment-target warnings.
