### PR TITLE
Fix lost URDF inertial origin rotation during compilation

### DIFF
--- a/src/user/user_objects.cc
+++ b/src/user/user_objects.cc
@@ -2577,7 +2577,25 @@ void mjCBody::Compile(void) {
 
   // process orientation alternatives for inertia
   if (mjuu_defined(fullinertia[0])) {
-    const char* err = mjuu_fullInertia(iquat, inertia, this->fullinertia);
+    // rotate tensor from inertial frame to body frame
+    double mat[9], full[9], full_body[9], fullinertia_body[6];
+    mjuu_quat2mat(mat, iquat);
+    full[0] = this->fullinertia[0];
+    full[4] = this->fullinertia[1];
+    full[8] = this->fullinertia[2];
+    full[1] = full[3] = this->fullinertia[3];
+    full[2] = full[6] = this->fullinertia[4];
+    full[5] = full[7] = this->fullinertia[5];
+    mjuu_mulRMRT(full_body, mat, full);
+    fullinertia_body[0] = full_body[0];
+    fullinertia_body[1] = full_body[4];
+    fullinertia_body[2] = full_body[8];
+    fullinertia_body[3] = full_body[1];
+    fullinertia_body[4] = full_body[2];
+    fullinertia_body[5] = full_body[5];
+
+    // decompose rotated tensor into principal axes
+    const char* err = mjuu_fullInertia(iquat, inertia, fullinertia_body);
     if (err) { throw mjCError(this, "error '%s' in fullinertia", err); }
   }
 

--- a/src/xml/xml_urdf.cc
+++ b/src/xml/xml_urdf.cc
@@ -249,19 +249,6 @@ void mjXURDF::Body(XMLElement* body_elem) {
       }
     }
     if (!inertia_defined) { pbody->fullinertia[0] = mjNAN; }
-
-    // process inertia
-    //  lquat = rotation from specified to default (joint/body) inertial frame
-    double      lquat[4]   = {1, 0, 0, 0};
-    double      tmpquat[4] = {1, 0, 0, 0};
-    const char* altres     = mjuu_fullInertia(lquat, nullptr, pbody->fullinertia);
-
-    // inertias are sometimes 0 in URDF files: ignore error in altres, fix later
-    (void)altres;
-
-    // correct for alignment of full inertia matrix
-    mjuu_mulquat(tmpquat, pbody->iquat, lquat);
-    mjuu_copyvec(pbody->iquat, tmpquat, 4);
   }
 
   // clear body frame; set by joint later

--- a/test/xml/CMakeLists.txt
+++ b/test/xml/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 mujoco_test(xml_api_test)
 
+mujoco_test(xml_urdf_test)
+
 mujoco_test(
   xml_native_reader_test
   ADDITIONAL_LINK_LIBRARIES compare_model

--- a/test/xml/xml_urdf_test.cc
+++ b/test/xml/xml_urdf_test.cc
@@ -15,12 +15,14 @@
 // Tests for xml/xml_api.cc.
 
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <mujoco/mujoco.h>
+#include "src/xml/xml_numeric_format.h"
 #include "test/fixture.h"
 
 namespace mujoco {
@@ -310,6 +312,71 @@ TEST_F(MujocoTest, UrdfInertialOriginRotation) {
     }
     EXPECT_NEAR(data->qfrc_inverse[3], expected, 1e-8)
         << "alignfree=" << alignfree;
+  }
+}
+
+TEST_F(MujocoTest, UrdfObliqueInertiaRecompileAndRoundTrip) {
+  // q = (1, 2, 3, 4) / sqrt(30), so R = [-10 2 11; 10 -5 10; 5 14 2] / 15.
+  // For I = [4 .3 .2; .3 3 .1; .2 .1 2], these are the exact entries of R I R'.
+  // I is positive definite, with every eigenvalue less than trace(I)/2.
+  constexpr mjtNum expected[9] = {
+      1004.0 / 375, -127.0 / 150, -49.0 / 125, -127.0 / 150, 3,
+      61.0 / 150,   -49.0 / 125,  61.0 / 150,  1246.0 / 375};
+  static constexpr char urdf[] = R"(
+    <robot name="oblique">
+      <mujoco><compiler fusestatic="false"/></mujoco>
+      <link name="world"/>
+      <link name="body">
+        <inertial>
+          <origin rpy="1.4288992721907328 -0.3398369094541219 2.356194490192345"/>
+          <mass value="1"/>
+          <inertia ixx="4" iyy="3" izz="2" ixy="0.3" ixz="0.2" iyz="0.1"/>
+        </inertial>
+      </link>
+      <joint name="free" type="floating">
+        <parent link="world"/>
+        <child link="body"/>
+      </joint>
+    </robot>)";
+
+  // World axes include the frame change made by alignfree.
+  auto check_inertia = [&](const MjModelPtr& model) {
+    int body = mj_name2id(model.get(), mjOBJ_BODY, "body");
+    ASSERT_GE(body, 0);
+    MjDataPtr data = MakeData(model);
+    mj_forward(model.get(), data.get());
+    const mjtNum* rot = data->ximat + 9 * body;
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        mjtNum inertia = 0;
+        for (int k = 0; k < 3; ++k) {
+          inertia += rot[3 * r + k] * model->body_inertia[3 * body + k] *
+                     rot[3 * c + k];
+        }
+        EXPECT_THAT(inertia, MjNear(expected[3 * r + c], 1e-7, 1e-5));
+      }
+    }
+  };
+
+  FullFloatPrecision precision;
+  for (bool alignfree : {false, true}) {
+    SCOPED_TRACE(alignfree);
+    std::array<char, 1000> error{};
+    std::unique_ptr<mjSpec, decltype(&mj_deleteSpec)> spec(
+        mj_parseXMLString(urdf, nullptr, error.data(), error.size()),
+        mj_deleteSpec);
+    ASSERT_THAT(spec.get(), NotNull()) << error.data();
+    spec->compiler.alignfree = alignfree;
+    for (int repeat = 0; repeat < 3; ++repeat) {
+      SCOPED_TRACE(repeat);
+      MjModelPtr model(mj_compile(spec.get(), nullptr));
+      ASSERT_THAT(model.get(), NotNull()) << mjs_getError(spec.get());
+      check_inertia(model);
+      MjModelPtr roundtrip = LoadModelFromString(SaveAndReadXml(spec.get()),
+                                                 error.data(), error.size());
+      ASSERT_THAT(roundtrip.get(), NotNull()) << error.data();
+      check_inertia(roundtrip);
+    }
   }
 }
 

--- a/test/xml/xml_urdf_test.cc
+++ b/test/xml/xml_urdf_test.cc
@@ -247,6 +247,72 @@ TEST_F(MujocoTest, ReadsJointTypes) {
   }
 }
 
+// ---------------------------- inertial orientation --------------------------
+
+TEST_F(MujocoTest, UrdfInertialOriginRotation) {
+  // issue #3559: the inertial origin rotation must not be lost during
+  // compilation, for both the default (alignfree) and non-aligned paths
+  for (bool alignfree : {true, false}) {
+    std::string urdf =
+        "<robot name=\"inertia_frame\">\n"
+        "  <mujoco><compiler fusestatic=\"false\" alignfree=\"" +
+        std::string(alignfree ? "true" : "false") +
+        "\"/></mujoco>\n"
+        "  <link name=\"world\"/>\n"
+        "  <link name=\"body\">\n"
+        "    <inertial>\n"
+        "      <origin xyz=\"0 0 0\" rpy=\"0 0 1.5707963267948966\"/>\n"
+        "      <mass value=\"1\"/>\n"
+        "      <inertia ixx=\"1\" iyy=\"2\" izz=\"2.5\" ixy=\"0\" ixz=\"0\" "
+        "iyz=\"0\"/>\n"
+        "    </inertial>\n"
+        "  </link>\n"
+        "  <joint name=\"free\" type=\"floating\">\n"
+        "    <parent link=\"world\"/>\n"
+        "    <child link=\"body\"/>\n"
+        "  </joint>\n"
+        "</robot>\n";
+
+    std::array<char, 1000> error;
+    MjModelPtr model = LoadModelFromString(urdf, error.data(), error.size());
+    ASSERT_THAT(model.get(), NotNull()) << error.data();
+
+    int body_id = mj_name2id(model.get(), mjtObj::mjOBJ_BODY, "body");
+
+    // world-frame inertia tensor must be diag(2, 1, 2.5)
+    mjtNum rot_body[9], mat[9], rot_world[9], tensor[9];
+    mju_quat2Mat(rot_body, model->body_iquat + 4 * body_id);
+    mju_quat2Mat(mat, model->body_quat + 4 * body_id);
+    mju_mulMatMat(rot_world, mat, rot_body, 3, 3, 3);
+    for (int r = 0; r < 3; r++) {
+      for (int c = 0; c < 3; c++) {
+        mjtNum sum = 0;
+        for (int k = 0; k < 3; k++) {
+          sum += rot_world[3 * r + k] * rot_world[3 * c + k] *
+                 model->body_inertia[3 * body_id + k];
+        }
+        tensor[3 * r + c] = sum;
+      }
+    }
+    constexpr double diag2[9] = {2, 0, 0, 0, 1, 0, 0, 0, 2.5};
+    for (int i = 0; i < 9; i++) {
+      EXPECT_NEAR(tensor[i], diag2[i], 1e-8) << "alignfree=" << alignfree;
+    }
+
+    // X torque for 1 rad/s^2 must equal the x principal moment R*D*R'[0][0]
+    MjDataPtr data = MakeData(model);
+    data->qacc[3] = 1.0;
+    mj_inverse(model.get(), data.get());
+    mjtNum expected = 0;
+    for (int k = 0; k < 3; k++) {
+      expected +=
+          rot_body[k] * rot_body[k] * model->body_inertia[3 * body_id + k];
+    }
+    EXPECT_NEAR(data->qfrc_inverse[3], expected, 1e-8)
+        << "alignfree=" << alignfree;
+  }
+}
+
 TEST_F(MujocoTest, RepeatedMeshName) {
   static constexpr char urdf[] = R"(
   <robot name="">


### PR DESCRIPTION
## What does this PR do?

URDF `<inertial><origin rpy=...>` rotations were being silently dropped during compilation, changing the rotational dynamics (issue #3559).

**Root cause:** the URDF reader stored the inertia tensor in the inertial frame and pre-composed the principal-axis rotation into `iquat` (`src/xml/xml_urdf.cc`). `mjCBody::Compile` then called `mjuu_fullInertia(iquat, inertia, fullinertia)` *again* on the unchanged tensor, which overwrote `iquat` with the principal-axis orientation and discarded the inertial-origin rotation.

**Fix (both changes required together):**

1. `src/user/user_objects.cc` — rotate the `fullinertia` tensor from the inertial frame into the body frame (`mjuu_quat2mat` + `mjuu_mulRMRT`, i.e. `R·M·Rᵀ`) before decomposing with `mjuu_fullInertia`. The compiler is now the single decomposition point.
2. `src/xml/xml_urdf.cc` — removed the `lquat` pre-composition block so `iquat` is the pure inertial-origin rotation; the compiler composes it correctly for both aligned and non-aligned free bodies.

## Why is this needed?

Without it, a URDF like

```xml
<inertial>
  <origin xyz="0 0 0" rpy="0 0 1.570796"/>
  <mass value="1"/>
  <inertia ixx="1" iyy="2" izz="2.5"/>
</inertial>
```

produces the wrong inertia (`diag(1,2,2.5)` instead of `diag(2,1,2.5)`), and the equivalent MJCF gives a different result — so a URDF's dynamics depend on file format rather than physics.

## Tests

Added `MujocoTest.UrdfInertialOriginRotation` to `test/xml/xml_urdf_test.cc` (and wired the previously-orphaned `xml_urdf_test` into `test/xml/CMakeLists.txt`). It verifies the world-frame inertia tensor is `diag(2,1,2.5)` and the inverse-dynamics X torque under **both** `alignfree=true` (URDF default) and `alignfree=false`. Confirmed the new test **fails on unmodified source** and **passes with the fix**.

Also verified existing URDF/MJCF reader, writer, and user-object test suites pass.