### PR TITLE
Fix sign extension when validating pair and exclude signatures

### DIFF
--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -2032,7 +2032,8 @@ const char* mj_validateReferences(const mjModel* m) {
     if (pair_body1 >= m->nbody || pair_body1 < 0) {
       return "Invalid model: pair_body1 out of bounds.";
     }
-    int pair_body2 = (m->pair_signature[i] >> 16);
+    // unsigned shift: a signed >> sign-extends signatures whose high id is >= 0x8000
+    int pair_body2 = (int)((unsigned int)m->pair_signature[i] >> 16);
     if (pair_body2 >= m->nbody || pair_body2 < 0) {
       return "Invalid model: pair_body2 out of bounds.";
     }
@@ -2230,7 +2231,8 @@ const char* mj_validateReferences(const mjModel* m) {
     if (exclude_body1 >= m->nbody || exclude_body1 < 0) {
       return "Invalid model: exclude_body1 out of bounds.";
     }
-    int exclude_body2 = (m->exclude_signature[i] >> 16);
+    // unsigned shift: a signed >> sign-extends signatures whose high id is >= 0x8000
+    int exclude_body2 = (int)((unsigned int)m->exclude_signature[i] >> 16);
     if (exclude_body2 >= m->nbody || exclude_body2 < 0) {
       return "Invalid model: exclude_body2 out of bounds.";
     }

--- a/test/engine/engine_io_test.cc
+++ b/test/engine/engine_io_test.cc
@@ -28,6 +28,7 @@
 #include <gtest/gtest-spi.h>  // IWYU pragma: keep
 #include <gtest/gtest.h>
 #include <absl/strings/str_format.h>
+#include <mujoco/mjspec.h>
 #include <mujoco/mjxmacro.h>
 #include <mujoco/mujoco.h>
 #include "src/engine/engine_memory.h"
@@ -576,6 +577,52 @@ TEST_F(ValidateReferencesTest, BodyExcludes) {
   EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("exclude_body1"));
   model->exclude_signature[0] = (4 << 16) | 2;
   EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("exclude_body2"));
+}
+
+TEST_F(ValidateReferencesTest, SignaturesAboveSignBit) {
+  // pair_signature and exclude_signature pack the two body ids as body1 << 16 | body2. Body ids at
+  // or above 0x8000 set the sign bit, so unpacking body1 with a signed shift sign-extends it into a
+  // negative id, and a valid model is rejected.
+  // Note: building the model is slow, mjCModel::Signature is recomputed on every added body.
+  static constexpr int kNumBodies = 0x8000 + 4;
+
+  mjSpec* spec = mj_makeSpec();
+  mjsBody* world = mjs_findBody(spec, "world");
+
+  // only the last four bodies are named; they are the ones with ids above the sign bit
+  for (int i = 0; i < kNumBodies; i++) {
+    mjsBody* body = mjs_addBody(world, nullptr);
+    if (i < kNumBodies - 4) {
+      continue;
+    }
+    std::string suffix = std::to_string(kNumBodies - i);
+    mjs_setName(body->element, ("body" + suffix).c_str());
+    mjsGeom* geom = mjs_addGeom(body, nullptr);
+    geom->type = mjGEOM_SPHERE;
+    geom->size[0] = 1;
+    mjs_setName(geom->element, ("geom" + suffix).c_str());
+  }
+
+  mjsExclude* exclude = mjs_addExclude(spec);
+  mjs_setString(exclude->bodyname1, "body4");
+  mjs_setString(exclude->bodyname2, "body3");
+
+  mjsPair* pair = mjs_addPair(spec, nullptr);
+  mjs_setString(pair->geomname1, "geom2");
+  mjs_setString(pair->geomname2, "geom1");
+
+  mjModel* model = mj_compile(spec, nullptr);
+  ASSERT_THAT(model, NotNull()) << mjs_getError(spec);
+
+  // both signatures have their sign bit set, and the model is valid
+  ASSERT_EQ(model->nexclude, 1);
+  ASSERT_EQ(model->npair, 1);
+  EXPECT_LT(model->exclude_signature[0], 0);
+  EXPECT_LT(model->pair_signature[0], 0);
+  EXPECT_THAT(mj_validateReferences(model), IsNull());
+
+  mj_deleteModel(model);
+  mj_deleteSpec(spec);
 }
 
 TEST_F(ValidateReferencesTest, EqualityConstraints) {


### PR DESCRIPTION
`pair_signature` and `exclude_signature` pack the two body ids of a contact pair into one `int`, documented in `mjmodel.h` as `body1 << 16 + body2`. `mj_validateReferences` decodes the low half with a mask, but the high half with a bare signed shift:

```c
int pair_body1 = (m->pair_signature[i] & 0xFFFF);
...
int pair_body2 = (m->pair_signature[i] >> 16);          // engine_io.c
...
int exclude_body1 = (m->exclude_signature[i] & 0xFFFF);
...
int exclude_body2 = (m->exclude_signature[i] >> 16);
```

Once the high id reaches `0x8000` it lands on bit 31 of the packed value, so the shift sign-extends and yields a negative id, which the next line reports as out of bounds.

`mj_validateReferences` runs at the end of every `mjCModel::Compile` and on every `mj_loadModel`, so a **valid** model with more than 32768 bodies and a `<pair>` or a `<contact><exclude>` between two of the high-id bodies is rejected outright:

```
Error: Invalid model: exclude_body2 out of bounds.
```

The compiler raises it as `throw mjCError(0, "%s", validationerr)` under a `// SHOULD NOT OCCUR` comment, so a user has no way to work around it other than renumbering their bodies.

These are now the last two places that read a packed signature as signed. The compiler packs it with `(body1 << 16) + body2` in `user_objects.cc`, and `mj_collision` builds the matching value with an explicit `(unsigned int)` cast before comparing against `pair_signature`/`exclude_signature`. This brings the two validation sites in line, shifting as unsigned rather than adding a redundant mask after a signed shift.

### Reproduction

Fails on released 3.12.0 (`pip install mujoco`) and on current `main`:

```python
import mujoco

N = 0x8000 + 4
spec = mujoco.MjSpec()
for i in range(N):
    b = spec.worldbody.add_body()
    if i >= N - 2:
        b.name = f"body{N - i}"
ex = spec.add_exclude()
ex.bodyname1, ex.bodyname2 = "body2", "body1"

model = spec.compile()   # ValueError: Error: Invalid model: exclude_body2 out of bounds.
```

The `<pair>` site fails the same way with a named geom on each of the two bodies, since `pair_signature` packs the geoms' body ids. Both are fixed here, and both are covered by the test.

### Test

`ValidateReferencesTest.SignaturesAboveSignBit` builds a model with `0x8000 + 4` bodies carrying one `<exclude>` and one `<pair>` between bodies whose ids are above the sign bit, and asserts that it compiles and validates. It fails on the parent commit with `Invalid model: pair_body2 out of bounds.` and passes after.

The test takes ~45 s, essentially all of it in `mjs_addBody`: `mjCModel::Signature()` re-serializes the entire body tree on every added element, so model construction is O(n²) — this is what makes any >32768-body model slow to build (cf. #3397). Only four of the bodies are named and carry geoms, to keep the per-element work as small as possible. Happy to drop the test, or to cut it down to the `<exclude>` half, if ~45 s is too much for CI.

Full suite passes, 1477/1477, with the two `RecompileCompare`/`WriteReadCompare` model-directory tests skipping as usual. Built with clang on macOS, Release, no new warnings.

### One more thing, not changed here

The two error strings are swapped relative to the documented layout. `mjmodel.h` says the packed value is `body1 << 16 + body2`, but `engine_io.c` reports the **low** half as `pair_body1`/`exclude_body1` and the **high** half as `pair_body2`/`exclude_body2`, so each message names the other body. I left it alone because `ValidateReferencesTest.BodyExcludes` asserts on the current strings and the swap is orthogonal to this fix, but it is worth a follow-up.

Separately, `mjx/_src/collision_driver.py` has the same signed/unsigned mismatch in a different form: `geom_pairs()` builds `signature = (b1 << 16) + b2` from Python ints (no wraparound, so positive) and tests membership in `set(m.exclude_signature)`, whose entries are negative `int32` for high ids. The two can never compare equal, so `<exclude>` is silently ignored above the sign bit rather than erroring. It needs >32768 bodies to hit and is in a different subsystem, so it is not touched here. (`mujoco_warp/_src/io.py` does the same shift on an `int32` array, which wraps and happens to match, so that one is fine.)
