### PR TITLE
Avoid catastrophic cancellation in mju_springDamper's overdamped roots

### DIFF
--- a/src/engine/engine_util_misc.c
+++ b/src/engine/engine_util_misc.c
@@ -1617,9 +1617,14 @@ mjtNum mju_springDamper(mjtNum pos0, mjtNum vel0, mjtNum k, mjtNum b, mjtNum t) 
     // compute w = sqrt(det)/2
     w = mju_sqrt(det)/2;
 
-    // compute r1,r2
-    r1 = -b/2 + w;
-    r2 = -b/2 - w;
+    // take the root without subtractive cancellation, recover the other from r1*r2 = k
+    if (b >= 0) {
+      r2 = -b/2 - w;
+      r1 = k/r2;
+    } else {
+      r1 = -b/2 + w;
+      r2 = k/r1;
+    }
 
     // compute coefficients
     c1 = (pos0*r2-vel0) / (r2-r1);

--- a/test/engine/engine_util_misc_test.cc
+++ b/test/engine/engine_util_misc_test.cc
@@ -118,6 +118,16 @@ TEST_F(UtilMiscTest, SpringDamperInvariantToTimeUnits) {
   }
 }
 
+TEST_F(UtilMiscTest, SpringDamperStronglyOverdamped) {
+  // b*b >> 4*k: the slow root ~ -k/b must not be lost to cancellation in
+  // -b/2 + sqrt(b*b - 4*k)/2. evaluated at t = b/k, one slow-mode time
+  // constant, so the answer is 1/e.
+  constexpr mjtNum inv_e = 0.36787944117144233;
+  EXPECT_NEAR(mju_springDamper(1, 0, 1, 1e9, 1e9), inv_e, MjTol(1e-10, 1e-4));
+  // the same physical system with time rescaled by 1e9
+  EXPECT_NEAR(mju_springDamper(1, 0, 1e18, 1e18, 1), inv_e, MjTol(1e-10, 1e-4));
+}
+
 TEST_F(UtilMiscTest, SphereWrap) {
   static constexpr char xml[] = R"(
   <mujoco>


### PR DESCRIPTION
Fixes #3551.

The overdamped branch of `mju_springDamper` computes the two roots as

```c
r1 = -b/2 + sqrt(b*b - 4*k)/2;
r2 = -b/2 - sqrt(b*b - 4*k)/2;
```

When `b*b` is much larger than `4*k`, `sqrt(b*b - 4*k)/2` is very close to `b/2`, so `r1` is the difference of two nearly-equal numbers and the slow root (`~ -k/b`) is lost - it can round to exactly zero, and then that decay mode disappears from the result.

`mju_springDamper(1, 0, 1, 1e9, 1e9)` returns `1.0`; the analytical answer is `1/e = 0.36787944117144233` (the reporter checked it with 90-digit arithmetic). In single precision it already breaks at `b = 1e4`.

Fix: compute whichever root does not involve a subtraction of near-equal terms (depends on the sign of `b`), then get the other from `r1*r2 = k`. This is the standard stable form for a quadratic. The regime selection from #3522 is untouched - this is only the root evaluation inside the overdamped branch.

Verified against the installed lib:

```
$ mju_springDamper(1, 0, 1,    1e9, 1e9)  ->  0.36787944117144233   (was 1.0)
$ mju_springDamper(1, 0, 1e18, 1e18, 1)   ->  0.36787944117144233   (same system, rescaled time)
$ mju_springDamper(1, 0, 1,    3,   1)    ->  0.78664559930336819   (unchanged)
```

`engine_util_misc_test` passes, including a new `SpringDamperStronglyOverdamped` case.
