### PR TITLE
Fix dead links in python, mjx, and XML reference docs

### DIFF
--- a/doc/XMLreference.rst
+++ b/doc/XMLreference.rst
@@ -5639,7 +5639,7 @@ specify them independently.
    Armature inertia (or mass for slider joints) contributed by the actuator to its transmission target (joint or tendon
    only). This is the actual inertia of the spinning element inside the actuator (e.g., a rotor). The contributed value
    is scaled by :ref:`gear<actuator-general-gear>` squared, because the gear ratio scales both forces and velocities,
-   leading to `reflected inertia <https://en.wikipedia.org/wiki/Reflective_inertia>`__. See
+   leading to reflected inertia. See
    :ref:`joint<body-joint-armature>` and :ref:`tendon<tendon-fixed-armature>` armature for more details.
 
    See also the note in :ref:`damping<actuator-general-damping>` regarding multiple actuators acting on the same

--- a/doc/mjx.rst
+++ b/doc/mjx.rst
@@ -154,7 +154,7 @@ Graph Modes
 The ``mjx.put_model`` function accepts a ``graph_mode`` argument to configure the CUDA graph capture behavior,
 exposed by the ``mjx.warp.GraphMode`` enum. When called from JAX, CUDA graphs are captured by the Warp
 Foreign Function interface and are cached to help improve runtime performance. See the
-`Warp JAX interoperability documentation <https://nvidia.github.io/warp/user_guide/interoperability.html#jax>`__
+`Warp JAX interoperability documentation <https://nvidia.github.io/warp/latest/user_guide/interoperability/jax.html>`__
 for more details. The graph mode can be configured as follows:
 
 .. code-block:: python
@@ -534,7 +534,7 @@ The following table compares feature support between MJX-Warp and MJX-JAX compar
 
 
 .. [1] Differentiability is `mostly supported <https://github.com/google-deepmind/mujoco/issues/2259>`__ in MJX-JAX but is
-       **not** currently available in MJX-Warp. See `Warp differentiability <https://nvidia.github.io/warp/user_guide/differentiability.html>`__
+       **not** currently available in MJX-Warp. See `Warp differentiability <https://nvidia.github.io/warp/latest/user_guide/differentiability.html>`__
        for more details.
 .. [2] **Sensors**: ``MAGNETOMETER``, ``CAMPROJECTION``, ``RANGEFINDER``, ``JOINTPOS``, ``TENDONPOS``, ``ACTUATORPOS``,
        ``BALLQUAT``, ``FRAMEPOS``, ``FRAMEXAXIS``, ``FRAMEYAXIS``, ``FRAMEZAXIS``, ``FRAMEQUAT``, ``SUBTREECOM``, ``CLOCK``,

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -750,7 +750,7 @@ For users familiar with ``PyMJCF``, the ``MjSpec`` object is conceptually simila
 Model Editing
 `colab notebook <https://colab.research.google.com/github/google-deepmind/mujoco/blob/main/python/mjspec.ipynb>`__
 includes a reimplementation of the ``PyMJCF`` example in the ``dm_control``
-`tutorial notebook <https://github.com/google-deepmind/dm_control/blob/main/dm_control/mjcf/tutorial.ipynb>`__.
+`tutorial notebook <https://github.com/google-deepmind/dm_control/blob/main/tutorial.ipynb>`__.
 
 ``PyMJCF`` provides a notion of "binding", giving access to :ref:`mjModel` and :ref:`mjData` values via a helper class.
 In the native API, the helper class is not needed, so it is possible to directly bind an ``mjs`` object to


### PR DESCRIPTION
The dm_control tutorial link in doc/python.rst, both Warp links in doc/mjx.rst, and the Wikipedia link behind "reflected inertia" in doc/XMLreference.rst return 404. The dm_control path dm_control/mjcf/tutorial.ipynb never existed in that repo, Warp moved its docs under /latest/ and split the JAX section into its own page, and no Wikipedia article exists under either "Reflective inertia" or "Reflected inertia". The tutorial link now points at the root tutorial.ipynb, which has the PyMJCF attach example the text describes, the Warp links point at latest/user_guide/interoperability/jax.html and latest/user_guide/differentiability.html, and the Wikipedia link is now plain text. With `curl -sL -o /dev/null -w '%{http_code}' -A Mozilla/5.0 "$url"`, the four old URLs return 404 and the three new ones return 200. I do not care about git authorship, so incorporating this directly is fine if that is faster.
