### PR TITLE
Keep finite-difference residual evaluations within bounds

### DIFF
--- a/python/mujoco/minimize.py
+++ b/python/mujoco/minimize.py
@@ -508,10 +508,14 @@ def jacobian_fd(
     eps_vec = eps * np.ones((n, 1))
   else:
     mid = 0.5 * bounds[0] + 0.5 * bounds[1]
-    eps_vec = np.where(x > mid, -eps, eps)
+    # The midpoint can round to the upper bound for adjacent floats.
+    eps_vec = np.where((x > mid) | (x == bounds[1]), -eps, eps)
   eps_vec *= np.maximum(1.0, np.abs(x))
-  eps_vec = (eps_vec + x) - x
   xh = x + np.diag(eps_vec.flatten())
+  if bounds is not None:
+    np.clip(xh, bounds[0], bounds[1], out=xh)
+  # Use the actual step after rounding and clipping the evaluation points.
+  eps_vec = xh.diagonal()[:, None] - x
   rh = residual(xh)
   jac = (rh - r) / eps_vec.T
   return jac, n_res + n

--- a/python/mujoco/minimize_test.py
+++ b/python/mujoco/minimize_test.py
@@ -192,6 +192,50 @@ class MinimizeTest(absltest.TestCase):
         self.assertGreaterEqual(pts.min(), lo)
         self.assertLessEqual(pts.max(), hi)
 
+  def test_jacobian_fd_narrow_bounds(self) -> None:
+    eps = np.float64(np.finfo(np.float64).eps ** 0.5)
+    one_up = np.nextafter(1.0, np.inf)
+    two_up = np.nextafter(one_up, np.inf)
+    cases = {
+        'mixed_scales': (
+            [1.0, -1.0, -1e-10, 1e8],
+            [1.0 + 1e-10, -1.0 + 1e-10, 1e-11, 1e8 + 1e-4],
+        ),
+        'midpoint_rounds_down': ([1.0], [one_up]),
+        'midpoint_rounds_up': ([one_up], [two_up]),
+    }
+    for name, (lower, upper) in cases.items():
+      bounds = [np.array(lower)[:, None], np.array(upper)[:, None]]
+      points = (bounds[0], 0.5 * bounds[0] + 0.5 * bounds[1], bounds[1])
+      for position, x in enumerate(points):
+        with self.subTest(case=name, position=position):
+
+          def residual(xx):
+            self.assertTrue(np.all(xx >= bounds[0]))
+            self.assertTrue(np.all(xx <= bounds[1]))
+            return xx.copy()
+
+          jac, n_res = minimize.jacobian_fd(
+              residual, x, residual(x), eps, 3, bounds
+          )
+          np.testing.assert_array_equal(jac, np.eye(x.size))
+          self.assertEqual(n_res, 3 + x.size)
+
+  def test_least_squares_narrow_bounds(self) -> None:
+    lower = np.array([0.0])
+    upper = np.array([1e-10])
+    target = 0.75 * upper
+
+    def residual(x):
+      self.assertTrue(np.all(x >= lower[:, None]))
+      self.assertTrue(np.all(x <= upper[:, None]))
+      return (x - target[:, None]) / upper[:, None]
+
+    x, _ = minimize.least_squares(
+        lower, residual, bounds=[lower, upper], output=io.StringIO()
+    )
+    np.testing.assert_allclose(x, target, rtol=0, atol=1e-22)
+
   def test_iter_callback(self) -> None:
     def residual(x):
       return np.stack([1 - x[0, :], 10 * (x[1, :] - x[0, :] ** 2)])


### PR DESCRIPTION
`jacobian_fd` chooses an inward finite-difference direction, but its relative step can still cross the opposite bound when the interval is narrow. For example, with bounds `[0, 1e-10]`, the default perturbation from zero evaluates the residual at about `1.49e-8`. This can make `least_squares` fail for residuals defined only inside the supplied bounds.

Clip the actual evaluation points to the box and use their actual displacement as the finite-difference denominator. Step inward explicitly at the upper bound, including when an adjacent-float interval's midpoint rounds to that endpoint. Clipping the points themselves also avoids a rounding excursion across zero that can remain after clipping only the displacement.

The regression tests cover lower/interior/upper points, mixed parameter scales, intervals crossing zero, adjacent floating-point bounds, exact linear Jacobians, and a bounded least-squares solve. Before the fix, the nine new helper subcases and the solver regression fail. After the fix, the full minimizer suite passes: **18 tests and 13 subtests**.

Validation used the current checkout's Python module and tests on Windows/Python 3.12 with installed MuJoCo 3.12.0 native bindings; no native code was changed or rebuilt. Reproduce that configuration from the repository root with:

```python
from pathlib import Path
import mujoco
import pytest

mujoco.__path__.insert(0, str(Path('python/mujoco').resolve()))
raise SystemExit(pytest.main(['python/mujoco/minimize_test.py', '-q']))
```

Pyink checks pass for the changed regions, isort passes with `mujoco` classified as a third-party extension package, and the applicable pre-commit checks pass.
