### PR TITLE
Fix/validate mesh face indices

### DIFF
--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -2027,6 +2027,51 @@ const char* mj_validateReferences(const mjModel* m) {
       return "Invalid model: tex_adr out of bounds.";
     }
   }
+  // validate per-mesh index arrays: their contents are mesh-local indices that
+  // are used as offsets at runtime (e.g. mesh_vert + 3*mesh_face[...]) without
+  // further bounds checks. These are set by the compiler for XML models, but
+  // are read verbatim from the file when loading a binary (MJB) model, so they
+  // must be validated here. The corresponding *adr/*num arrays are already
+  // bounds-checked by MJMODEL_REFERENCES above.
+  for (int i=0; i < m->nmesh; i++) {
+    int vertnum = m->mesh_vertnum[i];
+    int polynum = m->mesh_polynum[i];
+
+    // face vertex indices: local, in [0, vertnum)
+    int faceadr = m->mesh_faceadr[i];
+    for (int f=0; f < m->mesh_facenum[i]; f++) {
+      for (int k=0; k < 3; k++) {
+        int v = m->mesh_face[3*(faceadr + f) + k];
+        if (v < 0 || v >= vertnum) {
+          return "Invalid model: mesh_face vertex index out of bounds.";
+        }
+      }
+    }
+
+    // convex-hull polygon vertex indices: local, in [0, vertnum)
+    int polyadr = m->mesh_polyadr[i];
+    for (int p=0; p < polynum; p++) {
+      int pvadr = m->mesh_polyvertadr[polyadr + p];
+      for (int j=0; j < m->mesh_polyvertnum[polyadr + p]; j++) {
+        int v = m->mesh_polyvert[pvadr + j];
+        if (v < 0 || v >= vertnum) {
+          return "Invalid model: mesh_polyvert vertex index out of bounds.";
+        }
+      }
+    }
+
+    // vertex->polygon map entries: local polygon indices, in [0, polynum)
+    int vertadr = m->mesh_vertadr[i];
+    for (int v=0; v < vertnum; v++) {
+      int pmadr = m->mesh_polymapadr[vertadr + v];
+      for (int j=0; j < m->mesh_polymapnum[vertadr + v]; j++) {
+        int p = m->mesh_polymap[pmadr + j];
+        if (p < 0 || p >= polynum) {
+          return "Invalid model: mesh_polymap polygon index out of bounds.";
+        }
+      }
+    }
+  }
   for (int i=0; i < m->npair; i++) {
     int pair_body1 = (m->pair_signature[i] & 0xFFFF);
     if (pair_body1 >= m->nbody || pair_body1 < 0) {

--- a/src/engine/engine_io.c
+++ b/src/engine/engine_io.c
@@ -2028,22 +2028,40 @@ const char* mj_validateReferences(const mjModel* m) {
     }
   }
   // validate per-mesh index arrays: their contents are mesh-local indices that
-  // are used as offsets at runtime (e.g. mesh_vert + 3*mesh_face[...]) without
-  // further bounds checks. These are set by the compiler for XML models, but
-  // are read verbatim from the file when loading a binary (MJB) model, so they
-  // must be validated here. The corresponding *adr/*num arrays are already
-  // bounds-checked by MJMODEL_REFERENCES above.
+  // are used as offsets at runtime (e.g. mesh_vert + 3*mesh_face[...],
+  // mesh_normal + 3*mesh_facenormal[...]) without further bounds checks. These
+  // are set by the compiler for XML models, but are read verbatim from the file
+  // when loading a binary (MJB) model, so they must be validated here. The
+  // corresponding *adr/*num arrays are already bounds-checked by
+  // MJMODEL_REFERENCES above.
   for (int i=0; i < m->nmesh; i++) {
     int vertnum = m->mesh_vertnum[i];
     int polynum = m->mesh_polynum[i];
 
-    // face vertex indices: local, in [0, vertnum)
+    int normalnum = m->mesh_normalnum[i];
+    int texcoordnum = m->mesh_texcoordnum[i];
+    int has_texcoord = (m->mesh_texcoordadr[i] >= 0);
+
+    // per-face indices: local, in [0, vertnum), [0, normalnum), [0, texcoordnum)
+    // mesh_facetexcoord is only used when the mesh has texcoords
+    // (mesh_texcoordadr != -1), so it is only validated in that case.
     int faceadr = m->mesh_faceadr[i];
     for (int f=0; f < m->mesh_facenum[i]; f++) {
       for (int k=0; k < 3; k++) {
-        int v = m->mesh_face[3*(faceadr + f) + k];
+        int j = 3*(faceadr + f) + k;
+        int v = m->mesh_face[j];
         if (v < 0 || v >= vertnum) {
           return "Invalid model: mesh_face vertex index out of bounds.";
+        }
+        int n = m->mesh_facenormal[j];
+        if (n < 0 || n >= normalnum) {
+          return "Invalid model: mesh_facenormal normal index out of bounds.";
+        }
+        if (has_texcoord) {
+          int t = m->mesh_facetexcoord[j];
+          if (t < 0 || t >= texcoordnum) {
+            return "Invalid model: mesh_facetexcoord texcoord index out of bounds.";
+          }
         }
       }
     }

--- a/test/engine/engine_io_test.cc
+++ b/test/engine/engine_io_test.cc
@@ -400,7 +400,8 @@ TEST_F(ValidateReferencesTest, Mesh) {
   <mujoco>
     <asset>
       <mesh name="m" vertex="0 0 0  1 0 0  0 1 0  0 0 1"
-                      face="0 1 2  0 1 3  0 2 3  1 2 3"/>
+                      face="0 1 2  0 1 3  0 2 3  1 2 3"
+                      texcoord="0 0  1 0  0 1  1 1"/>
     </asset>
     <worldbody>
       <geom type="mesh" mesh="m"/>
@@ -425,6 +426,36 @@ TEST_F(ValidateReferencesTest, Mesh) {
   model->mesh_face[0] = -1;
   EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("mesh_face"));
   model->mesh_face[0] = saved;
+  EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
+
+  // Face normal indices are mesh-local indices into [0, mesh_normalnum) and
+  // are used the same way (mesh_normal + 3*(mesh_facenormal[...] + normaladr)).
+  saved = model->mesh_facenormal[0];
+  model->mesh_facenormal[0] = model->mesh_normalnum[0];  // one past the end
+  EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("mesh_facenormal"));
+  model->mesh_facenormal[0] = -1;
+  EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("mesh_facenormal"));
+  model->mesh_facenormal[0] = saved;
+  EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
+
+  // Face texcoord indices are mesh-local indices into [0, mesh_texcoordnum),
+  // used only when the mesh has texcoords (mesh_texcoordadr != -1).
+  ASSERT_GE(model->mesh_texcoordadr[0], 0);
+  saved = model->mesh_facetexcoord[0];
+  model->mesh_facetexcoord[0] = model->mesh_texcoordnum[0];  // one past the end
+  EXPECT_THAT(mj_validateReferences(model.get()),
+              HasSubstr("mesh_facetexcoord"));
+  model->mesh_facetexcoord[0] = -1;
+  EXPECT_THAT(mj_validateReferences(model.get()),
+              HasSubstr("mesh_facetexcoord"));
+
+  // A mesh without texcoords (mesh_texcoordadr == -1) never reads
+  // mesh_facetexcoord, so its contents are not validated in that case.
+  int saved_adr = model->mesh_texcoordadr[0];
+  model->mesh_texcoordadr[0] = -1;
+  EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
+  model->mesh_texcoordadr[0] = saved_adr;
+  model->mesh_facetexcoord[0] = saved;
   EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
 }
 

--- a/test/engine/engine_io_test.cc
+++ b/test/engine/engine_io_test.cc
@@ -395,6 +395,39 @@ TEST_F(ValidateReferencesTest, Texture) {
   EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("tex_adr"));
 }
 
+TEST_F(ValidateReferencesTest, Mesh) {
+  static const char xml[] = R"(
+  <mujoco>
+    <asset>
+      <mesh name="m" vertex="0 0 0  1 0 0  0 1 0  0 0 1"
+                      face="0 1 2  0 1 3  0 2 3  1 2 3"/>
+    </asset>
+    <worldbody>
+      <geom type="mesh" mesh="m"/>
+    </worldbody>
+  </mujoco>
+  )";
+
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(xml, error.data(), error.size());
+  ASSERT_THAT(model.get(), NotNull())
+      << "Failed to load model: " << error.data();
+
+  EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
+
+  // A mesh face vertex index is a mesh-local index into [0, mesh_vertnum).
+  // These are read verbatim from a binary (MJB) model, so an out-of-range value
+  // must be rejected here (it would otherwise cause an out-of-bounds read when
+  // the mesh is ray-cast, rendered or collided).
+  int saved = model->mesh_face[0];
+  model->mesh_face[0] = model->mesh_vertnum[0];  // one past the end
+  EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("mesh_face"));
+  model->mesh_face[0] = -1;
+  EXPECT_THAT(mj_validateReferences(model.get()), HasSubstr("mesh_face"));
+  model->mesh_face[0] = saved;
+  EXPECT_THAT(mj_validateReferences(model.get()), IsNull());
+}
+
 TEST_F(ValidateReferencesTest, GeomPairs) {
   static const char xml[] = R"(
   <mujoco>


### PR DESCRIPTION
## Validate mesh index arrays in `mj_validateReferences`

### Problem
When loading a **binary** model (`.mjb`), `mj_loadModelBuffer` reads the whole
`mjModel` buffer verbatim from the file and validates it only through
`mj_validateReferences`. That function checks the `*adr`/`*num` arrays but not the
*contents* of the mesh index arrays `mesh_face`, `mesh_polyvert` and `mesh_polymap`.

At runtime these are used as unchecked offsets, e.g.
`mesh_vert + 3*(mesh_face[...] + mesh_vertadr[meshid])`
in `engine_ray.c`, `render_context.c`, `engine_collision_sdf.c`,
`engine_support.c` and `engine_collision_convex.c`.

The XML compiler already rejects out-of-range indices
(`mjCMesh::CheckMesh`, `user_mesh.cc`), but that path is bypassed for binary models.
As a result a crafted `.mjb` with an out-of-bounds vertex index **loads successfully**
and then causes an out-of-bounds read (crash, or silent adjacent-heap read for small
overruns) as soon as the mesh is ray-cast, rendered or collided.

### Repro (before this change)
A `.mjb` identical to a valid model except `mesh_face` set to `100000000`
(with `nmeshvert == 4`) loads via `MjModel.from_binary_path` with no error, and a
single `mj_ray` against the mesh segfaults.

### Fix
Add content bounds-checks for `mesh_face`, `mesh_polyvert` and `mesh_polymap` to
`mj_validateReferences`, mirroring the compiler's checks. The `*adr`/`*num` arrays
iterated here are already validated by `MJMODEL_REFERENCES` earlier in the same
function, so the iteration is safe.

### Follow-ups (not in this PR)
`mesh_graph`, `bvh_child`/`bvh_nodeid`, and the `skin_*`/`flex_*` index arrays share
the same root cause and warrant equivalent validation.

### Testing
Adds `ValidateReferencesTest.Mesh` in `test/engine/engine_io_test.cc`, which corrupts
`mesh_face` to an out-of-range and to a negative index and expects
`mj_validateReferences` to report `mesh_face` (and to return null once restored),
following the existing `GeomCondim`/`Texture` cases.

`src/engine/engine_io.c` was syntax/type-checked locally with
`gcc -fsyntax-only -Iinclude -Isrc` (clean). The full test suite was not run in my
environment (no MSVC/Clang toolchain set up here); please rely on CI to execute the
added test.