### PR TITLE
Fix documented default of ccd_iterations (35, not 50)

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -510,7 +510,7 @@ adjust it properly through the XML.
 
 .. _option-ccd_iterations:
 
-:at:`ccd_iterations`: :at-val:`int, "50"`
+:at:`ccd_iterations`: :at-val:`int, "35"`
    Maximum number of iterations of the algorithm used for convex collisions. This rarely needs to be adjusted,
    except in situations where some geoms have very large aspect ratios.
 


### PR DESCRIPTION
`doc/XMLreference.rst` lists the default of `ccd_iterations` as 50, but `src/engine/engine_init.c:98` sets `opt->ccd_iterations = 35` and `src/xml/mjcf.schema` declares `ccd_iterations : int = 35`. Commit eb96dd55 reduced the value from 50 to 35 in 3.4.0 and updated the engine source and the USD schema, but not XMLreference.rst, so the doc kept 50. This changes the documented default to 35; `grep -n ccd_iterations doc/XMLreference.rst src/engine/engine_init.c src/xml/mjcf.schema` now shows 35 in all three files. Happy for this to be incorporated directly without git authorship if that is faster.
