### PR TITLE
Default tendon actuatorfrclimited to auto as documented

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,13 @@ Engine
   :at:`implicitfast` and damped-:at:`Euler` integrators (previously silent) and of the :at:`implicit` integrator
   (previously a fatal error).
 
+Bug fixes
+^^^^^^^^^
+- Tendon :ref:`actuatorfrclimited<tendon-spatial-actuatorfrclimited>` now defaults to "auto" as documented, so under
+  :ref:`autolimits<compiler-autolimits>` a tendon with :at:`actuatorfrcrange` has actuator force clamping enabled,
+  matching joints. Previously the default was "false" and :at:`actuatorfrcrange` was silently ignored unless
+  :at:`actuatorfrclimited` was set explicitly.
+
 Version 3.13.0 (September 8, 2026)
 ----------------------------------
 

--- a/src/user/user_init.c
+++ b/src/user/user_init.c
@@ -322,6 +322,7 @@ void mjs_defaultEquality(mjsEquality* equality) {
 void mjs_defaultTendon(mjsTendon* tendon) {
   memset(tendon, 0, sizeof(mjsTendon));
   tendon->limited         = mjLIMITED_AUTO;
+  tendon->actfrclimited   = mjLIMITED_AUTO;
   tendon->springlength[0] = tendon->springlength[1] = -1;
   mj_defaultSolRefImp(tendon->solref_limit, tendon->solimp_limit);
   mj_defaultSolRefImp(tendon->solref_friction, tendon->solimp_friction);

--- a/src/xml/generated/dmcontrol_schema.xml
+++ b/src/xml/generated/dmcontrol_schema.xml
@@ -2018,7 +2018,7 @@
             <attribute name="class" type="reference" reference_namespace="default"/>
             <attribute name="group" type="int"/>
             <attribute name="limited" type="keyword" valid_values="false true auto" default="auto"/>
-            <attribute name="actuatorfrclimited" type="keyword" valid_values="false true auto"/>
+            <attribute name="actuatorfrclimited" type="keyword" valid_values="false true auto" default="auto"/>
             <attribute name="range" type="array" array_type="float" array_size="2"/>
             <attribute name="actuatorfrcrange" type="array" array_type="float" array_size="2"/>
             <attribute name="solreflimit" type="array" array_type="float" array_size="2" default="0.02 1"/>
@@ -2061,7 +2061,7 @@
             <attribute name="class" type="reference" reference_namespace="default"/>
             <attribute name="group" type="int"/>
             <attribute name="limited" type="keyword" valid_values="false true auto" default="auto"/>
-            <attribute name="actuatorfrclimited" type="keyword" valid_values="false true auto"/>
+            <attribute name="actuatorfrclimited" type="keyword" valid_values="false true auto" default="auto"/>
             <attribute name="range" type="array" array_type="float" array_size="2"/>
             <attribute name="actuatorfrcrange" type="array" array_type="float" array_size="2"/>
             <attribute name="solreflimit" type="array" array_type="float" array_size="2" default="0.02 1"/>

--- a/src/xml/generated/mjcf.xsd
+++ b/src/xml/generated/mjcf.xsd
@@ -2460,7 +2460,7 @@
     <xs:attribute name="class" type="xs:string"/>
     <xs:attribute name="group" type="xs:int"/>
     <xs:attribute name="limited" type="kw_FalseTrueAuto" default="auto"/>
-    <xs:attribute name="actuatorfrclimited" type="kw_FalseTrueAuto"/>
+    <xs:attribute name="actuatorfrclimited" type="kw_FalseTrueAuto" default="auto"/>
     <xs:attribute name="range" type="double2"/>
     <xs:attribute name="actuatorfrcrange" type="double2"/>
     <xs:attribute name="solreflimit" type="double1to2" default="0.02 1"/>
@@ -2503,7 +2503,7 @@
     <xs:attribute name="class" type="xs:string"/>
     <xs:attribute name="group" type="xs:int"/>
     <xs:attribute name="limited" type="kw_FalseTrueAuto" default="auto"/>
-    <xs:attribute name="actuatorfrclimited" type="kw_FalseTrueAuto"/>
+    <xs:attribute name="actuatorfrclimited" type="kw_FalseTrueAuto" default="auto"/>
     <xs:attribute name="range" type="double2"/>
     <xs:attribute name="actuatorfrcrange" type="double2"/>
     <xs:attribute name="solreflimit" type="double1to2" default="0.02 1"/>

--- a/src/xml/generated/mjcf_default_table.inc
+++ b/src/xml/generated/mjcf_default_table.inc
@@ -471,7 +471,7 @@ static const mjXDefaultEntry kDefaults_mjsSkin[] = {
 static const mjXDefaultEntry kDefaults_mjsTendon[] = {
   {"group", (int)offsetof(mjsTendon, group), 2, 1, 0, 0, {0}},
   {"limited", (int)offsetof(mjsTendon, limited), 2, 1, 1, 0, {(double)2}},
-  {"actuatorfrclimited", (int)offsetof(mjsTendon, actfrclimited), 2, 1, 0, 0, {0}},
+  {"actuatorfrclimited", (int)offsetof(mjsTendon, actfrclimited), 2, 1, 1, 0, {(double)2}},
   {"range", (int)offsetof(mjsTendon, range), 0, 2, 0, 0, {0}},
   {"actuatorfrcrange", (int)offsetof(mjsTendon, actfrcrange), 0, 2, 0, 0, {0}},
   {"solreflimit", (int)offsetof(mjsTendon, solref_limit), 4, mjNREF, 2, 0, {0.02, 1.0}},

--- a/src/xml/mjcf.schema
+++ b/src/xml/mjcf.schema
@@ -1357,7 +1357,7 @@ element spatial : mjsTendon {
   class              : ref<default>
   group              : int
   limited            : enum<FalseTrueAuto> = auto
-  actuatorfrclimited : enum<FalseTrueAuto> (field=actfrclimited)
+  actuatorfrclimited : enum<FalseTrueAuto> = auto (field=actfrclimited)
   range              : double[2]
   actuatorfrcrange   : double[2] (field=actfrcrange)
   solreflimit        : double[1..mjNREF] = {0.02, 1} (field=solref_limit)
@@ -1400,7 +1400,7 @@ element fixed : mjsTendon {
   class              : ref<default>
   group              : int
   limited            : enum<FalseTrueAuto> = auto
-  actuatorfrclimited : enum<FalseTrueAuto> (field=actfrclimited)
+  actuatorfrclimited : enum<FalseTrueAuto> = auto (field=actfrclimited)
   range              : double[2]
   actuatorfrcrange   : double[2] (field=actfrcrange)
   solreflimit        : double[1..mjNREF] = {0.02, 1} (field=solref_limit)

--- a/test/user/user_objects_test.cc
+++ b/test/user/user_objects_test.cc
@@ -2229,6 +2229,51 @@ TEST_F(TendonTest, ActuatorForceRangeNotAllowed) {
   EXPECT_THAT(error.data(), HasSubstr("invalid actuatorfrcrange in tendon"));
 }
 
+TEST_F(TendonTest, ActuatorForceRangeAutoLimited) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <worldbody>
+      <site name="site0"/>
+      <site name="site1"/>
+    </worldbody>
+    <tendon>
+      <spatial name="spatial" actuatorfrcrange="-1 1">
+        <site site="site0"/>
+        <site site="site1"/>
+      </spatial>
+    </tendon>
+  </mujoco>
+  )";
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(xml, error.data(), error.size());
+  ASSERT_THAT(model.get(), NotNull()) << error.data();
+  EXPECT_EQ(model->tendon_actfrclimited[0], 1);
+}
+
+TEST_F(TendonTest, ErrorIfActuatorForceLimitedMissing) {
+  static constexpr char xml[] = R"(
+  <mujoco>
+    <compiler autolimits="false"/>
+    <worldbody>
+      <site name="site0"/>
+      <site name="site1"/>
+    </worldbody>
+    <tendon>
+      <spatial name="spatial" actuatorfrcrange="-1 1">
+        <site site="site0"/>
+        <site site="site1"/>
+      </spatial>
+    </tendon>
+  </mujoco>
+  )";
+  std::array<char, 1024> error;
+  MjModelPtr model = LoadModelFromString(xml, error.data(), error.size());
+  ASSERT_THAT(model.get(), IsNull());
+  EXPECT_THAT(error.data(), HasSubstr("limited"));
+  EXPECT_THAT(error.data(), HasSubstr("tendon"));
+  EXPECT_THAT(error.data(), HasSubstr("line 9"));
+}
+
 // ------------- tests for tendon springrange ----------------------------------
 
 using SpringrangeTest = MujocoTest;


### PR DESCRIPTION
The XML reference documents tendon `actuatorfrclimited` as `[false, true, auto]` with default "auto", and says that under compiler `autolimits` the clamp is enabled whenever `actuatorfrcrange` is defined. But `mjs_defaultTendon` in src/user/user_init.c never set `actfrclimited`, so it stayed at `mjLIMITED_FALSE`, unlike `mjs_defaultJoint`, which sets the joint field to `mjLIMITED_AUTO`. With a joint and a spatial tendon that each carry `actuatorfrcrange="-1 1"` and a motor driven at `ctrl=100`, the `jointactuatorfrc` sensor reads 1.0 while the `tendonactuatorfrc` sensor reads 100.0.

The tendon default is now `mjLIMITED_AUTO`, mjcf.schema declares the same default for spatial and fixed tendons, and the generated mjcf_default_table.inc, mjcf.xsd and dmcontrol_schema.xml are regenerated from it. Two tests sit next to `TendonTest.ActuatorForceRangeNotAllowed`, and the changelog has an entry. This changes behaviour for models with tendon `actuatorfrcrange` and no `actuatorfrclimited`: they are now clamped, and under `autolimits="false"` they now fail to load with the existing `checklimited` message, exactly as joints already do.

Checked with `ctest --test-dir build -R "TendonTest|LimitedTest|ActuatorTest|SchemaDefaultsTest"` (23 passed; the two new tests and `SchemaDefaultsTest` fail without the user_init.c line), `python3 test/doc/doc_test.py` (15 passed), and a Python bindings build from this tree where the repro above now prints 1.0 for the tendon sensor. If git authorship does not matter here, feel free to incorporate this directly.
